### PR TITLE
Fix all open issues (#1–#22): security, correctness, robustness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,9 @@ DATABASE_URL=postgresql+asyncpg://obsidian_mcp:CHANGE_ME@postgres:5432/obsidian_
 # Vault
 VAULT_PATH=/obsidian
 
-# Security — itsdangerous signer for cookies/sessions. When
-# MULTI_USER_MODE=true the app refuses to start with the default
-# placeholder value (generate with `openssl rand -hex 32`).
+# Security — itsdangerous signer for cookies/sessions. The app refuses to
+# start while this is left at a known placeholder (CHANGE_ME, changeme, or
+# empty), so you must replace it. Generate with `openssl rand -hex 32`.
 SECRET_KEY=CHANGE_ME
 
 # Multi-user mode — when true, the app enforces in-app username/password

--- a/alembic/versions/008_hnsw_embedding_index.py
+++ b/alembic/versions/008_hnsw_embedding_index.py
@@ -7,10 +7,19 @@ Create Date: 2026-05-01
 Replaces sequential scan on the `<=>` operator with a logarithmic-time
 index. Requires pgvector extension >= 0.5.0 (HNSW added 2023-08-28).
 """
+import logging
 from typing import Sequence, Union
 
 import sqlalchemy as sa
 from alembic import op
+
+from src.config import settings
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+# pgvector caps HNSW-indexable vectors at 2000 dimensions for the default
+# `vector` type; above that, CREATE INDEX ... USING hnsw hard-errors.
+HNSW_MAX_DIM = 2000
 
 revision: str = "008"
 down_revision: Union[str, None] = "007"
@@ -28,6 +37,17 @@ def upgrade() -> None:
     parts = tuple(int(p) for p in ver.split(".")[:2])
     if parts < (0, 5):
         raise RuntimeError(f"pgvector {ver} lacks HNSW; need >= 0.5.0")
+    dim = int(settings.embedding_dimensions)
+    if dim > HNSW_MAX_DIM:
+        # Skip the index so the migration still completes and the app starts.
+        # Semantic search falls back to a sequential scan on `<=>`. See issue #6.
+        logger.warning(
+            "Skipping HNSW index: embedding_dimensions=%d exceeds pgvector's "
+            "%d-dim HNSW limit; semantic_search will use a sequential scan.",
+            dim,
+            HNSW_MAX_DIM,
+        )
+        return
     op.execute("SET LOCAL maintenance_work_mem = '512MB'")
     op.execute(
         "CREATE INDEX IF NOT EXISTS ix_note_embeddings_embedding_hnsw "

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -7,6 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.auth.session import _SingleUserSentinel
 from src.control_panel.routes import require_admin_panel, require_user_panel
+from src.csrf import verify_csrf
 from src.database import get_session
 from src.limiter import limiter
 from src.mcp_server.auth import hash_key
@@ -14,6 +15,7 @@ from src.models.db import APIKey, User, UsageLog
 
 router = APIRouter(prefix="/api", tags=["api"])
 router.dependencies.append(Depends(require_user_panel))
+router.dependencies.append(Depends(verify_csrf))
 
 
 class CreateKeyRequest(BaseModel):
@@ -121,6 +123,7 @@ async def get_usage(
     session: AsyncSession = Depends(get_session),
     user: User | _SingleUserSentinel = Depends(require_user_panel),
 ):
+    limit = max(1, min(limit, 500))
     query = select(UsageLog).order_by(UsageLog.created_at.desc()).limit(limit)
     if key_id:
         query = query.where(UsageLog.key_id == key_id)

--- a/src/config.py
+++ b/src/config.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import model_validator
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings
 
 
@@ -9,13 +9,13 @@ class Settings(BaseSettings):
     ollama_url: str = "http://ollama:11434"
     vault_path: str = "/obsidian"
     secret_key: str = "changeme"
-    index_interval_seconds: int = 300
+    index_interval_seconds: int = Field(300, ge=1)
     embedding_model: str = "bge-m3"
-    embedding_dimensions: int = 1024
-    chunk_size: int = 512  # bge-m3 design point
+    embedding_dimensions: int = Field(1024, ge=1, le=16000)
+    chunk_size: int = Field(512, ge=1)  # bge-m3 design point
     # Overlap disabled: 2025 chunking benchmarks show no measurable retrieval
     # benefit; some research finds zero overlap optimal.
-    chunk_overlap: int = 0
+    chunk_overlap: int = Field(0, ge=0)
     # Path globs (fnmatch) skipped by the embedder — files remain
     # keyword-searchable but produce no vectors. Default skips Excalidraw
     # plugin files (drawings + downloaded scripts) which contain serialized
@@ -73,12 +73,18 @@ class Settings(BaseSettings):
             )
         return self
 
+    # Known weak placeholders shipped in .env.example / defaults. Matched
+    # case-insensitively so e.g. CHANGE_ME and changeme are both rejected.
+    _SECRET_KEY_PLACEHOLDERS = frozenset(
+        {"changeme", "change_me", "change-me", ""}
+    )
+
     @model_validator(mode="after")
     def _validate_multi_user_secret(self) -> "Settings":
-        if self.secret_key == "changeme":
+        if self.secret_key.strip().lower() in self._SECRET_KEY_PLACEHOLDERS:
             raise ValueError(
-                "SECRET_KEY must not be 'changeme'. Generate a strong key with: "
-                "python -c \"import secrets; print(secrets.token_hex(32))\""
+                "SECRET_KEY must not be a placeholder value. Generate a strong "
+                'key with: python -c "import secrets; print(secrets.token_hex(32))"'
             )
         return self
 

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -401,6 +401,12 @@ async def create_key_form(
     user=Depends(require_user_panel),
 ):
     raw_key = f"omcp_{secrets.token_hex(24)}"
+    # The keys.html <select> only constrains the UI; a scripted/tampered POST
+    # can submit any value. Mirror the JSON API's invariant (src/api/routes.py)
+    # and fail safe to read-only so the column never holds nonsense like
+    # "admin" or a trailing-space "readwrite " that silently behaves as read.
+    if permission not in ("read", "readwrite"):
+        permission = "read"
     # Always stamp the creator's user_id (even admins get their own keys
     # attributed to themselves — admin's omniscient view doesn't extend to
     # "create keys on behalf of"; that's a separate per-user-edit action).
@@ -962,13 +968,24 @@ async def reset_embeddings(
         await session.execute(
             text("UPDATE notes_metadata SET embedded_content_hash = NULL")
         )
-        await session.execute(
-            text(
-                "CREATE INDEX ix_note_embeddings_embedding_hnsw "
-                "ON note_embeddings USING hnsw (embedding vector_cosine_ops) "
-                "WITH (m = 16, ef_construction = 64)"
+        # pgvector caps HNSW-indexable vectors at 2000 dims; above that, CREATE
+        # INDEX ... USING hnsw hard-errors. Skip the index so the reset still
+        # completes; semantic_search falls back to a sequential scan. See issue #6.
+        hnsw = dim <= 2000
+        if hnsw:
+            await session.execute(
+                text(
+                    "CREATE INDEX ix_note_embeddings_embedding_hnsw "
+                    "ON note_embeddings USING hnsw (embedding vector_cosine_ops) "
+                    "WITH (m = 16, ef_construction = 64)"
+                )
             )
-        )
+        else:
+            logger.warning(
+                "Skipping HNSW index: embedding_dimensions=%d exceeds pgvector's "
+                "2000-dim HNSW limit; semantic_search will use a sequential scan.",
+                dim,
+            )
         await session.commit()
     finally:
         indexer_paused = False
@@ -976,7 +993,7 @@ async def reset_embeddings(
     _spawn(_reindex_background())
 
     if "application/json" in request.headers.get("accept", ""):
-        return JSONResponse({"status": "reset", "dimensions": dim})
+        return JSONResponse({"status": "reset", "dimensions": dim, "hnsw": hnsw})
     return RedirectResponse("/admin/settings", status_code=303)
 
 
@@ -1007,17 +1024,25 @@ async def _reindex_background():
     # Panel-triggered on-demand reindex. Mirrors `run_indexer_loop` so the
     # multi-user-mode case fans out to every active user; in single-user
     # mode it stays a single legacy pass with user_id=None.
-    from src.services.indexer import index_vault, embed_vault, _active_user_ids
-    if settings.multi_user_mode:
-        for uid in await _active_user_ids():
-            try:
-                await index_vault(user_id=uid)
-            except Exception as e:
-                logger.error(f"On-demand index failed (user_id={uid}): {e}")
-            try:
-                await embed_vault(user_id=uid)
-            except Exception as e:
-                logger.error(f"On-demand embedding failed (user_id={uid}): {e}")
-    else:
-        await index_vault()
-        await embed_vault()
+    #
+    # Acquire `index_pass_lock` for the whole pass: without it this task can
+    # run index_vault/embed_vault concurrently with the periodic loop over the
+    # same scope, racing on move-detection, deleted-path removal, and per-note
+    # embedding delete+insert.
+    from src.services.indexer import (
+        index_vault, embed_vault, _active_user_ids, index_pass_lock,
+    )
+    async with index_pass_lock:
+        if settings.multi_user_mode:
+            for uid in await _active_user_ids():
+                try:
+                    await index_vault(user_id=uid)
+                except Exception as e:
+                    logger.error(f"On-demand index failed (user_id={uid}): {e}")
+                try:
+                    await embed_vault(user_id=uid)
+                except Exception as e:
+                    logger.error(f"On-demand embedding failed (user_id={uid}): {e}")
+        else:
+            await index_vault()
+            await embed_vault()

--- a/src/control_panel/templates/authorize.html
+++ b/src/control_panel/templates/authorize.html
@@ -241,6 +241,7 @@
                     </div>
                 </label>
 
+                {% if client_can_write %}
                 <label class="scope-option">
                     <input type="radio" name="scope" value="readwrite">
                     <div>
@@ -248,6 +249,7 @@
                         <div class="scope-option-desc">Full access: search, read, create, and edit notes.</div>
                     </div>
                 </label>
+                {% endif %}
 
                 <div class="actions">
                     <button type="submit" name="action" value="approve" class="btn-approve">Approve</button>

--- a/src/csrf.py
+++ b/src/csrf.py
@@ -26,10 +26,10 @@ def validate_csrf_token(request: Request, token: str | None) -> bool:
     try:
         session = request.session
     except (AssertionError, AttributeError):
-        return True
+        return False
     nonce = session.get("csrf_nonce")
     if nonce is None:
-        return True
+        return False
     if not token:
         return False
     try:
@@ -42,7 +42,12 @@ def validate_csrf_token(request: Request, token: str | None) -> bool:
 async def verify_csrf(request: Request):
     if request.method in ("GET", "HEAD", "OPTIONS"):
         return
-    form = await request.form()
-    token = form.get("csrf_token")
+    token = request.headers.get("x-csrf-token")
+    if token is None:
+        try:
+            form = await request.form()
+        except Exception:
+            form = {}
+        token = form.get("csrf_token")
     if not validate_csrf_token(request, token):
         raise HTTPException(status_code=403, detail="CSRF validation failed")

--- a/src/main.py
+++ b/src/main.py
@@ -86,13 +86,15 @@ async def lifespan(app: FastAPI):
     await _check_embedding_dim()
     indexer_task = asyncio.create_task(run_indexer_loop())
     indexer_task.add_done_callback(_on_indexer_done)
-    async with mcp.session_manager.run():
-        yield
-    indexer_task.cancel()
     try:
-        await asyncio.wait_for(asyncio.shield(indexer_task), timeout=10.0)
-    except (asyncio.CancelledError, asyncio.TimeoutError):
-        pass
+        async with mcp.session_manager.run():
+            yield
+    finally:
+        indexer_task.cancel()
+        try:
+            await asyncio.wait_for(asyncio.shield(indexer_task), timeout=10.0)
+        except (asyncio.CancelledError, asyncio.TimeoutError):
+            pass
 
 
 app = FastAPI(title="Obsidian MCP", lifespan=lifespan)

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import os
 import re
@@ -73,17 +74,27 @@ def _truncate_params(params: dict) -> dict:
 def _tracked(tool_name: str, param_keys: list[str]):
     """Decorator that times the call and logs it to usage_logs."""
     def decorator(fn):
+        sig = inspect.signature(fn)
+
         @wraps(fn)
         async def wrapper(*args, **kwargs):
             start = time.monotonic()
             result = await fn(*args, **kwargs)
             duration_ms = int((time.monotonic() - start) * 1000)
             params = {}
-            for i, key in enumerate(param_keys):
-                if i < len(args):
-                    params[key] = args[i]
-                elif key in kwargs:
-                    params[key] = kwargs[key]
+            # Resolve logged params by NAME via the wrapped signature so that
+            # a non-logged positional arg between logged ones can't shift the
+            # mapping (positional zipping silently mislabelled params before).
+            try:
+                bound = sig.bind(*args, **kwargs)
+                bound.apply_defaults()
+                params = {
+                    key: bound.arguments[key]
+                    for key in param_keys
+                    if key in bound.arguments
+                }
+            except TypeError:
+                params = {}
             await _log_usage(tool_name, _truncate_params(params), duration_ms, len(str(result)))
             return result
         return wrapper
@@ -690,6 +701,11 @@ async def edit_note_impl(
         if err is not None:
             return err
     elif find is not None:
+        if find == "":
+            return (
+                "edit_note: find must be a non-empty string. "
+                "An empty find would match every position and corrupt the note."
+            )
         count = existing.count(find)
         if count == 0:
             preview = existing[:500]
@@ -745,7 +761,7 @@ _WIKILINK_REWRITE_RE = re.compile(
     r"(?P<rest>(?:#[^\]\|\n]*)?(?:\|[^\]\n]*)?)\]\]"
 )
 _MDLINK_REWRITE_RE = re.compile(
-    r"\[(?P<text>[^\]\n]+)\]\((?P<href>[^)\s]+?\.md)(?P<anchor>#[^)]*)?\)"
+    r"\[(?P<text>[^\]\n]+)\]\((?P<href>[^)\n]+?\.md)(?P<anchor>#[^)]*)?\)"
 )
 
 

--- a/src/oauth/routes.py
+++ b/src/oauth/routes.py
@@ -52,6 +52,22 @@ def _validate_scope(scope: str) -> str:
     return " ".join(parts & VALID_SCOPES) or "read"
 
 
+def _clamp_scope(requested: str, registered: str) -> str:
+    """Restrict a requested scope to what the client registered for.
+
+    Both inputs are already validated scope strings. The user can only ever
+    be granted the intersection of what they asked for at consent time and
+    what the client is registered to hold. `readwrite` implies `read`, so a
+    client registered for `readwrite` may still be granted plain `read`.
+    """
+    requested_parts = set(requested.split())
+    registered_parts = set(registered.split())
+    if "readwrite" in registered_parts:
+        registered_parts.add("read")
+    granted = requested_parts & registered_parts
+    return " ".join(sorted(granted)) or "read"
+
+
 def _state_serializer() -> URLSafeTimedSerializer:
     return URLSafeTimedSerializer(settings.secret_key, salt="oauth-state")
 
@@ -211,9 +227,14 @@ async def authorize_get(
     server_state = secrets.token_urlsafe(16)
     signed_state = _state_serializer().dumps(server_state)
 
+    # The registered scope caps what the user can grant; surface it so the
+    # consent screen only offers access levels the client can actually hold.
+    client_can_write = "readwrite" in client.scope.split()
+
     response = templates.TemplateResponse(request, "authorize.html", {
         "client_name": client.client_name,
         "scope": scope,
+        "client_can_write": client_can_write,
         "client_id": client_id,
         "redirect_uri": redirect_uri,
         "code_challenge": code_challenge,
@@ -264,19 +285,11 @@ async def authorize_post(
     except ValueError as exc:
         return JSONResponse({"error": "invalid_scope", "error_description": str(exc)}, status_code=400)
 
-    if action != "approve":
-        # Denied — redirect with error
-        sep = "&" if "?" in redirect_uri else "?"
-        url = f"{redirect_uri}{sep}error=access_denied"
-        if client_state:
-            url += f"&state={client_state}"
-        return RedirectResponse(url, status_code=302)
-
     # Multi-user mode: refuse to mint a code without a session. The GET
     # handler already redirects to login, but defend against a stale POST
     # arriving after the session expired.
     session_user_id: int | None = None
-    if settings.multi_user_mode:
+    if action == "approve" and settings.multi_user_mode:
         try:
             session_user_id = request.session.get("user_id")
         except (AssertionError, AttributeError):
@@ -287,20 +300,46 @@ async def authorize_post(
                 status_code=401,
             )
 
-    code = secrets.token_hex(32)
-
     async with async_session() as session:
+        # Re-validate redirect_uri against the client's registered list. The
+        # GET handler does this, but redirect_uri arrives here as an
+        # attacker-controllable form field, so a confused-deputy / open
+        # redirect is possible unless we re-check before any redirect or code
+        # minting. Load the client once and reuse it for the multi-user
+        # first-authorizer binding below.
+        result = await session.execute(
+            select(OAuthClient).where(OAuthClient.client_id == client_id)
+        )
+        client_row = result.scalar_one_or_none()
+
+        if client_row is None:
+            return JSONResponse({"error": "invalid_client"}, status_code=400)
+
+        if redirect_uri not in client_row.redirect_uris:
+            return JSONResponse({"error": "invalid_redirect_uri"}, status_code=400)
+
+        # Clamp the consent-form scope to what the client registered for.
+        # `scope` arrives as an attacker-controllable form field (the radio
+        # buttons are client-side and trivially bypassed), so a client
+        # registered for read-only could otherwise mint a readwrite code.
+        scope = _clamp_scope(scope, client_row.scope)
+
+        if action != "approve":
+            # Denied — redirect with error (redirect_uri now verified)
+            sep = "&" if "?" in redirect_uri else "?"
+            url = f"{redirect_uri}{sep}error=access_denied"
+            if client_state:
+                url += f"&state={client_state}"
+            return RedirectResponse(url, status_code=302)
+
+        code = secrets.token_hex(32)
+
         # Bind the OAuth client to its first-authorizing user. RFC 7591
         # dynamic registration is unauthenticated, so we can't bind at
         # registration time — first /authorize wins. Subsequent authorizes
         # for the same client leave `user_id` alone.
-        if session_user_id is not None:
-            result = await session.execute(
-                select(OAuthClient).where(OAuthClient.client_id == client_id)
-            )
-            client_row = result.scalar_one_or_none()
-            if client_row is not None and client_row.user_id is None:
-                client_row.user_id = session_user_id
+        if session_user_id is not None and client_row.user_id is None:
+            client_row.user_id = session_user_id
 
         oauth_code = OAuthCode(
             code_hash=_hash(code),

--- a/src/services/embeddings.py
+++ b/src/services/embeddings.py
@@ -41,6 +41,9 @@ def chunk_text(content: str, chunk_size: int = 512, overlap: int = 0) -> list[st
     """
     char_size = chunk_size * 4
     char_overlap = overlap * 4
+    # Guard against overlap >= chunk_size, which would make the window
+    # never advance (start <= previous start) and loop forever.
+    step = max(char_size - char_overlap, 1)
 
     if len(content) <= char_size:
         return [content] if content.strip() else []
@@ -54,7 +57,7 @@ def chunk_text(content: str, chunk_size: int = 512, overlap: int = 0) -> list[st
             chunks.append(chunk.strip())
         if end >= len(content):
             break
-        start = end - char_overlap
+        start += step
 
     return chunks
 
@@ -187,15 +190,18 @@ async def embed_note(session: AsyncSession, note: NoteMetadata, content: str):
     if not chunks:
         return 0
 
-    await session.execute(
-        delete(NoteEmbedding).where(NoteEmbedding.note_id == note.id)
-    )
-
     try:
         embeddings = await get_embeddings_batch(chunks)
     except Exception as e:
         logger.warning(f"Failed to embed {note.file_path}: {e}")
         return 0
+
+    # Only delete the old embeddings once new ones are in hand. If the provider
+    # call above had failed, deleting first would let embed_vault commit the
+    # DELETE and drop good vectors (issue #11).
+    await session.execute(
+        delete(NoteEmbedding).where(NoteEmbedding.note_id == note.id)
+    )
 
     for i, (chunk, embedding) in enumerate(zip(chunks, embeddings)):
         session.add(NoteEmbedding(

--- a/src/services/indexer.py
+++ b/src/services/indexer.py
@@ -25,20 +25,37 @@ from src.services.vault import (
 # progress" while the one-shot backfill is running.
 link_backfill_in_progress: bool = False
 
+# Serializes full index/embed passes so the periodic loop and a
+# panel-triggered on-demand reindex can never run index_vault/embed_vault
+# concurrently for the same scope. Two overlapping passes share no DB lock and
+# would race on move-detection, deleted-path removal, and per-note embedding
+# delete+insert (duplicate-key errors, lost/duplicated rows). Both
+# `run_indexer_loop` and `_reindex_background` acquire this before doing work.
+index_pass_lock: asyncio.Lock = asyncio.Lock()
+
+
+def _sanitize_value(v):
+    """Recursively coerce a frontmatter value into a JSON-serializable form.
+
+    Lists and dicts are walked element-by-element; non-string dict keys and
+    any non-serializable scalar (e.g. a YAML date/datetime) are stringified.
+    """
+    if isinstance(v, (str, int, float, bool, type(None))):
+        return v
+    elif isinstance(v, list):
+        return [_sanitize_value(i) for i in v]
+    elif isinstance(v, dict):
+        return {
+            (k if isinstance(k, str) else str(k)): _sanitize_value(val)
+            for k, val in v.items()
+        }
+    else:
+        return str(v)
+
 
 def _sanitize_frontmatter(fm: dict) -> dict:
     """Convert non-JSON-serializable values (dates, etc) to strings."""
-    sanitized = {}
-    for k, v in fm.items():
-        if isinstance(v, (str, int, float, bool, type(None))):
-            sanitized[k] = v
-        elif isinstance(v, list):
-            sanitized[k] = [str(i) if not isinstance(i, (str, int, float, bool, type(None))) else i for i in v]
-        elif isinstance(v, dict):
-            sanitized[k] = _sanitize_frontmatter(v)
-        else:
-            sanitized[k] = str(v)
-    return sanitized
+    return _sanitize_value(fm)
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +96,11 @@ async def index_vault(user_id: int | None = None):
 
         # Determine changes
         to_upsert = []
+        # Body text parsed during this scan, keyed by rel_path. The tsvector
+        # loop below reuses these instead of re-reading from disk — a concurrent
+        # delete between the two passes would otherwise raise FileNotFoundError
+        # and leave the just-committed row's content_tsvector null/stale.
+        path_to_content: dict[str, str] = {}
         for rel_path, full_path in files.items():
             try:
                 raw = full_path.read_text(encoding="utf-8", errors="strict")
@@ -94,6 +116,7 @@ async def index_vault(user_id: int | None = None):
                 continue  # No change
 
             frontmatter, content = parse_frontmatter(raw)
+            path_to_content[rel_path] = content
             title = frontmatter.get("title") or full_path.stem
             tags = extract_tags(raw, frontmatter)
             stat = full_path.stat()
@@ -236,14 +259,13 @@ async def index_vault(user_id: int | None = None):
                       AND user_id = :uid
                 """
             for path in paths:
-                full_path = vault / path
+                # Reuse the body parsed during the scan loop above instead of
+                # re-reading from disk; a concurrent delete between the passes
+                # would otherwise leave content_tsvector null/stale (issue #18).
+                if path not in path_to_content:
+                    continue
+                content = path_to_content[path]
                 try:
-                    try:
-                        raw = full_path.read_text(encoding="utf-8", errors="strict")
-                    except UnicodeDecodeError:
-                        logger.warning(f"Skipping non-UTF8 file: {path}")
-                        continue
-                    _, content = parse_frontmatter(raw)
                     params: dict = {"content": content[:100000], "path": path}
                     if user_id is not None:
                         params["uid"] = user_id
@@ -358,37 +380,45 @@ async def _update_links_for_changed(
     # belongs to the same user — otherwise alice's newly-created `foo.md`
     # would silently get attached as the target of bob's dangling
     # `[[foo]]` link.
-    if user_id is None:
-        reresolve_sql = """
-            UPDATE note_links
-            SET target_note_id = :nid
-            WHERE target_note_id IS NULL
-              AND target_path IN (:full, :stem, :no_ext)
-        """
-    else:
-        reresolve_sql = """
-            UPDATE note_links
-            SET target_note_id = :nid
-            WHERE target_note_id IS NULL
-              AND target_path IN (:full, :stem, :no_ext)
-              AND source_note_id IN (
-                  SELECT id FROM notes_metadata WHERE user_id = :uid
-              )
-        """
+    #
+    # The bare-stem form (`[[Foo]]`) is only safe to match when exactly one
+    # note in the vault carries that stem. With a shared stem the resolver
+    # (`resolve_target`) uses same-folder preference and an alphabetical
+    # tie-break, so a blind `target_path = stem` match here would mis-attach
+    # dangling rows that belong to a *different* note. Ambiguous stems stay
+    # dangling and resolve later when their own source note is reindexed.
+    stems: dict[str, list[tuple[str, int]]] = vault_index["stems"]
     for path in changed_paths:
         nid = paths_to_id.get(path)
         if nid is None:
             continue
         stem = os.path.splitext(os.path.basename(path))[0]
         path_no_ext = path[:-3] if path.endswith(".md") else path
+        # Always-safe canonical forms keyed to the exact stored path.
         params: dict = {
             "nid": nid,
             "full": path,
-            "stem": stem,
             "no_ext": path_no_ext,
         }
+        # Only fold in the bare stem when it maps to a single note.
+        if len(stems.get(stem, [])) == 1:
+            params["stem"] = stem
+        in_clause = ", ".join(f":{p}" for p in ("full", "no_ext", "stem")
+                              if p in params)
+        where_extra = ""
         if user_id is not None:
             params["uid"] = user_id
+            where_extra = (
+                " AND source_note_id IN ("
+                "SELECT id FROM notes_metadata WHERE user_id = :uid)"
+            )
+        reresolve_sql = (
+            "UPDATE note_links "
+            "SET target_note_id = :nid "
+            "WHERE target_note_id IS NULL "
+            f"AND target_path IN ({in_clause})"
+            f"{where_extra}"
+        )
         await session.execute(text(reresolve_sql), params)
     if changed_paths:
         await session.commit()
@@ -510,6 +540,12 @@ async def embed_vault(user_id: int | None = None):
         total_chunks = 0
         skipped_excluded = 0
         for i, row in enumerate(unembedded):
+            # Re-check the pause flag every iteration so a panel-driven pause
+            # (e.g. reset-embeddings) stops an in-flight embed pass promptly
+            # instead of grinding through the whole backlog first (issue #19).
+            if _is_paused():
+                logger.info(f"Embedding pass paused, stopping early{log_suffix}")
+                break
             try:
                 # Skip files matching exclude patterns. Drop any pre-existing
                 # embeddings (in case the file was indexed before exclusion was
@@ -637,43 +673,46 @@ async def run_indexer_loop():
     parallelism can come later). Single-user mode runs one legacy pass with
     `user_id=None`.
     """
-    if settings.multi_user_mode:
-        # Initial pass per user.
-        user_ids = await _active_user_ids()
-        for uid in user_ids:
-            try:
-                await index_vault(user_id=uid)
-            except Exception as e:
-                logger.error(f"Initial index failed (user_id={uid}): {e}")
-        try:
-            # Link backfill still uses the global "table empty" guard but
-            # runs the per-user pass when triggered. Iterate every user so
-            # each user's notes get their links resolved against their own
-            # vault_index.
+    # Hold `index_pass_lock` for the initial pass too, so a panel-triggered
+    # `_reindex_background` fired during startup is serialized against it.
+    async with index_pass_lock:
+        if settings.multi_user_mode:
+            # Initial pass per user.
+            user_ids = await _active_user_ids()
             for uid in user_ids:
-                await link_backfill_pass(user_id=uid)
-        except Exception as e:
-            logger.error(f"Link backfill failed: {e}")
-        for uid in user_ids:
+                try:
+                    await index_vault(user_id=uid)
+                except Exception as e:
+                    logger.error(f"Initial index failed (user_id={uid}): {e}")
             try:
-                await embed_vault(user_id=uid)
+                # Link backfill still uses the global "table empty" guard but
+                # runs the per-user pass when triggered. Iterate every user so
+                # each user's notes get their links resolved against their own
+                # vault_index.
+                for uid in user_ids:
+                    await link_backfill_pass(user_id=uid)
             except Exception as e:
-                logger.error(f"Initial embedding failed (user_id={uid}): {e}")
-    else:
-        try:
-            await index_vault()
-        except Exception as e:
-            logger.error(f"Initial index failed: {e}")
+                logger.error(f"Link backfill failed: {e}")
+            for uid in user_ids:
+                try:
+                    await embed_vault(user_id=uid)
+                except Exception as e:
+                    logger.error(f"Initial embedding failed (user_id={uid}): {e}")
+        else:
+            try:
+                await index_vault()
+            except Exception as e:
+                logger.error(f"Initial index failed: {e}")
 
-        try:
-            await link_backfill_pass()
-        except Exception as e:
-            logger.error(f"Link backfill failed: {e}")
+            try:
+                await link_backfill_pass()
+            except Exception as e:
+                logger.error(f"Link backfill failed: {e}")
 
-        try:
-            await embed_vault()
-        except Exception as e:
-            logger.error(f"Initial embedding failed: {e}")
+            try:
+                await embed_vault()
+            except Exception as e:
+                logger.error(f"Initial embedding failed: {e}")
 
     consecutive_failures = 0
     logger.info(
@@ -687,14 +726,18 @@ async def run_indexer_loop():
             logger.info("Periodic tick skipped (paused)")
             continue
         try:
-            if settings.multi_user_mode:
-                # Re-fetch the user list every cycle so newly-added or
-                # newly-deactivated users are picked up without a restart.
-                for uid in await _active_user_ids():
-                    await _index_pass_once(uid)
-            else:
-                await index_vault()
-                await embed_vault()
+            # Hold `index_pass_lock` for the whole index/embed pass so a
+            # concurrent panel-triggered `_reindex_background` cannot run a
+            # second index_vault/embed_vault over the same scope.
+            async with index_pass_lock:
+                if settings.multi_user_mode:
+                    # Re-fetch the user list every cycle so newly-added or
+                    # newly-deactivated users are picked up without a restart.
+                    for uid in await _active_user_ids():
+                        await _index_pass_once(uid)
+                else:
+                    await index_vault()
+                    await embed_vault()
             await cleanup_expired_tokens()
             consecutive_failures = 0
         except Exception as e:

--- a/src/services/links.py
+++ b/src/services/links.py
@@ -33,10 +33,15 @@ _WIKILINK_RE = re.compile(
     r"(?:\|(?P<alias>[^\]\n]*))?\]\]"
 )
 
-# Markdown link: `[text](href.md)` or `[text](href.md#anchor)`. Href must
-# end in `.md` (with optional `#anchor`) — we ignore non-note links here.
+# Markdown link: `[text](href.md)`, `[text](href.md#anchor)`, or the
+# CommonMark angle-bracket form `[text](<href.md>)`. Href must end in `.md`
+# (with optional `#anchor`) — we ignore non-note links here. The href class
+# forbids only newlines (not all whitespace), so raw-space note names like
+# `My Note.md` and `folder/My Note.md` are captured.
 _MDLINK_RE = re.compile(
-    r"\[(?P<text>[^\]\n]+)\]\((?P<href>[^)\s]+?\.md)(?:#[^)]*)?\)"
+    r"\[(?P<text>[^\]\n]+)\]\("
+    r"(?:<(?P<href_ab>[^>\n]+?\.md)(?:#[^>]*)?>"
+    r"|(?P<href>[^)\n]+?\.md)(?:#[^)\n]*)?)\)"
 )
 
 # Fenced code blocks (``` or ~~~) — match the whole fence including newlines.
@@ -77,7 +82,7 @@ def extract_links(content: str) -> list[ExtractedLink]:
         ))
 
     for m in _MDLINK_RE.finditer(masked):
-        href = m.group("href").strip()
+        href = (m.group("href_ab") or m.group("href") or "").strip()
         if not href:
             continue
         # Decode percent-encoded characters (e.g. `%20` → space).

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -336,6 +336,13 @@ def replace_section(text: str, heading: str, new_body: str) -> tuple[str | None,
         body_end = len(text)
 
     inserted = new_body
+    # If the retained prefix lacks a trailing newline (an end-of-file heading
+    # with no trailing newline, where the heading match consumed to EOF),
+    # the new body would glue directly onto the heading text. Prepend one
+    # newline to separate them. No-op when the prefix already ends in "\n".
+    prefix = text[:body_start]
+    if prefix and not prefix.endswith("\n"):
+        inserted = "\n" + inserted
     if next_heading_line_start is not None and not inserted.endswith("\n"):
         inserted = inserted + "\n"
 
@@ -353,6 +360,9 @@ def extract_tags(raw: str, frontmatter: dict) -> list[str]:
     elif isinstance(fm_tags, str):
         tags.update(t.strip() for t in fm_tags.split(","))
     # Inline #tags (not inside code blocks)
-    for match in re.finditer(r"(?:^|\s)#([a-zA-Z][a-zA-Z0-9_/-]*)", raw):
+    from src.services.links import mask_code
+
+    masked = mask_code(raw)
+    for match in re.finditer(r"(?:^|\s)#([a-zA-Z][a-zA-Z0-9_/-]*)", masked):
         tags.add(match.group(1))
     return sorted(tags)

--- a/tests/test_issue_10_chunk_overlap_infinite_loop.py
+++ b/tests/test_issue_10_chunk_overlap_infinite_loop.py
@@ -1,0 +1,75 @@
+"""Regression test for issue #10: chunk_text loops forever when overlap >= chunk_size.
+
+Before the fix, step was computed implicitly as `start = end - char_overlap`.
+When overlap >= chunk_size, char_overlap >= char_size, so `start` never advanced
+and the while loop at embeddings.py:50-57 spun forever. The fix clamps the
+advance step to at least 1 char (`step = max(char_size - char_overlap, 1)`).
+
+Fully offline: only exercises pure string-chunking, no DB / network / Ollama.
+"""
+import pytest
+
+from src.services.embeddings import chunk_text
+
+
+def _run_with_timeout(fn, seconds=5.0):
+    """Run fn() in a worker thread, fail if it doesn't return in time.
+
+    A pre-fix chunk_text() never returns, so without a guard the test would
+    hang the whole suite. We don't kill the runaway thread (can't, cleanly) —
+    we just assert it finished and surface its result.
+    """
+    import threading
+
+    result = {}
+
+    def target():
+        result["value"] = fn()
+
+    t = threading.Thread(target=target, daemon=True)
+    t.start()
+    t.join(seconds)
+    if t.is_alive():
+        pytest.fail("chunk_text did not terminate (infinite loop)")
+    return result["value"]
+
+
+def test_overlap_equal_to_chunk_size_terminates():
+    content = "word " * 2000  # comfortably larger than one chunk
+    chunks = _run_with_timeout(lambda: chunk_text(content, chunk_size=10, overlap=10))
+    assert chunks  # produced output rather than hanging
+    assert all(c.strip() for c in chunks)
+
+
+def test_overlap_greater_than_chunk_size_terminates():
+    content = "word " * 2000
+    chunks = _run_with_timeout(lambda: chunk_text(content, chunk_size=10, overlap=50))
+    assert chunks
+    assert all(c.strip() for c in chunks)
+
+
+def test_chunks_cover_full_content_when_overlap_too_large():
+    # With step clamped to 1 char, every character must still be reachable;
+    # concatenating chunk content (before strip) would cover the input.
+    content = "abcdefghij" * 100
+    chunks = _run_with_timeout(lambda: chunk_text(content, chunk_size=1, overlap=1))
+    assert chunks
+    # Last chunk must reach the end of the content.
+    assert content.rstrip()[-1] in chunks[-1]
+
+
+def test_normal_overlap_still_advances_with_overlap():
+    # Sanity: legitimate overlap (< chunk_size) keeps working and overlaps.
+    content = "x" * 5000
+    chunks = chunk_text(content, chunk_size=100, overlap=10)
+    assert len(chunks) > 1
+    # char_size=400, step=360 -> first chunk ends at 400, second starts at 360.
+    assert chunks[0][360:400] == chunks[1][0:40]
+
+
+def test_zero_overlap_unchanged():
+    content = "y" * 5000
+    chunks = chunk_text(content, chunk_size=100, overlap=0)
+    assert len(chunks) > 1
+    # No overlap: contiguous slices, no shared boundary chars.
+    assert chunks[0][-1] != "" and chunks[1]

--- a/tests/test_issue_11_embed_note_preserves_vectors_on_failure.py
+++ b/tests/test_issue_11_embed_note_preserves_vectors_on_failure.py
@@ -1,0 +1,117 @@
+"""Regression test for issue #11: embed_note dropped good vectors on provider failure.
+
+Before the fix, embed_note deleted the note's existing NoteEmbedding rows BEFORE
+calling the provider. When the provider raised, the exception was swallowed and
+embed_note returned 0 without re-raising — but the DELETE was already staged on
+the session. embed_vault then committed that session (indexer.py:558), so a
+transient embedding failure permanently dropped previously-good vectors.
+
+The fix moves the DELETE to after get_embeddings_batch succeeds. On failure,
+no DELETE is staged, so the existing vectors survive the surrounding commit.
+
+Fully offline: the AsyncSession and embedding provider are both faked, so no
+DB / network / Ollama / OpenAI is touched.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import delete
+
+import src.services.embeddings as embeddings
+from src.models.db import NoteEmbedding
+
+
+class _FakeNote:
+    def __init__(self):
+        self.id = 42
+        self.file_path = "notes/example.md"
+        self.content_hash = "newhash"
+        self.embedded_content_hash = "oldhash"
+
+
+class _RecordingSession:
+    """Minimal AsyncSession stand-in that records what embed_note does.
+
+    We don't simulate a real DB — we only need to know whether embed_note
+    issued the DELETE of existing embeddings, and what rows it tried to add.
+    """
+
+    def __init__(self):
+        self.delete_executed = False
+        self.added: list = []
+        self.flushed = False
+
+    async def execute(self, stmt):
+        # The only execute() embed_note issues is the DELETE of old embeddings.
+        if isinstance(stmt, delete(NoteEmbedding).__class__):
+            self.delete_executed = True
+        return None
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def flush(self):
+        self.flushed = True
+
+
+@pytest.mark.asyncio
+async def test_provider_failure_does_not_delete_existing_embeddings(monkeypatch):
+    session = _RecordingSession()
+    note = _FakeNote()
+
+    async def boom(_chunks):
+        raise RuntimeError("ollama down")
+
+    monkeypatch.setattr(embeddings, "get_embeddings_batch", boom)
+
+    result = await embeddings.embed_note(session, note, "some real content here")
+
+    # Failure is reported as 0 chunks (caller treats note as still un-embedded).
+    assert result == 0
+    # Critical invariant: the old embeddings must NOT have been deleted, so the
+    # surrounding embed_vault commit cannot drop good vectors.
+    assert session.delete_executed is False
+    assert session.added == []
+    # And the note must not be marked as freshly embedded.
+    assert note.embedded_content_hash == "oldhash"
+
+
+@pytest.mark.asyncio
+async def test_provider_success_replaces_embeddings(monkeypatch):
+    session = _RecordingSession()
+    note = _FakeNote()
+
+    async def ok(chunks):
+        return [[0.0, 1.0, 2.0] for _ in chunks]
+
+    monkeypatch.setattr(embeddings, "get_embeddings_batch", ok)
+
+    result = await embeddings.embed_note(session, note, "some real content here")
+
+    # On success the old embeddings are deleted and new rows are staged.
+    assert result >= 1
+    assert session.delete_executed is True
+    assert len(session.added) == result
+    assert all(isinstance(o, NoteEmbedding) for o in session.added)
+    assert session.flushed is True
+    # The note is marked embedded against its current content hash.
+    assert note.embedded_content_hash == note.content_hash
+
+
+@pytest.mark.asyncio
+async def test_empty_content_short_circuits(monkeypatch):
+    session = _RecordingSession()
+    note = _FakeNote()
+
+    # Provider should never be called for empty/whitespace content.
+    monkeypatch.setattr(
+        embeddings, "get_embeddings_batch", AsyncMock(side_effect=AssertionError)
+    )
+
+    result = await embeddings.embed_note(session, note, "   \n  ")
+
+    assert result == 0
+    assert session.delete_executed is False
+    assert session.added == []

--- a/tests/test_issue_12_reindex_mutual_exclusion.py
+++ b/tests/test_issue_12_reindex_mutual_exclusion.py
@@ -1,0 +1,128 @@
+"""Regression test for GitHub issue #12.
+
+The periodic indexer loop (`run_indexer_loop`) and the panel-triggered
+on-demand reindex (`_reindex_background` in `src/control_panel/routes.py`)
+both call `index_vault`/`embed_vault`. Originally there was no mutual
+exclusion: a user clicking "reindex" in the panel could launch a second
+`index_vault`/`embed_vault` pass concurrently with the periodic loop over the
+same scope, racing on move-detection, deleted-path removal, and per-note
+embedding delete+insert.
+
+The fix introduces a module-level `asyncio.Lock`
+(`src.services.indexer.index_pass_lock`) that both the periodic loop's pass
+body and `_reindex_background` acquire, so only one index/embed pass runs at a
+time.
+
+This test drives `_reindex_background` while the shared lock is already held
+(simulating an in-flight periodic pass) and asserts the on-demand reindex
+blocks until the lock is released — i.e. it does NOT run a concurrent
+`index_vault`. It also asserts two concurrent `_reindex_background` calls never
+overlap.
+
+Fully offline: no DB, no network, no embedding provider. `index_vault` and
+`embed_vault` are replaced with fakes before anything runs.
+"""
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+# Importing the production modules pulls in `src.config`, whose module-level
+# `Settings()` singleton reads `./.env`. The real `.env` on this host carries
+# host-only keys the model forbids, so we must NOT let it load: provide the
+# same minimal defaults conftest uses and chdir to a dir without a `.env`
+# (env_file is resolved relative to CWD) BEFORE importing anything.
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+import src.services.indexer as indexer  # noqa: E402
+import src.control_panel.routes as routes  # noqa: E402
+
+
+def test_index_pass_lock_exists():
+    """The shared lock must exist at module level (the anchor of the fix)."""
+    assert isinstance(indexer.index_pass_lock, asyncio.Lock)
+
+
+@pytest.mark.asyncio
+async def test_reindex_background_blocks_on_held_lock(monkeypatch):
+    """`_reindex_background` must acquire `index_pass_lock`. While the lock is
+    held (simulating an in-flight periodic pass), the on-demand reindex must
+    NOT call `index_vault` — proving the two passes are serialized."""
+    # Single-user mode keeps the legacy one-pass path.
+    monkeypatch.setattr(routes.settings, "multi_user_mode", False, raising=False)
+
+    index_started = asyncio.Event()
+
+    async def _fake_index_vault(*args, **kwargs):
+        index_started.set()
+
+    async def _fake_embed_vault(*args, **kwargs):
+        return None
+
+    # `_reindex_background` imports these names from `src.services.indexer`
+    # at call time, so patching the indexer module is what counts.
+    monkeypatch.setattr(indexer, "index_vault", _fake_index_vault)
+    monkeypatch.setattr(indexer, "embed_vault", _fake_embed_vault)
+
+    # Use a fresh lock to avoid cross-test interference, and bind it where
+    # `_reindex_background` reads it from.
+    fresh_lock = asyncio.Lock()
+    monkeypatch.setattr(indexer, "index_pass_lock", fresh_lock)
+
+    # Simulate the periodic loop currently holding the pass lock.
+    await fresh_lock.acquire()
+    try:
+        task = asyncio.create_task(routes._reindex_background())
+        # Give the task ample scheduling opportunities; it must block on the
+        # lock and never reach index_vault while we hold it.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        assert not index_started.is_set(), (
+            "_reindex_background ran index_vault while the index pass lock was "
+            "held — passes are not mutually exclusive"
+        )
+    finally:
+        fresh_lock.release()
+
+    # Once released, the on-demand reindex proceeds.
+    await asyncio.wait_for(task, timeout=2)
+    assert index_started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_two_reindex_passes_do_not_overlap(monkeypatch):
+    """Two concurrent `_reindex_background` calls must serialize via the lock:
+    `index_vault` is never running for both at the same time."""
+    monkeypatch.setattr(routes.settings, "multi_user_mode", False, raising=False)
+
+    concurrency = {"current": 0, "max": 0}
+
+    async def _fake_index_vault(*args, **kwargs):
+        concurrency["current"] += 1
+        concurrency["max"] = max(concurrency["max"], concurrency["current"])
+        # Yield so an overlapping pass (if any) would be observed.
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        concurrency["current"] -= 1
+
+    async def _fake_embed_vault(*args, **kwargs):
+        await asyncio.sleep(0)
+
+    monkeypatch.setattr(indexer, "index_vault", _fake_index_vault)
+    monkeypatch.setattr(indexer, "embed_vault", _fake_embed_vault)
+    monkeypatch.setattr(indexer, "index_pass_lock", asyncio.Lock())
+
+    await asyncio.gather(
+        routes._reindex_background(),
+        routes._reindex_background(),
+    )
+
+    assert concurrency["max"] == 1, (
+        f"index_vault ran concurrently (max overlap={concurrency['max']}); "
+        "the index pass lock did not serialize the two reindex passes"
+    )

--- a/tests/test_issue_13_reresolve_shared_stem.py
+++ b/tests/test_issue_13_reresolve_shared_stem.py
@@ -1,0 +1,147 @@
+"""Regression test for GitHub issue #13.
+
+The indexer's re-resolution pass in `_update_links_for_changed` patches
+previously-dangling `note_links` rows when a note (re)appears. The buggy
+version matched `target_path IN (:full, :stem, :no_ext)` unconditionally,
+where `:stem` is the bare filename without extension.
+
+When two notes share a stem (e.g. `a/Foo.md` and `b/Foo.md`), reindexing
+one of them would attach *every* dangling `[[Foo]]` row to it — including
+rows that the resolver (`resolve_target`, same-folder + alphabetical
+tie-break) would assign to the other note. The fix: only fold the bare
+stem into the IN clause when that stem maps to exactly one note.
+
+This test runs fully offline. It drives `_update_links_for_changed` with a
+fake async session that records the re-resolution UPDATE statements and a
+tmp_path vault holding the real markdown files the function reads.
+"""
+import asyncio
+import re
+
+import pytest
+
+from src.services.indexer import _update_links_for_changed
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _Row:
+    def __init__(self, file_path, id):
+        self.file_path = file_path
+        self.id = id
+
+
+class _FakeSession:
+    """Minimal async session double.
+
+    - The first `execute` (the SELECT that builds the vault_index) returns
+      the configured notes_metadata rows.
+    - delete/insert statements (SQLAlchemy Core constructs) are ignored.
+    - `text(...)` UPDATE statements are recorded with their params for
+      assertions.
+    """
+
+    def __init__(self, rows):
+        self._rows = rows
+        self._select_served = False
+        self.updates = []  # list of (sql_text, params)
+
+    async def execute(self, statement, params=None):
+        # The text() UPDATE statements carry a `.text` attribute.
+        sql = getattr(statement, "text", None)
+        if isinstance(sql, str) and sql.lstrip().upper().startswith("UPDATE"):
+            self.updates.append((sql, params or {}))
+            return _FakeResult([])
+        # First non-text execute is the vault_index SELECT.
+        if not self._select_served:
+            self._select_served = True
+            return _FakeResult(self._rows)
+        return _FakeResult([])
+
+    async def commit(self):
+        pass
+
+
+def _update_targets(session):
+    """Return the set of target_path values folded into the IN clause across
+    all recorded UPDATE statements."""
+    folded = set()
+    for sql, params in session.updates:
+        in_match = re.search(r"target_path IN \(([^)]*)\)", sql)
+        assert in_match, f"no IN clause found in: {sql}"
+        bind_names = re.findall(r":(\w+)", in_match.group(1))
+        for name in bind_names:
+            folded.add(params[name])
+    return folded
+
+
+def test_shared_stem_does_not_fold_bare_stem(tmp_path):
+    """Reindexing one of two notes that share a stem must NOT match the bare
+    stem in the re-resolution UPDATE."""
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+    (tmp_path / "a" / "Foo.md").write_text("a body", encoding="utf-8")
+    (tmp_path / "b" / "Foo.md").write_text("b body", encoding="utf-8")
+
+    rows = [_Row("a/Foo.md", 1), _Row("b/Foo.md", 2)]
+    session = _FakeSession(rows)
+
+    asyncio.run(
+        _update_links_for_changed(
+            session, tmp_path, ["a/Foo.md"], user_id=None
+        )
+    )
+
+    folded = _update_targets(session)
+    # The full path and the no-extension path are always safe.
+    assert "a/Foo.md" in folded
+    assert "a/Foo" in folded
+    # The bare ambiguous stem must NOT be folded in — that is the bug.
+    assert "Foo" not in folded
+
+
+def test_unique_stem_folds_bare_stem(tmp_path):
+    """When a stem is unique in the vault, the bare stem IS safe to match."""
+    (tmp_path / "a").mkdir()
+    (tmp_path / "a" / "Bar.md").write_text("bar body", encoding="utf-8")
+
+    rows = [_Row("a/Bar.md", 1)]
+    session = _FakeSession(rows)
+
+    asyncio.run(
+        _update_links_for_changed(
+            session, tmp_path, ["a/Bar.md"], user_id=None
+        )
+    )
+
+    folded = _update_targets(session)
+    assert "a/Bar.md" in folded
+    assert "a/Bar" in folded
+    # Unique stem → safe to fold the bare form.
+    assert "Bar" in folded
+
+
+def test_multi_user_scope_clause_preserved(tmp_path):
+    """The per-user source-note scope guard survives the rewrite."""
+    (tmp_path / "Baz.md").write_text("baz", encoding="utf-8")
+
+    rows = [_Row("Baz.md", 7)]
+    session = _FakeSession(rows)
+
+    asyncio.run(
+        _update_links_for_changed(
+            session, tmp_path, ["Baz.md"], user_id=42
+        )
+    )
+
+    assert session.updates, "expected at least one UPDATE"
+    for sql, params in session.updates:
+        assert "source_note_id IN" in sql
+        assert "WHERE user_id = :uid" in sql
+        assert params["uid"] == 42

--- a/tests/test_issue_14_extract_tags_code_blocks.py
+++ b/tests/test_issue_14_extract_tags_code_blocks.py
@@ -1,0 +1,82 @@
+"""Regression test for GitHub issue #14.
+
+`extract_tags` scanned inline `#tags` over the *raw* note body, so `#token`
+forms inside fenced code blocks or inline backtick spans were captured as
+vault tags (e.g. `#anothercomment` in a python block, or `#inlinecode` in a
+backtick span). The docstring/comment claimed code blocks were excluded, but
+the body was never code-masked. The fix masks code via `mask_code` before the
+inline-tag scan, matching the precedent in `_scan_headings`.
+
+`extract_tags` is a pure dict/string -> list function with no DB / network /
+embedding dependencies, so the whole module runs fully offline.
+"""
+
+import os
+import tempfile
+
+# Importing `src.services.vault` pulls in `src.config`, whose module-level
+# `Settings()` singleton reads `./.env`. On this host the real `.env` carries
+# host-only keys the model forbids, so we must NOT let that file load. Provide
+# the same minimal defaults conftest uses and chdir to a dir without a `.env`
+# (env_file is resolved relative to CWD) BEFORE importing the module.
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+from src.services.vault import extract_tags  # noqa: E402
+
+
+def test_fenced_code_block_tags_are_not_captured():
+    """The bug case: `#tags` inside a fenced code block must be ignored."""
+    raw = (
+        "Intro with a #realtag here.\n"
+        "\n"
+        "```python\n"
+        "x = 1  #anothercomment\n"
+        "```\n"
+        "\n"
+        "Trailing #afterblock tag.\n"
+    )
+    tags = extract_tags(raw, {})
+    assert "realtag" in tags
+    assert "afterblock" in tags
+    # The comment inside the python fence must NOT become a vault tag.
+    assert "anothercomment" not in tags
+
+
+def test_inline_code_span_tags_are_not_captured():
+    """`#tags` inside a backtick span must be ignored."""
+    raw = "See `#inlinecode` but keep #realtag.\n"
+    tags = extract_tags(raw, {})
+    assert "realtag" in tags
+    assert "inlinecode" not in tags
+
+
+def test_legitimate_body_tags_still_captured():
+    """Regression guard: real inline tags outside code are preserved,
+    including nested forms and start-of-line tags."""
+    raw = "#start of line tag\nmid #project/sub line\nend #done\n"
+    tags = extract_tags(raw, {})
+    assert tags == ["done", "project/sub", "start"]
+
+
+def test_frontmatter_tags_unaffected():
+    """Frontmatter tag handling stays unchanged and combines with body tags."""
+    raw = "Body with #bodytag.\n"
+    tags = extract_tags(raw, {"tags": ["fm-one", "fm-two"]})
+    assert "fm-one" in tags
+    assert "fm-two" in tags
+    assert "bodytag" in tags
+
+
+def test_tag_immediately_after_fence_close():
+    """A tag on the line right after a closing fence must still match.
+
+    `mask_code` replaces the fence with same-length whitespace but preserves
+    newlines, so the `^`/`\\s` boundary still fires for `#afterfence`.
+    """
+    raw = "```\ncode #hidden\n```\n#afterfence works\n"
+    tags = extract_tags(raw, {})
+    assert "afterfence" in tags
+    assert "hidden" not in tags

--- a/tests/test_issue_15_usage_limit_clamp.py
+++ b/tests/test_issue_15_usage_limit_clamp.py
@@ -1,0 +1,85 @@
+"""Regression test for GitHub issue #15.
+
+The control-panel `GET /api/usage` endpoint (`get_usage` in `src/api/routes.py`)
+took an unbounded `limit` query param and passed it straight into
+`select(UsageLog).limit(limit)`. Any authenticated panel user could request,
+e.g., `?limit=10000000`, forcing the DB to materialize an arbitrarily large
+result set — a trivial resource-exhaustion vector. Sibling MCP tools in
+`src/mcp_server/tools.py` already clamp with `limit = max(1, min(limit, 500))`.
+
+The fix adds the same clamp as the first line of `get_usage`. These tests call
+`get_usage` directly with a fake AsyncSession that captures the executed
+SQLAlchemy statement, then assert the LIMIT value reaching the query is clamped
+to [1, 500]. No DB, no network, no embeddings — fully offline.
+"""
+
+import asyncio
+import os
+import sys
+import tempfile
+
+# `src.api.routes` -> `src.config`, whose module-level `Settings()` reads
+# `./.env`. The real `.env` carries forbidden host-only keys, so provide minimal
+# defaults and chdir to a dir without a `.env` (env_file resolves relative to
+# CWD) BEFORE importing. Keeps the import fully offline.
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+os.chdir(tempfile.gettempdir())
+
+from src.api.routes import get_usage  # noqa: E402
+
+
+class _FakeResult:
+    def scalars(self):
+        return self
+
+    def all(self):
+        return []
+
+
+class _CapturingSession:
+    """Minimal stand-in for AsyncSession that records the executed statement."""
+
+    def __init__(self):
+        self.executed = None
+
+    async def execute(self, query):
+        self.executed = query
+        return _FakeResult()
+
+
+class _AdminUser:
+    is_admin = True
+    id = 1
+
+
+def _applied_limit(requested: int) -> int:
+    """Run get_usage with a capturing session and return the LIMIT value that
+    actually reached the SQLAlchemy statement."""
+    session = _CapturingSession()
+    asyncio.run(
+        get_usage(limit=requested, key_id=None, session=session, user=_AdminUser())
+    )
+    return session.executed._limit_clause.value
+
+
+def test_huge_limit_is_clamped_to_500():
+    assert _applied_limit(10_000_000) == 500
+
+
+def test_zero_limit_is_clamped_to_1():
+    assert _applied_limit(0) == 1
+
+
+def test_negative_limit_is_clamped_to_1():
+    assert _applied_limit(-5) == 1
+
+
+def test_in_range_limit_is_preserved():
+    assert _applied_limit(100) == 100
+
+
+def test_boundary_500_is_preserved():
+    assert _applied_limit(500) == 500

--- a/tests/test_issue_16_numeric_bounds.py
+++ b/tests/test_issue_16_numeric_bounds.py
@@ -1,0 +1,65 @@
+"""Issue #16: numeric settings must reject 0/negative (and absurd dims).
+
+Without bounds, INDEX_INTERVAL_SECONDS<=0 turns the periodic indexer into a
+busy-loop (asyncio.sleep(0)), EMBEDDING_DIMENSIONS<=0 produces invalid
+`vector(<dim>)` DDL, and CHUNK_SIZE<=0 with CHUNK_OVERLAP=0 makes the chunker
+loop forever. These constraints fail fast at Settings() instantiation instead.
+"""
+import pytest
+from pydantic import ValidationError
+
+from src.config import Settings
+
+
+def _make(**overrides):
+    return Settings(_env_file=None, **overrides)
+
+
+def test_defaults_still_valid():
+    s = _make()
+    assert s.index_interval_seconds == 300
+    assert s.embedding_dimensions == 1024
+    assert s.chunk_size == 512
+    assert s.chunk_overlap == 0
+
+
+@pytest.mark.parametrize("value", [0, -1, -300])
+def test_index_interval_seconds_rejects_non_positive(value):
+    with pytest.raises(ValidationError):
+        _make(index_interval_seconds=value)
+
+
+@pytest.mark.parametrize("value", [0, -1, 16001, 100000])
+def test_embedding_dimensions_out_of_range(value):
+    with pytest.raises(ValidationError):
+        _make(embedding_dimensions=value)
+
+
+@pytest.mark.parametrize("value", [0, -1, -512])
+def test_chunk_size_rejects_non_positive(value):
+    with pytest.raises(ValidationError):
+        _make(chunk_size=value)
+
+
+@pytest.mark.parametrize("value", [-1, -100])
+def test_chunk_overlap_rejects_negative(value):
+    with pytest.raises(ValidationError):
+        _make(chunk_overlap=value)
+
+
+def test_chunk_overlap_zero_allowed():
+    # Zero overlap is the documented default and must stay valid.
+    assert _make(chunk_overlap=0).chunk_overlap == 0
+
+
+def test_sane_operator_overrides_still_validate():
+    s = _make(
+        index_interval_seconds=600,
+        embedding_dimensions=3072,
+        chunk_size=256,
+        chunk_overlap=32,
+    )
+    assert s.index_interval_seconds == 600
+    assert s.embedding_dimensions == 3072
+    assert s.chunk_size == 256
+    assert s.chunk_overlap == 32

--- a/tests/test_issue_17_permission_validation.py
+++ b/tests/test_issue_17_permission_validation.py
@@ -1,0 +1,119 @@
+"""Regression test for GitHub issue #17: the control-panel key-creation form
+persists the `permission` field verbatim with no validation.
+
+`create_key_form` (the @router.post("/keys/create") handler in
+`src/control_panel/routes.py`) accepted `permission: str = Form("read")` and
+wrote it straight into the `APIKey` ORM object. The `permission` column is an
+unconstrained `String(20)`, so any value up to 20 chars persisted. The keys.html
+`<select>` only constrains the *UI*, so a scripted/tampered POST could submit
+e.g. "admin" (nonsense) or "readwrite " with a trailing space (silently behaves
+as read-only because the write gate checks an exact `!= "readwrite"`). The JSON
+API path validated the same field, so the two creation paths were inconsistent.
+
+The fix normalizes the value before constructing the ORM object: anything that
+is not exactly "read" or "readwrite" is coerced to "read", failing safe and
+matching the JSON API's invariant.
+
+Runs fully offline: no DB, no network, no embedding provider. The DB layer is a
+tiny in-memory fake `_FakeSession` that captures the `add()`ed `APIKey`; the
+request/user are minimal stand-ins. We assert on the persisted `permission`.
+"""
+# Point pydantic-settings at a non-existent env file BEFORE importing
+# `src.control_panel.routes` (which imports `src.config`) so config loads purely
+# from process env + conftest defaults, independent of the dev host's `.env`.
+import pydantic_settings  # noqa: E402
+
+_orig_init = pydantic_settings.BaseSettings.__init__
+
+
+def _no_env_file_init(self, *args, **kwargs):
+    kwargs.setdefault("_env_file", None)
+    _orig_init(self, *args, **kwargs)
+
+
+pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+try:
+    import asyncio
+
+    import pytest
+
+    from src.control_panel import routes
+    from src.models.db import APIKey
+finally:
+    pydantic_settings.BaseSettings.__init__ = _orig_init
+
+
+class _FakeSession:
+    def __init__(self):
+        self.added = []
+        self.committed = False
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+
+class _FakeUser:
+    id = 1
+
+
+class _FakeRequest:
+    """Minimal stand-in: create_key_form only touches `request.session`."""
+
+    def __init__(self):
+        self.session = {}
+
+
+def _create(permission):
+    """Run create_key_form with the given raw permission value and return the
+    persisted APIKey object."""
+    session = _FakeSession()
+    resp = asyncio.run(
+        routes.create_key_form(
+            request=_FakeRequest(),
+            name="my-key",
+            permission=permission,
+            session=session,
+            user=_FakeUser(),
+        )
+    )
+    # The handler always redirects on success and persists exactly one key.
+    assert resp.status_code == 303
+    assert len(session.added) == 1
+    assert isinstance(session.added[0], APIKey)
+    return session.added[0]
+
+
+# --- The core regression: junk / non-canonical values fail safe to read ---
+
+
+def test_nonsense_permission_is_coerced_to_read():
+    key = _create("admin")
+    assert key.permission == "read"
+
+
+def test_trailing_space_readwrite_is_coerced_to_read():
+    # "readwrite " behaves as read-only at the write gate but used to persist
+    # verbatim, producing silently-broken data. It must normalize to "read".
+    key = _create("readwrite ")
+    assert key.permission == "read"
+
+
+def test_empty_permission_is_coerced_to_read():
+    key = _create("")
+    assert key.permission == "read"
+
+
+# --- Legitimate values are preserved unchanged ---
+
+
+def test_read_is_preserved():
+    key = _create("read")
+    assert key.permission == "read"
+
+
+def test_readwrite_is_preserved():
+    key = _create("readwrite")
+    assert key.permission == "readwrite"

--- a/tests/test_issue_18_tsvector_concurrent_delete.py
+++ b/tests/test_issue_18_tsvector_concurrent_delete.py
@@ -1,0 +1,141 @@
+"""Regression test for GitHub issue #18.
+
+`index_vault` scans the vault once to build `to_upsert`, commits the metadata
+rows, then runs a SECOND loop that updates each changed note's
+`content_tsvector`. Originally that second loop re-read every file from disk.
+If a file was deleted on disk between the two passes (a concurrent delete —
+e.g. the user removing a note in Obsidian, or a `move_note`), the re-read
+raised `FileNotFoundError`, which the loop swallowed. The metadata row was
+already committed but its `content_tsvector` was never set, leaving the note
+unsearchable via full-text search until a later reindex happened to catch it.
+
+The fix carries the body parsed during the first scan loop (`path_to_content`)
+into the tsvector loop, so disk is read exactly once. A file vanishing after
+the scan no longer prevents its tsvector from being written.
+
+This test drives the real `index_vault` against a temp vault on disk, using a
+fake `async_session` that deletes the file from disk right after the metadata
+upsert (simulating the concurrent delete). It then asserts the tsvector UPDATE
+still ran with the in-memory body.
+
+Fully offline: no DB, no network, no embedding provider. The session is faked;
+`embed_vault`/links are never reached because the fake records only what
+`index_vault` itself executes.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+# Avoid loading the host's real `./.env` (forbidden host keys): set the same
+# minimal defaults conftest uses and chdir away from any `.env` BEFORE import.
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+from sqlalchemy.dialects.postgresql import Insert  # noqa: E402
+from sqlalchemy.sql.elements import TextClause  # noqa: E402
+
+import src.services.indexer as indexer  # noqa: E402
+
+
+class _FakeResult:
+    """Mimics the slice of the SQLAlchemy Result API that index_vault uses."""
+
+    def __init__(self, rows=None):
+        self._rows = rows or []
+
+    def fetchall(self):
+        return self._rows
+
+    def all(self):
+        return self._rows
+
+    def scalar(self):
+        return 0
+
+    def scalar_one(self):
+        raise AssertionError("scalar_one not expected in this test")
+
+
+class _FakeSession:
+    """Records executed statements and triggers a concurrent delete.
+
+    - The existing-hash SELECT returns no rows, so the single vault file is
+      treated as new and lands in `to_upsert`.
+    - When the metadata INSERT (the upsert) executes, we delete the file from
+      disk — reproducing the issue #18 race between the scan loop and the
+      tsvector loop.
+    - The `content_tsvector` UPDATE (a TextClause) is captured for assertions.
+    """
+
+    def __init__(self, on_metadata_insert):
+        self._on_metadata_insert = on_metadata_insert
+        self.tsvector_params = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, stmt, params=None):
+        # Capture the tsvector UPDATE (the thing the bug skipped on delete).
+        if isinstance(stmt, TextClause) and "content_tsvector" in stmt.text:
+            self.tsvector_params.append(params)
+            return _FakeResult()
+
+        # Simulate the concurrent on-disk delete the instant the row is
+        # committed-ready (mirrors the real "row exists, file gone" window).
+        if isinstance(stmt, Insert) and stmt.table.name == "notes_metadata":
+            self._on_metadata_insert()
+            return _FakeResult()
+
+        # Everything else (existing-hash SELECT, link/select/delete) is inert.
+        return _FakeResult()
+
+    async def commit(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_tsvector_written_despite_concurrent_delete(monkeypatch, tmp_path):
+    """A file deleted after the scan loop must still get its tsvector set."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    note = vault / "racey.md"
+    body = "The quick brown fox jumps over the lazy dog."
+    note.write_text(f"---\ntitle: Racey\n---\n{body}\n", encoding="utf-8")
+
+    # Point single-user mode at our temp vault.
+    monkeypatch.setattr(indexer.settings, "vault_path", str(vault), raising=False)
+
+    def _delete_file():
+        # The concurrent delete: gone before the tsvector loop runs.
+        if note.exists():
+            note.unlink()
+
+    fake = _FakeSession(on_metadata_insert=_delete_file)
+    monkeypatch.setattr(indexer, "async_session", lambda: fake)
+
+    await indexer.index_vault()
+
+    # The file was deleted mid-pass, yet the tsvector UPDATE must have run for
+    # it, carrying the body parsed during the scan loop (not a disk re-read).
+    assert fake.tsvector_params, (
+        "content_tsvector was never updated — the concurrent delete suppressed "
+        "the tsvector write (issue #18 regression)"
+    )
+    matching = [
+        p for p in fake.tsvector_params
+        if p and p.get("path") == "racey.md"
+    ]
+    assert matching, "no tsvector UPDATE was issued for the deleted note"
+    assert body in matching[0]["content"], (
+        "tsvector content did not come from the in-memory scan body"
+    )

--- a/tests/test_issue_19_embed_vault_rechecks_pause.py
+++ b/tests/test_issue_19_embed_vault_rechecks_pause.py
@@ -1,0 +1,168 @@
+"""Regression test for GitHub issue #19.
+
+`embed_vault` selects every note whose embedding is missing or stale, then
+loops over the result embedding one note per iteration. Originally that loop
+never rechecked the panel-driven pause flag (`_is_paused()`), so once an embed
+pass was underway a panel action (e.g. **Settings -> Reset embeddings**, which
+sets `indexer_paused = True`) could not actually stop it: the loop ground
+through the entire backlog before the next periodic tick noticed the pause.
+
+The fix rechecks `_is_paused()` at the top of every iteration and breaks out of
+the loop when it flips true, so an in-flight embed pass stops promptly.
+
+This test drives the real `embed_vault` against a temp vault on disk with a
+fake `async_session`. It stubs out the actual embedding work (`embed_note`) and
+toggles the pause flag, then asserts the loop stops early instead of embedding
+every note.
+
+Fully offline: no DB, no network, no embedding provider. The session is faked
+and `embed_note` is monkeypatched, so neither pgvector nor Ollama/OpenAI are
+touched.
+"""
+
+import os
+import tempfile
+
+import pytest
+
+# Avoid loading the host's real `./.env` (forbidden host keys): set the same
+# minimal defaults conftest uses and chdir away from any `.env` BEFORE import.
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+from sqlalchemy.sql.elements import TextClause  # noqa: E402
+
+import src.services.indexer as indexer  # noqa: E402
+
+
+class _Row:
+    """Mimics one row from the unembedded SELECT."""
+
+    def __init__(self, id, file_path, content_hash):
+        self.id = id
+        self.file_path = file_path
+        self.content_hash = content_hash
+
+
+class _FakeResult:
+    def __init__(self, rows=None, scalar_one=None):
+        self._rows = rows or []
+        self._scalar_one = scalar_one
+
+    def fetchall(self):
+        return self._rows
+
+    def all(self):
+        return self._rows
+
+    def scalar(self):
+        return 0
+
+    def scalar_one(self):
+        # Returned for the per-note `select(NoteMetadata)` lookup. Any object
+        # works here because `embed_note` is monkeypatched in the test.
+        return self._scalar_one
+
+
+class _FakeSession:
+    """Returns the unembedded rows for the initial SELECT, inert otherwise."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self._returned_unembedded = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, stmt, params=None):
+        # The first TextClause SELECT is the "find unembedded notes" query.
+        if isinstance(stmt, TextClause) and "embedded_content_hash" in stmt.text \
+                and "SELECT" in stmt.text.upper():
+            if not self._returned_unembedded:
+                self._returned_unembedded = True
+                return _FakeResult(rows=list(self._rows))
+            return _FakeResult()
+        # The per-note `select(NoteMetadata).where(...)` lookup.
+        return _FakeResult(scalar_one=object())
+
+    async def commit(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+
+def _make_rows(vault, n):
+    rows = []
+    for i in range(n):
+        rel = f"note{i}.md"
+        (vault / rel).write_text(f"# Note {i}\n\nbody {i}\n", encoding="utf-8")
+        rows.append(_Row(id=i + 1, file_path=rel, content_hash=f"hash{i}"))
+    return rows
+
+
+@pytest.mark.asyncio
+async def test_embed_vault_breaks_when_paused_before_loop(monkeypatch, tmp_path):
+    """If paused before the loop runs, no notes are embedded."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    rows = _make_rows(vault, 5)
+
+    monkeypatch.setattr(indexer.settings, "vault_path", str(vault), raising=False)
+    monkeypatch.setattr(indexer, "async_session", lambda: _FakeSession(rows))
+    monkeypatch.setattr(indexer.settings, "embedding_exclude_patterns", [], raising=False)
+
+    embedded = []
+
+    async def _fake_embed_note(session, note, content):
+        embedded.append(note)
+        return 1
+
+    monkeypatch.setattr(indexer, "embed_note", _fake_embed_note)
+    # Paused for the entire pass.
+    monkeypatch.setattr(indexer, "_is_paused", lambda: True)
+
+    await indexer.embed_vault()
+
+    assert embedded == [], (
+        "embed_vault embedded notes despite the indexer being paused — the "
+        "loop never rechecked the pause flag (issue #19 regression)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_embed_vault_stops_early_when_pause_flips_mid_pass(monkeypatch, tmp_path):
+    """Pausing mid-pass stops further embedding promptly."""
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    rows = _make_rows(vault, 5)
+
+    monkeypatch.setattr(indexer.settings, "vault_path", str(vault), raising=False)
+    monkeypatch.setattr(indexer, "async_session", lambda: _FakeSession(rows))
+    monkeypatch.setattr(indexer.settings, "embedding_exclude_patterns", [], raising=False)
+
+    embedded = []
+    paused = {"value": False}
+
+    async def _fake_embed_note(session, note, content):
+        embedded.append(note)
+        # After the first note is embedded, simulate a panel-driven pause.
+        paused["value"] = True
+        return 1
+
+    monkeypatch.setattr(indexer, "embed_note", _fake_embed_note)
+    monkeypatch.setattr(indexer, "_is_paused", lambda: paused["value"])
+
+    await indexer.embed_vault()
+
+    # Without the fix the loop runs to completion (all 5 notes). With the fix it
+    # embeds the first note, the pause flips, and the next iteration breaks.
+    assert len(embedded) == 1, (
+        f"expected the embed loop to stop after the pause flipped, but it "
+        f"embedded {len(embedded)} notes (issue #19 regression)"
+    )

--- a/tests/test_issue_1_frontmatter_sanitize.py
+++ b/tests/test_issue_1_frontmatter_sanitize.py
@@ -1,0 +1,88 @@
+"""Regression test for GitHub issue #1.
+
+YAML frontmatter can contain `date`/`datetime` objects (and other
+non-JSON-serializable scalars). The indexer writes the frontmatter into a
+JSONB column whose codec is `json.dumps`, which rejects dates. The sanitizer
+must coerce every such value to a string regardless of where it appears:
+as a top-level value, inside a list, inside a nested dict, inside a dict
+nested in a list, and — crucially — as a mapping *key*.
+
+Runs fully offline: imports the pure helper directly, no DB / network / model.
+"""
+
+import datetime
+import json
+
+from src.services.indexer import _sanitize_frontmatter
+
+
+def _is_json_serializable(obj) -> bool:
+    try:
+        json.dumps(obj)
+        return True
+    except (TypeError, ValueError):
+        return False
+
+
+def test_date_as_top_level_value():
+    fm = {"created": datetime.date(2024, 1, 2)}
+    out = _sanitize_frontmatter(fm)
+    assert _is_json_serializable(out)
+    assert out["created"] == "2024-01-02"
+
+
+def test_datetime_as_value():
+    fm = {"ts": datetime.datetime(2024, 1, 2, 3, 4, 5)}
+    out = _sanitize_frontmatter(fm)
+    assert _is_json_serializable(out)
+    assert isinstance(out["ts"], str)
+
+
+def test_date_in_list():
+    fm = {"dates": [datetime.date(2024, 1, 2), "plain"]}
+    out = _sanitize_frontmatter(fm)
+    assert _is_json_serializable(out)
+    assert out["dates"] == ["2024-01-02", "plain"]
+
+
+def test_date_in_nested_dict():
+    fm = {"meta": {"due": datetime.date(2024, 1, 2)}}
+    out = _sanitize_frontmatter(fm)
+    assert _is_json_serializable(out)
+    assert out["meta"]["due"] == "2024-01-02"
+
+
+def test_dict_inside_list_is_recursed_not_stringified():
+    fm = {"items": [{"due": datetime.date(2024, 1, 2)}]}
+    out = _sanitize_frontmatter(fm)
+    assert _is_json_serializable(out)
+    # Must stay a dict (not stringified), with the inner date coerced.
+    assert out["items"][0] == {"due": "2024-01-02"}
+
+
+def test_list_inside_list_is_recursed():
+    fm = {"matrix": [[datetime.date(2024, 1, 2)]]}
+    out = _sanitize_frontmatter(fm)
+    assert _is_json_serializable(out)
+    assert out["matrix"] == [["2024-01-02"]]
+
+
+def test_date_as_mapping_key():
+    fm = {datetime.date(2024, 1, 2): "value"}
+    out = _sanitize_frontmatter(fm)
+    assert _is_json_serializable(out)
+    assert out == {"2024-01-02": "value"}
+
+
+def test_date_key_in_nested_dict():
+    fm = {"schedule": {datetime.date(2024, 1, 2): "busy"}}
+    out = _sanitize_frontmatter(fm)
+    assert _is_json_serializable(out)
+    assert out["schedule"] == {"2024-01-02": "busy"}
+
+
+def test_plain_values_untouched():
+    fm = {"title": "Hello", "n": 3, "f": 1.5, "b": True, "none": None}
+    out = _sanitize_frontmatter(fm)
+    assert out == fm
+    assert _is_json_serializable(out)

--- a/tests/test_issue_20_mdlink_spaces.py
+++ b/tests/test_issue_20_mdlink_spaces.py
@@ -1,0 +1,107 @@
+r"""Regression test for GitHub issue #20.
+
+Raw-space markdown links to notes (`[a](My Note.md)`, `[a](folder/My Note.md)`,
+`[a](My Note.md#anchor)`, and the angle-bracket form `[a](<My Note.md>)`) were
+dropped by the markdown-link extractor and rewriter because the href character
+class forbade ALL whitespace (`[^)\s]`). Only the `%20`-encoded form matched.
+
+These tests run fully offline: they exercise the pure regex / extraction code
+in src/services/links.py and the rewrite regex in src/mcp_server/tools.py
+without any DB, network, or embedding provider.
+"""
+
+import os
+import re
+import tempfile
+
+# The autouse fixture in conftest imports `src.services.embeddings`, which pulls
+# in `src.config`, whose module-level `Settings()` reads `./.env`. On this host
+# the real `.env` carries host-only keys the model forbids. `env_file=".env"` is
+# resolved relative to CWD, so chdir to a dir without a `.env` before importing.
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+from src.services.links import _MDLINK_RE, extract_links  # noqa: E402
+
+
+def _markdown_targets(content: str) -> list[str]:
+    return [
+        link.target
+        for link in extract_links(content)
+        if link.kind == "markdown"
+    ]
+
+
+def test_raw_space_markdown_link_extracted():
+    # Before the fix, this produced no markdown ExtractedLink.
+    targets = _markdown_targets("See [a](My Note.md) for details.")
+    assert "My Note" in targets
+
+
+def test_raw_space_markdown_link_with_folder_extracted():
+    targets = _markdown_targets("See [a](folder/My Note.md).")
+    assert "folder/My Note" in targets
+
+
+def test_raw_space_markdown_link_with_anchor_extracted():
+    targets = _markdown_targets("See [label](My Note.md#anchor).")
+    assert "My Note" in targets
+
+
+def test_angle_bracket_markdown_link_extracted():
+    targets = _markdown_targets("See [a](<My Note.md>).")
+    assert "My Note" in targets
+
+
+def test_percent_encoded_form_still_works():
+    # Regression guard: the previously-working encoded form is unchanged.
+    targets = _markdown_targets("See [a](My%20Note.md).")
+    assert "My Note" in targets
+
+
+def test_non_md_href_still_rejected():
+    # An image link followed later by a `.md)` must not be slurped into one
+    # giant match. `.png)` closes the paren before any `.md`.
+    targets = _markdown_targets("![img](image.png) then file.md)")
+    assert "image" not in [t.lower() for t in targets]
+    # And a plain non-note href is ignored entirely.
+    assert _markdown_targets("[ext](https://example.com/page) text") == []
+
+
+def test_extract_regex_matches_raw_space_directly():
+    # Direct probe of the compiled module-level regex.
+    assert _MDLINK_RE.search("[a](My Note.md)") is not None
+    assert _MDLINK_RE.search("[a](folder/My Note.md)") is not None
+
+
+# ── Rewrite regex used by move_note(rewrite_links=True) ──────────────────────
+# Mirrors src/mcp_server/tools.py::_MDLINK_REWRITE_RE. Kept as a local literal
+# so this assertion runs without importing the MCP tools module (which has
+# heavier deps); if the source regex drifts, update this copy too.
+
+_MDLINK_REWRITE_RE = re.compile(
+    r"\[(?P<text>[^\]\n]+)\]\((?P<href>[^)\n]+?\.md)(?P<anchor>#[^)]*)?\)"
+)
+
+
+def test_rewrite_regex_matches_raw_space_href():
+    # Before the fix the href group's `[^)\s]` made this return None.
+    m = _MDLINK_REWRITE_RE.search("[a](My Note.md)")
+    assert m is not None
+    assert m.group("href") == "My Note.md"
+
+
+def test_rewrite_regex_matches_raw_space_href_with_folder_and_anchor():
+    m = _MDLINK_REWRITE_RE.search("[a](folder/My Note.md#anchor)")
+    assert m is not None
+    assert m.group("href") == "folder/My Note.md"
+    assert m.group("anchor") == "#anchor"
+
+
+def test_rewrite_regex_matches_source_module_literal():
+    # Guard against the in-test copy diverging from the real source regex.
+    from src.mcp_server import tools
+
+    assert tools._MDLINK_REWRITE_RE.pattern == _MDLINK_REWRITE_RE.pattern

--- a/tests/test_issue_21_registered_scope_enforced.py
+++ b/tests/test_issue_21_registered_scope_enforced.py
@@ -1,0 +1,173 @@
+"""Regression test for GitHub issue #21: the registered client scope is never
+enforced at the authorization endpoint.
+
+A client registers via /register with a `scope` (e.g. read-only). At consent
+time, `authorize_post` previously took the `scope` form field at face value —
+only checking it against the global VALID_SCOPES set — and minted an auth code
+with whatever the form claimed. The consent radio buttons are client-side and
+trivially bypassed, so a read-only client could POST scope=readwrite and obtain
+a readwrite grant, escalating beyond what it was registered for.
+
+The fix clamps the consent-form scope to the intersection of what the user
+requested and what the client is registered to hold (`_clamp_scope`), applied
+in `authorize_post` before the code is minted. `readwrite` still implies
+`read`, so a readwrite-registered client may downgrade to plain read.
+
+Runs fully offline: no DB, no network, no embedding provider. The DB layer is
+replaced with an in-memory fake `async_session`; the CSRF cookie/state pair is
+produced with the real signed-state serializer so the CSRF guard passes and we
+exercise the scope-clamp specifically.
+"""
+# Point pydantic-settings at a non-existent env file BEFORE importing
+# `src.oauth.routes` (which imports `src.config`) so config loads purely from
+# process env + conftest defaults, independent of the dev host's `.env`.
+import pydantic_settings  # noqa: E402
+
+_orig_init = pydantic_settings.BaseSettings.__init__
+
+
+def _no_env_file_init(self, *args, **kwargs):
+    kwargs.setdefault("_env_file", None)
+    _orig_init(self, *args, **kwargs)
+
+
+pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+try:
+    import asyncio
+
+    import pytest
+    from fastapi.responses import JSONResponse, RedirectResponse
+
+    from src.oauth import routes
+finally:
+    pydantic_settings.BaseSettings.__init__ = _orig_init
+
+
+REGISTERED_URI = "https://client.example.com/callback"
+
+
+class _FakeClient:
+    def __init__(self, scope, redirect_uris=(REGISTERED_URI,), user_id=None):
+        self.client_id = "client123"
+        self.scope = scope
+        self.redirect_uris = list(redirect_uris)
+        self.user_id = user_id
+
+
+class _FakeResult:
+    def __init__(self, obj):
+        self._obj = obj
+
+    def scalar_one_or_none(self):
+        return self._obj
+
+
+class _FakeSession:
+    def __init__(self, client):
+        self._client = client
+        self.added = []
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, _stmt):
+        return _FakeResult(self._client)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+
+class _FakeRequest:
+    def __init__(self, signed_cookie):
+        self.cookies = {"oauth_state": signed_cookie}
+        self.session = {}
+
+
+def _signed_state():
+    server_state = "csrfstatetoken1234567890"
+    signed = routes._state_serializer().dumps(server_state)
+    return server_state, signed
+
+
+def _approve(client, *, requested_scope):
+    """Run authorize_post(action=approve) and return the persisted OAuthCode
+    (or the JSONResponse on rejection)."""
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(routes.settings, "multi_user_mode", False, raising=False)
+        session = _FakeSession(client)
+        monkeypatch.setattr(routes, "async_session", lambda: session)
+        server_state, signed = _signed_state()
+        req = _FakeRequest(signed)
+        resp = asyncio.run(
+            routes.authorize_post(
+                req,
+                action="approve",
+                client_id="client123",
+                redirect_uri=REGISTERED_URI,
+                code_challenge="challenge",
+                code_challenge_method="S256",
+                scope=requested_scope,
+                state=server_state,
+                client_state="clientecho",
+            )
+        )
+        return resp, session
+    finally:
+        monkeypatch.undo()
+
+
+# --- The core regression: read-only client cannot escalate to readwrite ---
+
+
+def test_readonly_client_cannot_be_granted_readwrite():
+    client = _FakeClient(scope="read")
+    resp, session = _approve(client, requested_scope="readwrite")
+
+    # The flow still succeeds (it's a valid request), but the issued code's
+    # scope is clamped to the registered read-only scope.
+    assert isinstance(resp, RedirectResponse)
+    assert resp.status_code == 302
+    assert len(session.added) == 1
+    oauth_code = session.added[0]
+    assert oauth_code.scope == "read"
+
+
+def test_readwrite_client_keeps_readwrite():
+    client = _FakeClient(scope="readwrite")
+    resp, session = _approve(client, requested_scope="readwrite")
+
+    assert isinstance(resp, RedirectResponse)
+    assert len(session.added) == 1
+    assert session.added[0].scope == "readwrite"
+
+
+def test_readwrite_client_may_downgrade_to_read():
+    """readwrite implies read — a readwrite-registered client can still pick
+    plain read at consent time."""
+    client = _FakeClient(scope="readwrite")
+    resp, session = _approve(client, requested_scope="read")
+
+    assert isinstance(resp, RedirectResponse)
+    assert len(session.added) == 1
+    assert session.added[0].scope == "read"
+
+
+# --- Unit-level coverage of the clamp helper ---
+
+
+def test_clamp_scope_helper():
+    assert routes._clamp_scope("readwrite", "read") == "read"
+    assert routes._clamp_scope("read", "read") == "read"
+    assert routes._clamp_scope("readwrite", "readwrite") == "readwrite"
+    # readwrite registration implies read availability
+    assert routes._clamp_scope("read", "readwrite") == "read"
+    # empty intersection falls back to safe default
+    assert routes._clamp_scope("", "read") == "read"

--- a/tests/test_issue_22_indexer_cleanup_on_aenter_failure.py
+++ b/tests/test_issue_22_indexer_cleanup_on_aenter_failure.py
@@ -1,0 +1,150 @@
+"""Regression test for GitHub issue #22.
+
+In the non-sandbox lifespan path (`src/main.py`), the indexer background task
+is created and scheduled BEFORE entering `async with
+mcp.session_manager.run():`. The post-yield cleanup that cancels and awaits
+that task originally sat *outside* any `try/finally`. If
+`mcp.session_manager.run().__aenter__()` raised, the exception propagated out
+of the lifespan generator and the cancel/await lines never ran, orphaning the
+already-scheduled indexer task (which holds DB sessions).
+
+The fix wraps the `async with` in `try/finally` so the indexer task is always
+cancelled on every exit path. This test drives the lifespan generator with a
+session manager whose `__aenter__` raises and asserts the indexer task ends up
+cancelled (and that the original exception still propagates).
+
+Fully offline: no DB, no network, no embedding provider. `run_indexer_loop`,
+`_check_embedding_dim`, and `session_manager.run()` are all replaced with
+fakes/stubs before the generator runs.
+"""
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+# Importing the production modules pulls in `src.config`, whose module-level
+# `Settings()` singleton reads `./.env`. On this host the real `.env` carries
+# host-only keys the model forbids, so we must NOT let that file load. Provide
+# the same minimal defaults conftest uses and chdir to a dir without a `.env`
+# (env_file is resolved relative to CWD) BEFORE importing anything.
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+import src.main as main  # noqa: E402
+
+
+class _RaisingSessionManager:
+    """Stand-in for ``mcp.session_manager`` whose ``run()`` context manager
+    fails on ``__aenter__`` — the exact failure mode issue #22 is about."""
+
+    def run(self):
+        return self
+
+    async def __aenter__(self):
+        raise RuntimeError("session manager boom")
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _OkSessionManager:
+    """Stand-in whose ``run()`` enters/exits cleanly (normal shutdown path)."""
+
+    def run(self):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeMcp:
+    """Minimal stand-in for the ``mcp`` object the lifespan touches. The real
+    ``FastMCP.session_manager`` is a read-only property, so we replace the whole
+    object reference in ``src.main`` rather than its attribute."""
+
+    def __init__(self, session_manager):
+        self.session_manager = session_manager
+
+
+async def _never_returns():
+    """A stand-in indexer loop: runs forever until cancelled."""
+    while True:
+        await asyncio.sleep(3600)
+
+
+def _install_fakes(monkeypatch, session_manager):
+    # Force the non-sandbox branch.
+    monkeypatch.setattr(main.settings, "mcp_sandbox_mode", False, raising=False)
+    # Skip the DB dim check (would otherwise open a DB session).
+    async def _noop_check():
+        return None
+
+    monkeypatch.setattr(main, "_check_embedding_dim", _noop_check)
+    # Replace the indexer loop with a forever-sleeping coroutine so it never
+    # touches a DB/network and is observably cancellable.
+    monkeypatch.setattr(main, "run_indexer_loop", _never_returns)
+    # Swap the whole MCP object for our fake (session_manager is a read-only
+    # property on the real FastMCP, so it can't be set directly).
+    monkeypatch.setattr(main, "mcp", _FakeMcp(session_manager))
+
+
+@pytest.mark.asyncio
+async def test_indexer_cancelled_when_session_manager_aenter_raises(monkeypatch):
+    """When ``session_manager.run().__aenter__()`` raises, the indexer task
+    must still be cancelled (not orphaned), and the original error propagates.
+    """
+    _install_fakes(monkeypatch, _RaisingSessionManager())
+
+    captured = {}
+    real_create_task = asyncio.create_task
+
+    def _spy_create_task(coro, *args, **kwargs):
+        task = real_create_task(coro, *args, **kwargs)
+        captured["task"] = task
+        return task
+
+    monkeypatch.setattr(main.asyncio, "create_task", _spy_create_task)
+
+    gen = main.lifespan(object())
+    with pytest.raises(RuntimeError, match="session manager boom"):
+        await gen.__aenter__()
+
+    task = captured["task"]
+    # Give the event loop a tick so the cancellation requested in the
+    # ``finally`` block is actually processed.
+    await asyncio.sleep(0)
+    assert task.cancelled(), "indexer task was orphaned instead of cancelled"
+
+
+@pytest.mark.asyncio
+async def test_indexer_cancelled_on_normal_shutdown(monkeypatch):
+    """Sanity check: the normal startup/shutdown path still cancels the
+    indexer task (behaviour unchanged by the fix)."""
+    _install_fakes(monkeypatch, _OkSessionManager())
+
+    captured = {}
+    real_create_task = asyncio.create_task
+
+    def _spy_create_task(coro, *args, **kwargs):
+        task = real_create_task(coro, *args, **kwargs)
+        captured["task"] = task
+        return task
+
+    monkeypatch.setattr(main.asyncio, "create_task", _spy_create_task)
+
+    cm = main.lifespan(object())
+    await cm.__aenter__()
+    task = captured["task"]
+    assert not task.done()
+    # Trigger shutdown (runs the finally block).
+    await cm.__aexit__(None, None, None)
+
+    await asyncio.sleep(0)
+    assert task.cancelled(), "indexer task was not cancelled on normal shutdown"

--- a/tests/test_issue_2_secret_key_placeholder.py
+++ b/tests/test_issue_2_secret_key_placeholder.py
@@ -1,0 +1,40 @@
+"""Regression test for issue #2.
+
+The SECRET_KEY weak-default guard previously only rejected the exact
+lowercase literal "changeme", letting the actual shipped .env.example
+placeholder "CHANGE_ME" boot with a public, predictable signing secret.
+
+These tests run fully offline: they construct `Settings` directly with
+`_env_file=None` and an explicit `secret_key`, so no .env, DB, network, or
+embedding provider is touched.
+"""
+import pytest
+from pydantic import ValidationError
+
+from src.config import Settings
+
+
+@pytest.mark.parametrize(
+    "placeholder",
+    [
+        "CHANGE_ME",  # the value actually shipped in .env.example
+        "changeme",
+        "Changeme",
+        "change_me",
+        "change-me",
+        "  CHANGE_ME  ",  # surrounding whitespace must not bypass the guard
+        "",
+    ],
+)
+def test_placeholder_secret_key_rejected(placeholder):
+    with pytest.raises(ValidationError) as exc:
+        Settings(secret_key=placeholder, _env_file=None)
+    assert "SECRET_KEY" in str(exc.value)
+
+
+def test_real_secret_key_accepted():
+    s = Settings(
+        secret_key="9f8c1d2e3a4b5c6d7e8f90112233445566778899aabbccddeeff001122334455",
+        _env_file=None,
+    )
+    assert s.secret_key.startswith("9f8c")

--- a/tests/test_issue_3_csrf_fail_closed.py
+++ b/tests/test_issue_3_csrf_fail_closed.py
@@ -1,0 +1,96 @@
+"""Regression test for GitHub issue #3: CSRF validation failing open.
+
+`validate_csrf_token` previously returned True (passed) in two situations
+that an attacker can trivially reproduce for a login-CSRF / session-fixation
+attack:
+
+  1. SessionMiddleware not in the stack -> `request.session` raises
+     AssertionError/AttributeError. The old code returned True.
+  2. SessionMiddleware active but the request carries an empty session
+     (no cookie, or a cookie without a `csrf_nonce`). Under SameSite=Lax a
+     cross-site POST sends no session cookie, so `nonce is None` and the old
+     code returned True.
+
+Both must now fail CLOSED (return False) for state-changing requests, while
+the legitimate flow — a GET form-render establishes the nonce + embeds the
+matching signed token, then the POST submits it — must still pass.
+
+Runs fully offline: no DB, no network, no embedding provider. `secret_key`
+comes from the `SECRET_KEY=test` default set in tests/conftest.py.
+"""
+# Importing `src.csrf` pulls in `src.config`, which instantiates a module
+# level `Settings()`. By default pydantic-settings reads a relative `.env`,
+# which on a dev host may carry host-only keys the model forbids. Point the
+# env-file at a path that cannot exist BEFORE the first import so config
+# loads purely from process env + defaults — keeping this test hermetic and
+# independent of the developer's `.env`.
+import pydantic_settings  # noqa: E402
+
+_orig_init = pydantic_settings.BaseSettings.__init__
+
+
+def _no_env_file_init(self, *args, **kwargs):
+    kwargs.setdefault("_env_file", None)
+    _orig_init(self, *args, **kwargs)
+
+
+pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+try:
+    from src.csrf import generate_csrf_token, validate_csrf_token
+finally:
+    pydantic_settings.BaseSettings.__init__ = _orig_init
+
+
+class _NoSessionRequest:
+    """Stand-in for a Request when SessionMiddleware isn't installed.
+
+    Starlette raises AssertionError on `request.session` access in that
+    case; we mimic that by raising AssertionError from the property.
+    """
+
+    @property
+    def session(self):
+        raise AssertionError("SessionMiddleware must be installed")
+
+
+class _SessionRequest:
+    """Stand-in for a Request with SessionMiddleware active."""
+
+    def __init__(self, session: dict | None = None):
+        self.session = {} if session is None else session
+
+
+def test_missing_session_middleware_fails_closed():
+    # Branch 1: no SessionMiddleware -> must reject, not pass.
+    assert validate_csrf_token(_NoSessionRequest(), "anything") is False
+
+
+def test_empty_session_fails_closed():
+    # Branch 2: session exists but has no csrf_nonce -> must reject.
+    # This is the exact login-CSRF vector: victim's browser sends no/empty
+    # session cookie on the attacker's cross-site POST.
+    assert validate_csrf_token(_SessionRequest(), "anything") is False
+
+
+def test_empty_session_fails_closed_even_without_token():
+    assert validate_csrf_token(_SessionRequest(), None) is False
+
+
+def test_legitimate_flow_still_passes():
+    # GET form-render establishes the nonce and returns the signed token;
+    # the subsequent POST submits that token against the same session.
+    req = _SessionRequest()
+    token = generate_csrf_token(req)
+    assert token  # a non-empty signed token was issued
+    assert "csrf_nonce" in req.session
+    assert validate_csrf_token(req, token) is True
+
+
+def test_token_from_other_session_rejected():
+    # A token minted against a different nonce must not validate against a
+    # session whose nonce differs.
+    issuer = _SessionRequest()
+    token = generate_csrf_token(issuer)
+
+    victim = _SessionRequest({"csrf_nonce": "deadbeefdeadbeefdeadbeefdeadbeef"})
+    assert validate_csrf_token(victim, token) is False

--- a/tests/test_issue_4_authorize_post_redirect_validation.py
+++ b/tests/test_issue_4_authorize_post_redirect_validation.py
@@ -1,0 +1,212 @@
+"""Regression test for GitHub issue #4: open redirect / confused-deputy in
+the OAuth authorization POST handler.
+
+`authorize_post` accepts `redirect_uri` as a form field but previously never
+re-validated it against the client's registered list (the GET handler does).
+A CSRF cookie+state pair is obtainable by an attacker who runs their own
+GET /authorize, so they could POST action=approve (or action=deny) with an
+arbitrary `redirect_uri` and have the issued auth code (or an error redirect)
+delivered to an attacker-controlled URL.
+
+The fix loads the client in the POST path and rejects any `redirect_uri` not
+in `client.redirect_uris` BEFORE minting a code or emitting any redirect, on
+both the approve and deny paths.
+
+Runs fully offline: no DB, no network, no embedding provider. The DB layer is
+replaced with an in-memory fake `async_session`; the CSRF cookie/state pair is
+produced with the real signed-state serializer so the CSRF guard passes and we
+exercise the redirect-uri check specifically.
+"""
+# Point pydantic-settings at a non-existent env file BEFORE importing
+# `src.oauth.routes` (which imports `src.config`) so config loads purely from
+# process env + conftest defaults, independent of the dev host's `.env`.
+import pydantic_settings  # noqa: E402
+
+_orig_init = pydantic_settings.BaseSettings.__init__
+
+
+def _no_env_file_init(self, *args, **kwargs):
+    kwargs.setdefault("_env_file", None)
+    _orig_init(self, *args, **kwargs)
+
+
+pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+try:
+    import asyncio
+
+    import pytest
+    from fastapi.responses import JSONResponse, RedirectResponse
+
+    from src.oauth import routes
+finally:
+    pydantic_settings.BaseSettings.__init__ = _orig_init
+
+
+REGISTERED_URI = "https://client.example.com/callback"
+ATTACKER_URI = "https://evil.example.com/steal"
+
+
+class _FakeClient:
+    def __init__(self, redirect_uris, user_id=None, scope="read"):
+        self.client_id = "client123"
+        self.redirect_uris = list(redirect_uris)
+        self.user_id = user_id
+        self.scope = scope
+
+
+class _FakeResult:
+    def __init__(self, obj):
+        self._obj = obj
+
+    def scalar_one_or_none(self):
+        return self._obj
+
+
+class _FakeSession:
+    """Minimal async-session stand-in. Returns a preset client for the single
+    SELECT the handler issues; records any added rows; no-ops commit."""
+
+    def __init__(self, client):
+        self._client = client
+        self.added = []
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, _stmt):
+        return _FakeResult(self._client)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+
+class _FakeRequest:
+    """Carries only what authorize_post touches: cookies and session."""
+
+    def __init__(self, signed_cookie):
+        self.cookies = {"oauth_state": signed_cookie}
+        self.session = {}
+
+
+def _signed_state():
+    """Produce a (server_state, signed_cookie) pair via the real serializer,
+    mirroring what the GET handler sets so the CSRF guard passes."""
+    server_state = "csrfstatetoken1234567890"
+    signed = routes._state_serializer().dumps(server_state)
+    return server_state, signed
+
+
+def _install_fake_session(monkeypatch, client):
+    session = _FakeSession(client)
+    monkeypatch.setattr(routes, "async_session", lambda: session)
+    return session
+
+
+def _call(client, *, action, redirect_uri, multi_user=False):
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        if multi_user:
+            monkeypatch.setattr(routes.settings, "multi_user_mode", True, raising=False)
+        else:
+            monkeypatch.setattr(routes.settings, "multi_user_mode", False, raising=False)
+        session = _install_fake_session(monkeypatch, client)
+        server_state, signed = _signed_state()
+        req = _FakeRequest(signed)
+        if multi_user:
+            req.session["user_id"] = 7
+        resp = asyncio.run(
+            routes.authorize_post(
+                req,
+                action=action,
+                client_id="client123",
+                redirect_uri=redirect_uri,
+                code_challenge="challenge",
+                code_challenge_method="S256",
+                scope="read",
+                state=server_state,
+                client_state="clientecho",
+            )
+        )
+        return resp, session
+    finally:
+        monkeypatch.undo()
+
+
+def test_approve_with_unregistered_redirect_uri_rejected():
+    """The core vuln: action=approve with an attacker redirect_uri must be
+    rejected with invalid_redirect_uri and must NOT mint/redirect a code."""
+    client = _FakeClient([REGISTERED_URI])
+    resp, session = _call(client, action="approve", redirect_uri=ATTACKER_URI)
+
+    assert isinstance(resp, JSONResponse)
+    assert resp.status_code == 400
+    assert b"invalid_redirect_uri" in resp.body
+    # No auth code was persisted and nothing was committed.
+    assert session.added == []
+    assert session.committed is False
+
+
+def test_deny_with_unregistered_redirect_uri_rejected():
+    """The deny path must not be abusable as an open redirect either."""
+    client = _FakeClient([REGISTERED_URI])
+    resp, _session = _call(client, action="deny", redirect_uri=ATTACKER_URI)
+
+    assert isinstance(resp, JSONResponse)
+    assert resp.status_code == 400
+    assert b"invalid_redirect_uri" in resp.body
+
+
+def test_unknown_client_rejected():
+    resp, _session = _call(None, action="approve", redirect_uri=REGISTERED_URI)
+    assert isinstance(resp, JSONResponse)
+    assert resp.status_code == 400
+    assert b"invalid_client" in resp.body
+
+
+def test_approve_with_registered_redirect_uri_still_works():
+    """Legitimate flow: a registered redirect_uri mints a code and 302s to it."""
+    client = _FakeClient([REGISTERED_URI])
+    resp, session = _call(client, action="approve", redirect_uri=REGISTERED_URI)
+
+    assert isinstance(resp, RedirectResponse)
+    assert resp.status_code == 302
+    location = resp.headers["location"]
+    assert location.startswith(REGISTERED_URI)
+    assert "code=" in location
+    assert ATTACKER_URI not in location
+    # A code row was persisted.
+    assert len(session.added) == 1
+    assert session.committed is True
+
+
+def test_deny_with_registered_redirect_uri_still_redirects():
+    """Legitimate deny: registered redirect_uri gets an access_denied 302."""
+    client = _FakeClient([REGISTERED_URI])
+    resp, _session = _call(client, action="deny", redirect_uri=REGISTERED_URI)
+
+    assert isinstance(resp, RedirectResponse)
+    assert resp.status_code == 302
+    location = resp.headers["location"]
+    assert location.startswith(REGISTERED_URI)
+    assert "error=access_denied" in location
+
+
+def test_multi_user_binds_first_authorizer_on_registered_uri():
+    """Multi-user first-authorizer binding still works and reuses the loaded
+    client row (user_id stamped) on the legitimate approve path."""
+    client = _FakeClient([REGISTERED_URI], user_id=None)
+    resp, session = _call(
+        client, action="approve", redirect_uri=REGISTERED_URI, multi_user=True
+    )
+
+    assert isinstance(resp, RedirectResponse)
+    assert resp.status_code == 302
+    assert client.user_id == 7
+    assert session.committed is True

--- a/tests/test_issue_5_replace_section_eof_heading.py
+++ b/tests/test_issue_5_replace_section_eof_heading.py
@@ -1,0 +1,71 @@
+"""Regression test for GitHub issue #5.
+
+`replace_section` corrupted a note when the target was the last heading and
+that heading line had no trailing newline: the new body was glued directly
+onto the heading text (e.g. "# Notes- item" instead of "# Notes\n- item").
+
+These tests exercise `replace_section` directly. It is a pure
+string-to-string function with no DB / network / embedding dependencies, so
+the whole module runs fully offline.
+"""
+
+import os
+import tempfile
+
+# Importing `src.services.vault` pulls in `src.config`, whose module-level
+# `Settings()` singleton reads `./.env`. On this host the real `.env` carries
+# host-only keys the model forbids, so we must NOT let that file load. Provide
+# the same minimal defaults conftest uses and chdir to a dir without a `.env`
+# (env_file is resolved relative to CWD) BEFORE importing the module. This
+# keeps the test fully self-contained and offline regardless of where pytest
+# is invoked from.
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+from src.services.vault import replace_section  # noqa: E402
+
+
+def test_eof_heading_without_trailing_newline_is_separated():
+    """The bug case: last heading, no trailing newline on the heading line."""
+    text = "# Notes"  # no trailing newline at all
+    new_text, error = replace_section(text, "Notes", "- item")
+    assert error is None
+    assert new_text == "# Notes\n- item"
+    # The heading text must remain intact (not "# Notes- item").
+    assert new_text.startswith("# Notes\n")
+
+
+def test_eof_heading_with_one_trailing_newline_not_double_spaced():
+    """Regression guard: a heading with exactly one trailing newline is
+    already correct. The fix must NOT add a spurious blank line here (the
+    issue's suggested `body_start == line_end` test would have)."""
+    text = "# Notes\n"
+    new_text, error = replace_section(text, "Notes", "- item")
+    assert error is None
+    assert new_text == "# Notes\n- item"
+
+
+def test_eof_heading_with_existing_body_replaced_cleanly():
+    """Last heading with a body already present, no double newline."""
+    text = "# Notes\nold line\n"
+    new_text, error = replace_section(text, "Notes", "new line")
+    assert error is None
+    assert new_text == "# Notes\nnew line"
+
+
+def test_mid_file_section_unaffected():
+    """A section followed by another heading still behaves as before."""
+    text = "# A\nbody a\n\n# B\nbody b\n"
+    new_text, error = replace_section(text, "A", "replaced")
+    assert error is None
+    assert new_text == "# A\nreplaced\n# B\nbody b\n"
+
+
+def test_eof_heading_no_newline_multiline_body():
+    """EOF heading without trailing newline, multi-line replacement body."""
+    text = "intro\n\n# Tasks"
+    new_text, error = replace_section(text, "Tasks", "- a\n- b")
+    assert error is None
+    assert new_text == "intro\n\n# Tasks\n- a\n- b"

--- a/tests/test_issue_6_hnsw_dim_guard.py
+++ b/tests/test_issue_6_hnsw_dim_guard.py
@@ -1,0 +1,171 @@
+"""Regression test for GitHub issue #6.
+
+pgvector's default `vector` type allows an HNSW index only up to 2000
+dimensions; above that, `CREATE INDEX ... USING hnsw (embedding
+vector_cosine_ops)` hard-errors with "column cannot have more than 2000
+dimensions for hnsw index". Two runtime sites issued that DDL with no
+dimension guard:
+
+  * alembic migration 008's ``upgrade()`` — aborts the deploy half-migrated.
+  * the control-panel ``reset_embeddings`` route — same failure in-app.
+
+The fix skips index creation (with a warning) when
+``settings.embedding_dimensions > 2000`` so the schema operation completes and
+the app starts; semantic search degrades to a sequential scan.
+
+These tests exercise both sites with fakes — no DB, no network, no embedding
+provider — so the whole module runs fully offline.
+"""
+
+import asyncio
+import importlib.util
+import os
+import tempfile
+from pathlib import Path
+
+# Importing the production modules pulls in `src.config`, whose module-level
+# `Settings()` singleton reads `./.env`. On this host the real `.env` carries
+# host-only keys the model forbids, so we must NOT let that file load. Provide
+# the same minimal defaults conftest uses and chdir to a dir without a `.env`
+# (env_file is resolved relative to CWD) BEFORE importing anything.
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+from src.config import settings  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+class _FakeScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar(self):
+        return self._value
+
+
+class _FakeConn:
+    """Stands in for op.get_bind(); reports a recent pgvector version."""
+
+    def execute(self, *_a, **_k):
+        # The migration only uses this to read pg_extension.extversion.
+        return _FakeScalarResult("0.7.0")
+
+
+class _RecordingOp:
+    """Records every SQL string passed to op.execute()."""
+
+    def __init__(self, conn):
+        self._conn = conn
+        self.executed: list[str] = []
+
+    def get_bind(self):
+        return self._conn
+
+    def execute(self, sql):
+        self.executed.append(str(sql))
+
+
+def _load_migration_008():
+    """Import migration 008 by path (the alembic/versions dir is not a package)."""
+    path = (
+        Path(__file__).resolve().parent.parent
+        / "alembic"
+        / "versions"
+        / "008_hnsw_embedding_index.py"
+    )
+    spec = importlib.util.spec_from_file_location("_mig008", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run_migration_upgrade(monkeypatch, dim):
+    mig = _load_migration_008()
+    rec = _RecordingOp(_FakeConn())
+    # The migration calls `op.get_bind()`, `op.execute(...)` and `sa.text(...)`.
+    monkeypatch.setattr(mig, "op", rec)
+    monkeypatch.setattr(settings, "embedding_dimensions", dim)
+    mig.upgrade()
+    return rec.executed
+
+
+def _has_hnsw_create(statements):
+    return any(
+        "CREATE INDEX" in s and "hnsw" in s for s in statements
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Migration 008
+# --------------------------------------------------------------------------- #
+def test_migration_skips_hnsw_index_when_dim_over_2000(monkeypatch):
+    """dim=3072 (text-embedding-3-large) must NOT emit a CREATE INDEX hnsw."""
+    statements = _run_migration_upgrade(monkeypatch, 3072)
+    assert not _has_hnsw_create(statements), (
+        "migration must skip HNSW index creation above 2000 dims"
+    )
+
+
+def test_migration_creates_hnsw_index_at_2000(monkeypatch):
+    """dim=2000 is the documented hard limit and must still build the index."""
+    statements = _run_migration_upgrade(monkeypatch, 2000)
+    assert _has_hnsw_create(statements)
+
+
+def test_migration_creates_hnsw_index_at_default_dim(monkeypatch):
+    """The common 1024-dim case is unaffected by the fix."""
+    statements = _run_migration_upgrade(monkeypatch, 1024)
+    assert _has_hnsw_create(statements)
+
+
+# --------------------------------------------------------------------------- #
+# reset_embeddings control-panel route
+# --------------------------------------------------------------------------- #
+class _FakeSession:
+    def __init__(self):
+        self.executed: list[str] = []
+
+    async def execute(self, clause, *_a, **_k):
+        self.executed.append(str(clause))
+
+    async def commit(self):
+        pass
+
+
+class _FakeRequest:
+    headers = {"accept": "application/json"}
+
+
+async def _call_reset(monkeypatch, dim):
+    from src.control_panel import routes
+
+    monkeypatch.setattr(settings, "embedding_dimensions", dim)
+    # Don't spawn the background reindex (it would touch DB/embeddings).
+    monkeypatch.setattr(routes, "_spawn", lambda coro: coro.close())
+
+    sess = _FakeSession()
+    resp = await routes.reset_embeddings(
+        request=_FakeRequest(), session=sess, user=object()
+    )
+    return sess.executed, resp
+
+
+def test_reset_skips_hnsw_index_when_dim_over_2000(monkeypatch):
+    executed, resp = asyncio.run(_call_reset(monkeypatch, 3072))
+    assert not _has_hnsw_create(executed), (
+        "reset route must skip HNSW index creation above 2000 dims"
+    )
+    # The ALTER COLUMN to the wide vector must still have happened.
+    assert any("ALTER COLUMN embedding TYPE vector(3072)" in s for s in executed)
+    # JSON response surfaces the degraded state.
+    assert resp.body and b'"hnsw":false' in resp.body.replace(b" ", b"")
+
+
+def test_reset_creates_hnsw_index_at_default_dim(monkeypatch):
+    executed, resp = asyncio.run(_call_reset(monkeypatch, 1024))
+    assert _has_hnsw_create(executed)
+    assert resp.body and b'"hnsw":true' in resp.body.replace(b" ", b"")

--- a/tests/test_issue_7_csrf_json_header.py
+++ b/tests/test_issue_7_csrf_json_header.py
@@ -1,0 +1,161 @@
+"""Regression test for GitHub issue #7: CSRF unprotected JSON API.
+
+`src/api/routes.py` attached only `require_user_panel` to its router and was
+missing `verify_csrf`, which every other state-changing router uses. The
+`/api/keys` POST and `/api/keys/{id}` DELETE endpoints are session-cookie
+authed over a `same_site=lax` cookie, so SameSite was the *only* CSRF
+defense for those state-changing JSON routes.
+
+Wiring `verify_csrf` onto the router is only half the fix: the old
+`verify_csrf` read the token exclusively from `await request.form()`, but
+these endpoints take JSON bodies. Parsing a JSON body as a form yields no
+`csrf_token`, so a legitimate JSON client could never satisfy the check, and
+on some bodies `request.form()` raises. `verify_csrf` must therefore:
+
+  1. read the token from the `X-CSRF-Token` header first (JSON clients), and
+  2. fall back to the form field (legacy HTML forms) without crashing when
+     the body is not form-encoded.
+
+Runs fully offline: no DB, no network, no embedding provider. `secret_key`
+comes from the `SECRET_KEY=test` default set in tests/conftest.py.
+"""
+# Importing `src.csrf` pulls in `src.config`, which instantiates a module
+# level `Settings()`. By default pydantic-settings reads a relative `.env`,
+# which on a dev host may carry host-only keys the model forbids. Point the
+# env-file at a path that cannot exist BEFORE the first import so config
+# loads purely from process env + defaults — keeping this test hermetic and
+# independent of the developer's `.env`.
+import asyncio
+
+import pydantic_settings
+import pytest
+from fastapi import HTTPException
+from starlette.datastructures import Headers
+
+_orig_init = pydantic_settings.BaseSettings.__init__
+
+
+def _no_env_file_init(self, *args, **kwargs):
+    kwargs.setdefault("_env_file", None)
+    _orig_init(self, *args, **kwargs)
+
+
+pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+try:
+    from src.csrf import generate_csrf_token, verify_csrf
+finally:
+    pydantic_settings.BaseSettings.__init__ = _orig_init
+
+
+class _FakeRequest:
+    """Minimal stand-in for a Starlette Request exercising `verify_csrf`.
+
+    - `headers` is a real case-insensitive `Headers`, matching production.
+    - `form()` is awaitable; `form_raises=True` mimics a JSON body that
+      Starlette refuses to parse as a form (it raises), which must NOT
+      bubble up as a 500.
+    """
+
+    def __init__(
+        self,
+        method="POST",
+        session=None,
+        headers=None,
+        form_data=None,
+        form_raises=False,
+    ):
+        self.method = method
+        self.session = {} if session is None else session
+        self.headers = Headers(headers or {})
+        self._form_data = form_data or {}
+        self._form_raises = form_raises
+
+    async def form(self):
+        if self._form_raises:
+            raise RuntimeError("body is not form-encoded")
+        return self._form_data
+
+
+def _issue_token():
+    """Establish a session nonce + matching signed token, as a GET render would."""
+    req = _FakeRequest(method="GET")
+    token = generate_csrf_token(req)
+    return req.session, token
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_valid_token_in_header_passes():
+    # The core fix: a JSON client (no form body) supplies the token via the
+    # X-CSRF-Token header. Before the fix the header was ignored, so this
+    # could never pass.
+    session, token = _issue_token()
+    req = _FakeRequest(
+        session=session,
+        headers={"X-CSRF-Token": token},
+        form_raises=True,  # JSON body — form parse would raise
+    )
+    # Returns None (no exception) when valid.
+    assert _run(verify_csrf(req)) is None
+
+
+def test_header_lookup_is_case_insensitive():
+    session, token = _issue_token()
+    req = _FakeRequest(
+        session=session,
+        headers={"x-csrf-token": token},
+        form_raises=True,
+    )
+    assert _run(verify_csrf(req)) is None
+
+
+def test_missing_token_on_json_body_fails_closed_without_500():
+    # No header and an unparseable (JSON) body: must reject with 403, and
+    # crucially must NOT let the form-parse exception escape as a 500.
+    session, _ = _issue_token()
+    req = _FakeRequest(session=session, form_raises=True)
+    with pytest.raises(HTTPException) as exc:
+        _run(verify_csrf(req))
+    assert exc.value.status_code == 403
+
+
+def test_forged_token_in_header_rejected():
+    session, _ = _issue_token()
+    req = _FakeRequest(
+        session=session,
+        headers={"X-CSRF-Token": "not-a-valid-signed-token"},
+        form_raises=True,
+    )
+    with pytest.raises(HTTPException) as exc:
+        _run(verify_csrf(req))
+    assert exc.value.status_code == 403
+
+
+def test_legacy_form_token_still_passes():
+    # Backward compatibility: existing HTML form posts (no header) keep working.
+    session, token = _issue_token()
+    req = _FakeRequest(session=session, form_data={"csrf_token": token})
+    assert _run(verify_csrf(req)) is None
+
+
+def test_safe_methods_skip_validation():
+    # GET/HEAD/OPTIONS must short-circuit before any token check.
+    for method in ("GET", "HEAD", "OPTIONS"):
+        req = _FakeRequest(method=method, form_raises=True)
+        assert _run(verify_csrf(req)) is None
+
+
+def test_router_has_verify_csrf_dependency():
+    # The other half of the fix: the /api router must actually enforce CSRF.
+    # Import lazily so the env-file guard above is already in place.
+    _orig = pydantic_settings.BaseSettings.__init__
+    pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+    try:
+        from src.api.routes import router
+    finally:
+        pydantic_settings.BaseSettings.__init__ = _orig
+
+    dep_calls = [d.dependency for d in router.dependencies]
+    assert verify_csrf in dep_calls

--- a/tests/test_issue_8_tracked_param_mapping.py
+++ b/tests/test_issue_8_tracked_param_mapping.py
@@ -1,0 +1,129 @@
+"""Regression test for GitHub issue #8.
+
+The `_tracked` usage-logging decorator mapped logged params to call args by
+positional zipping: `param_keys[i] -> args[i]`. That assumption breaks for any
+tool whose call passes a non-logged positional arg between logged ones.
+
+`edit_note_impl(path, content, ...)` is the live victim: its decorator omits
+`content` from `param_keys` on purpose (the note body is large/sensitive), but
+the server calls it as `edit_note_impl(path, content, append=..., ...)`. The
+old loop matched key="append" -> args[1] == content, so the note body landed in
+`usage_logs.params["append"]` and the real `append` boolean (in kwargs) was
+dropped.
+
+The fix resolves logged params by NAME via the wrapped function's signature.
+These tests exercise `_tracked` directly with a fake function carrying the same
+signature shape, capturing the params the decorator would log by stubbing out
+`_log_usage`. No DB / network / embedding access — fully offline.
+"""
+
+import asyncio
+import os
+import tempfile
+
+# `src.mcp_server.tools` pulls in `src.config`, whose module-level `Settings()`
+# reads `./.env`. The real `.env` on this host carries forbidden host-only keys,
+# so provide minimal defaults and chdir to a dir without a `.env` (env_file is
+# resolved relative to CWD) BEFORE importing. Keeps the module fully offline.
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+import src.mcp_server.tools as tools  # noqa: E402
+
+
+def _capture_logged_params(fn, *args, **kwargs):
+    """Invoke a `_tracked`-decorated coroutine and return the params dict the
+    decorator handed to `_log_usage`, with the DB call stubbed out."""
+    captured = {}
+
+    async def fake_log_usage(tool, params, duration_ms, response_size):
+        captured["tool"] = tool
+        captured["params"] = params
+
+    original = tools._log_usage
+    tools._log_usage = fake_log_usage
+    try:
+        asyncio.run(fn(*args, **kwargs))
+    finally:
+        tools._log_usage = original
+    return captured["params"]
+
+
+def _make_edit_note_like():
+    """A stand-in with edit_note_impl's exact signature and param_keys: `content`
+    is positional but intentionally NOT logged."""
+
+    @tools._tracked(
+        "edit_note",
+        ["path", "append", "find", "section", "replace_all", "dry_run"],
+    )
+    async def edit_note_like(
+        path: str,
+        content: str,
+        append: bool = False,
+        find: str | None = None,
+        section: str | None = None,
+        replace_all: bool = False,
+        dry_run: bool = False,
+    ) -> str:
+        return "ok"
+
+    return edit_note_like
+
+
+def test_non_logged_positional_does_not_shift_param_mapping():
+    """The bug case: server-style call with `content` positional and the rest
+    as kwargs. `append` must log the boolean, NOT the note body."""
+    fn = _make_edit_note_like()
+    params = _capture_logged_params(
+        fn,
+        "notes/foo.md",
+        "THE NOTE BODY CONTENT",
+        append=True,
+        find=None,
+        section=None,
+        replace_all=False,
+        dry_run=False,
+    )
+
+    # The real append flag is logged...
+    assert params["append"] is True
+    # ...and the note body never leaks into any logged field.
+    assert "THE NOTE BODY CONTENT" not in params.values()
+    assert params["path"] == "notes/foo.md"
+    # `content` was deliberately omitted from param_keys and must stay out.
+    assert "content" not in params
+    assert params["dry_run"] is False
+
+
+def test_all_positional_call_still_maps_by_name():
+    """Even when every arg is positional, mapping is by name, so the
+    non-logged `content` slot is skipped rather than mislabelled."""
+    fn = _make_edit_note_like()
+    params = _capture_logged_params(
+        fn,
+        "notes/bar.md",
+        "BODY",
+        True,  # append
+        "needle",  # find
+        None,  # section
+        True,  # replace_all
+        False,  # dry_run
+    )
+    assert params["path"] == "notes/bar.md"
+    assert params["append"] is True
+    assert params["find"] == "needle"
+    assert params["replace_all"] is True
+    assert "BODY" not in params.values()
+    assert "content" not in params
+
+
+def test_defaults_are_logged_when_omitted():
+    """Params left at their defaults are still logged (apply_defaults)."""
+    fn = _make_edit_note_like()
+    params = _capture_logged_params(fn, "notes/baz.md", "BODY")
+    assert params["append"] is False
+    assert params["find"] is None
+    assert params["dry_run"] is False

--- a/tests/test_issue_9_empty_find_guard.py
+++ b/tests/test_issue_9_empty_find_guard.py
@@ -1,0 +1,118 @@
+"""Regression test for GitHub issue #9.
+
+`edit_note(..., find="", replace_all=True)` corrupted the note. The
+find/replace branch only checked `find is not None`, so an empty string flowed
+through to `existing.replace("", content)`, which inserts `content` between
+every character of the note (e.g. "Hi" -> "XHXiX"). `existing.count("")` is
+`len(existing) + 1` (positive), so the "not found" guard never tripped; with
+`replace_all=True` the "multiple matches" guard is bypassed and the corrupting
+replace runs.
+
+The fix rejects an empty `find` with a clear error and leaves the note
+untouched. This test invokes the real `edit_note_impl` against a temp-dir
+vault, with the usage-logging DB call stubbed out — fully offline (no DB,
+network, or embedding access).
+"""
+
+import asyncio
+import os
+import tempfile
+
+# `src.mcp_server.tools` pulls in `src.config`, whose module-level `Settings()`
+# reads `./.env`. Provide minimal defaults and point the vault at a temp dir
+# BEFORE importing, and chdir to a dir without a `.env` (env_file is resolved
+# relative to CWD). Keeps the module fully offline.
+_VAULT_DIR = tempfile.mkdtemp(prefix="issue9-vault-")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ["VAULT_PATH"] = _VAULT_DIR
+os.chdir(tempfile.gettempdir())
+
+import src.mcp_server.tools as tools  # noqa: E402
+from src.mcp_server.auth import current_permission  # noqa: E402
+from src.config import settings  # noqa: E402
+
+# The module-level `settings` singleton may already have been constructed by an
+# earlier test in the suite (with a different VAULT_PATH), in which case setting
+# `os.environ["VAULT_PATH"]` above has no effect. Pin the vault root directly so
+# `_vault_root(None)` -> `Path(settings.vault_path)` resolves to our temp vault
+# regardless of import order.
+settings.vault_path = _VAULT_DIR
+
+
+def _run_edit(path, **kwargs):
+    """Invoke the real edit_note_impl with usage logging stubbed and a
+    readwrite permission set on the contextvar."""
+    async def _noop_log(tool, params, duration_ms, response_size):
+        return None
+
+    original = tools._log_usage
+    tools._log_usage = _noop_log
+    perm_token = current_permission.set("readwrite")
+    try:
+        return asyncio.run(tools.edit_note_impl(path, **kwargs))
+    finally:
+        current_permission.reset(perm_token)
+        tools._log_usage = original
+
+
+_ORIGINAL = "# Title\n\nHello world, this is a note.\n"
+
+
+def _fresh_note(name="note.md"):
+    full = os.path.join(_VAULT_DIR, name)
+    with open(full, "w", encoding="utf-8") as fh:
+        fh.write(_ORIGINAL)
+    return name, full
+
+
+def test_empty_find_with_replace_all_is_rejected_and_note_untouched():
+    """The corruption case: empty find + replace_all bypasses the
+    multiple-match guard and inserts content between every character."""
+    rel, full = _fresh_note("empty_find.md")
+
+    result = _run_edit(rel, content="INJECTED", find="", replace_all=True)
+
+    # An informative error is returned...
+    assert "non-empty" in result.lower() or "empty" in result.lower()
+    assert "INJECTED" not in result
+    # ...and crucially the note on disk is byte-identical (not corrupted).
+    with open(full, encoding="utf-8") as fh:
+        assert fh.read() == _ORIGINAL
+
+
+def test_empty_find_single_match_path_is_rejected():
+    """Empty find without replace_all must also be rejected up front (rather
+    than relying on the incidental multiple-match guard)."""
+    rel, full = _fresh_note("empty_find_single.md")
+
+    result = _run_edit(rel, content="INJECTED", find="")
+
+    assert "non-empty" in result.lower() or "empty" in result.lower()
+    with open(full, encoding="utf-8") as fh:
+        assert fh.read() == _ORIGINAL
+
+
+def test_empty_find_dry_run_does_not_corrupt():
+    rel, full = _fresh_note("empty_find_dry.md")
+
+    result = _run_edit(
+        rel, content="INJECTED", find="", replace_all=True, dry_run=True
+    )
+
+    assert "empty" in result.lower() or "non-empty" in result.lower()
+    with open(full, encoding="utf-8") as fh:
+        assert fh.read() == _ORIGINAL
+
+
+def test_nonempty_find_still_replaces():
+    """Sanity: the guard does not break ordinary find/replace."""
+    rel, full = _fresh_note("normal_find.md")
+
+    result = _run_edit(rel, content="Goodbye world", find="Hello world")
+
+    assert "Updated note" in result
+    with open(full, encoding="utf-8") as fh:
+        body = fh.read()
+    assert "Goodbye world" in body
+    assert "Hello world" not in body


### PR DESCRIPTION
## Summary

Fixes the entire open-issue backlog (#1–#22): security hardening, correctness, and robustness. Each fix is minimal and in-scope and ships with an isolated, fully-offline regression test under `tests/test_issue_<N>_*.py`.

Produced via a dynamic multi-agent workflow: parallel triage (root-cause confirmed against the code; both `[DISPUTED]` issues adjudicated as real), conflict-free wave scheduling so no two fix agents touched the same file, then a parallel adversarial verification pass over every diff.

## Verification
- **140 tests pass** (25 existing + 115 new), source + migrations compile clean.
- The two disputed issues were confirmed real and fixed defensively:
  - **#21** — the `scope` POST field at `/authorize` is attacker-controllable (the radio buttons are client-side only); scope is now clamped to the registered client scope.
  - **#22** — harmless `try/finally` so the indexer task is always cancelled.

## Issues fixed

**High severity**
- Closes #2 — SECRET_KEY weak-default guard misses shipped `CHANGE_ME`
- Closes #3 — CSRF validation fails open with no session nonce
- Closes #4 — OAuth `/authorize` POST doesn't validate `redirect_uri`
- Closes #5 — replace_section glues body onto EOF heading (data corruption)

**Medium severity**
- Closes #6 — HNSW migration fails for dims > 2000
- Closes #7 — `/api/*` has no CSRF protection
- Closes #8 — edit_note logging mislabels content into `append`
- Closes #9 — edit_note `find=""` corrupts the note under replace_all
- Closes #10 — chunk_text infinite loop when overlap >= chunk_size
- Closes #11 — embed_note drops vectors on provider failure
- Closes #12 — panel reindex races the periodic indexer
- Closes #13 — link re-resolution ignores same-folder/ambiguity rules
- Closes #14 — extract_tags pulls #tags out of code blocks
- Closes #21 — OAuth client can self-escalate scope at `/authorize`

**Low severity**
- Closes #1 — frontmatter date objects break the asyncpg insert
- Closes #15 — `/api/usage` accepts an unbounded limit
- Closes #16 — no validation on numeric settings
- Closes #17 — create-key form stores permission without validation
- Closes #18 — tsvector update silently skips concurrently-changed files
- Closes #19 — embed_vault ignores the pause flag mid-pass
- Closes #20 — markdown links with spaces are silently dropped
- Closes #22 — indexer task leaked on session_manager start failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)
