### PR TITLE
fix: place @limiter.limit as innermost decorator (was no-op)

### DIFF
--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -41,8 +41,8 @@ class KeyInfo(BaseModel):
     last_used_at: str | None
 
 
-@limiter.limit("5/minute")
 @router.post("/keys", response_model=CreateKeyResponse)
+@limiter.limit("5/minute")
 async def create_key(
     request: Request,
     req: CreateKeyRequest,

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -117,8 +117,8 @@ async def login_form(request: Request, next: str = "/admin/"):
     return _render_login(request, next_url=_safe_next(next))
 
 
-@limiter.limit("5/minute")
 @router.post("/admin/auth/login")
+@limiter.limit("5/minute")
 async def login_submit(
     request: Request,
     username: str = Form(...),

--- a/src/oauth/routes.py
+++ b/src/oauth/routes.py
@@ -117,8 +117,8 @@ async def oauth_protected_resource_mcp():
 # --- Dynamic Client Registration ---
 
 
-@limiter.limit("3/minute")
 @router.post("/register")
+@limiter.limit("3/minute")
 async def register_client(request: Request):
     body = await request.json()
     client_name = body.get("client_name", "Unknown Client")
@@ -364,8 +364,8 @@ async def authorize_post(
 # --- Token Endpoint ---
 
 
-@limiter.limit("10/minute")
 @router.post("/token")
+@limiter.limit("10/minute")
 async def token_endpoint(request: Request):
     form = await request.form()
     grant_type = form.get("grant_type")


### PR DESCRIPTION
## Problem
slowapi's `@limiter.limit(...)` is applied *outside* `@router.<method>(...)` at four endpoints. The router decorator registers and returns the bare function, so the limiter's wrapper is never reached at request time — rate limiting is silently a no-op on:

- `src/auth/routes.py` (login)
- `src/api/routes.py` (API key creation)
- `src/oauth/routes.py` (`/register` and `/token`)

## Fix
Swap decorator order at all four sites so `@limiter.limit` is the innermost decorator (directly above the handler), as slowapi requires. All four handlers already take `request: Request`.

## Verification
Existing test suite passes (140 tests). Pure decorator-order change; the only behavioral difference is that the limiter is now actually engaged.

Found via an independent security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)