### PR TITLE
fix: restrict trusted proxy IPs and redact token logs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,8 @@ USER appuser
 
 EXPOSE 8000
 
-CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1", "--proxy-headers", "--forwarded-allow-ips", "*"]
+# --forwarded-allow-ips: trust X-Forwarded-* only from private ranges (the
+# reverse proxy lives in the Docker network), not from "*" which would let any
+# client spoof its forwarded IP. Narrow to the specific compose subnet CIDR if
+# desired.
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "1", "--proxy-headers", "--forwarded-allow-ips", "172.16.0.0/12,10.0.0.0/8"]

--- a/src/mcp_server/auth.py
+++ b/src/mcp_server/auth.py
@@ -27,6 +27,17 @@ def hash_key(key: str) -> str:
     return hashlib.sha256(key.encode()).hexdigest()
 
 
+def _redacted_prefix(token: str) -> str:
+    """Stable, non-reversible tag for an auth-failure log line.
+
+    A SHA-256 prefix keeps failures correlatable (same token -> same tag)
+    without writing raw credential material to logs, unlike the previous
+    `token[:8]` which leaked the first 8 chars of an attacker-supplied
+    (or, worst case, valid) token.
+    """
+    return "sha:" + hashlib.sha256(token.encode()).hexdigest()[:8]
+
+
 class APIKeyMiddleware:
     """ASGI middleware that authenticates requests via Bearer token against api_keys table."""
 
@@ -73,7 +84,7 @@ class APIKeyMiddleware:
                     api_key = result.scalar_one_or_none()
 
                     if api_key is None:
-                        logger.warning("auth_failure", extra={"reason": "invalid_key", "key_prefix": token[:8]})
+                        logger.warning("auth_failure", extra={"reason": "invalid_key", "key_prefix": _redacted_prefix(token)})
                         response = JSONResponse({"error": "Invalid or revoked key"}, status_code=401)
                         await response(scope, receive, send)
                         return
@@ -124,7 +135,7 @@ class APIKeyMiddleware:
                     oauth_token = result.scalar_one_or_none()
 
                     if oauth_token is None:
-                        logger.warning("auth_failure", extra={"reason": "invalid_key", "key_prefix": token[:8]})
+                        logger.warning("auth_failure", extra={"reason": "invalid_key", "key_prefix": _redacted_prefix(token)})
                         response = JSONResponse({"error": "Invalid or revoked token"}, status_code=401)
                         await response(scope, receive, send)
                         return


### PR DESCRIPTION
## Problem
Two proxy/logging-hygiene issues:
1. uvicorn starts with `--forwarded-allow-ips "*"`, trusting `X-Forwarded-*` from any source. If the container is ever reachable outside the trusted proxy path, clients can spoof their forwarded IP (poisoning rate-limit keying and usage-log client IPs).
2. On failed auth the middleware logs `token[:8]` — the first 8 chars of an attacker-supplied (or, worst case, valid) token.

## Fix
1. Replace `"*"` with private subnets (`172.16.0.0/12,10.0.0.0/8`); deployers can narrow to their compose subnet.
2. Log a SHA-256 prefix (`sha:xxxxxxxx`) instead of raw token chars — correlatable (same token -> same tag), no plaintext leak.

## Verification
Existing test suite passes (140 tests). Manual check confirms the redaction helper is stable and emits no raw token bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)