### PR TITLE
fix: reject sandbox-mode combined with public hostname

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -88,5 +88,22 @@ class Settings(BaseSettings):
             )
         return self
 
+    @model_validator(mode="after")
+    def _reject_sandbox_with_public_hostname(self) -> "Settings":
+        """Refuse to boot a publicly-routed deployment with auth disabled.
+
+        MCP_SANDBOX_MODE bypasses all authentication on /mcp (registry-eval
+        only). Combined with a public MCP_HOSTNAME that would expose the
+        vault unauthenticated to the internet, so reject the combination at
+        startup — analogous to the SECRET_KEY placeholder guard above.
+        """
+        if self.mcp_sandbox_mode and (self.mcp_hostname or "").strip():
+            raise ValueError(
+                "MCP_SANDBOX_MODE disables all authentication on /mcp and must "
+                "never run on a publicly-routed deployment. Either unset "
+                "MCP_SANDBOX_MODE or remove MCP_HOSTNAME."
+            )
+        return self
+
 
 settings = Settings()


### PR DESCRIPTION
## Problem
`MCP_SANDBOX_MODE=true` disables all authentication on `/mcp` (a registry-eval switch). Nothing prevents combining it with a public `MCP_HOSTNAME`, which would expose the vault unauthenticated on a misconfigured deploy.

## Fix
Add a `model_validator(mode="after")` that raises at startup if `mcp_sandbox_mode` is set together with a non-empty `mcp_hostname` — analogous to the existing SECRET_KEY placeholder guard. Sandbox-mode alone (local registry-eval) and hostname alone (normal production) both stay valid.

## Verification
Existing test suite passes (140 tests). Manual check: `Settings(mcp_sandbox_mode=True, mcp_hostname=...)` raises; each value alone is accepted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)