### PR TITLE
Fix dashboard "Reindex Now" button (CSRF 403)

### DIFF
--- a/src/control_panel/templates/dashboard.html
+++ b/src/control_panel/templates/dashboard.html
@@ -13,6 +13,7 @@
     <div class="page-actions">
         <span id="reindex-status" class="inline-status ok" role="status" aria-live="polite"></span>
         <form id="reindex-form" onsubmit="event.preventDefault(); triggerReindex(this);" style="display:inline;">
+            {% if csrf_token %}<input type="hidden" name="csrf_token" value="{{ csrf_token }}">{% endif %}
             <button type="submit" class="btn btn-primary btn-lg" title="Scan the vault for new or changed notes and embed them">
                 <svg class="btn-icon" width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
                     <path d="M13.5 8 A5.5 5.5 0 1 1 11.5 3.8"/>
@@ -229,9 +230,13 @@ async function triggerReindex(form) {
     status.textContent = '';
 
     try {
+        const csrf = form.querySelector('input[name="csrf_token"]');
         const r = await fetch('/admin/settings/reindex', {
             method: 'POST',
-            headers: { 'Accept': 'application/json' },
+            headers: {
+                'Accept': 'application/json',
+                ...(csrf ? { 'X-CSRF-Token': csrf.value } : {}),
+            },
         });
         if (!r.ok) throw new Error('HTTP ' + r.status);
         status.textContent = '✓ Reindex started — new notes will appear shortly';


### PR DESCRIPTION
## Problem

Clicking **Reindex Now** on the admin dashboard showed *"✗ Failed to start reindex"*.

The button uses a JS `fetch` POST to `/admin/settings/reindex`, but the control-panel router now requires a CSRF token (`verify_csrf` dependency added in the v0.3.0 security hardening pass). The fetch sent only `Accept: application/json` and **no token**, so the server returned **403 "CSRF validation failed"**.

The *Settings*-page reindex button was unaffected — it's a normal form POST that already includes the hidden `csrf_token` field. This is the only JS `fetch` POST in the panel, so it was the only casualty.

This fetch pattern dates back to the 2026-04-23 control-panel redesign that promoted "Reindex Now" to the primary dashboard action; the later CSRF hardening is what broke it.

## Fix

`src/control_panel/templates/dashboard.html`:
1. Add the hidden `csrf_token` input to the reindex form (the dashboard context already provides it via `_panel_context`).
2. Have `triggerReindex` read that token and send it as the `X-CSRF-Token` header.

## Verification

Built and deployed to the live server (`make deploy`) — trivy gate passed, container came up healthy (`/health` → `{"status":"ok"}`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)