### PR TITLE
perf(embeddings): keep bge-m3 warm via Ollama keep_alive

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,11 @@ EMBEDDING_DIMENSIONS=1024
 # --- Ollama settings (used when EMBEDDING_PROVIDER=ollama) ---
 OLLAMA_URL=http://ollama:11434
 EMBEDDING_MODEL=bge-m3
+# How long Ollama keeps the model in VRAM after an embed call. "-1" pins it
+# indefinitely (avoids a ~15s cold reload when semantic_search is used
+# infrequently and the model gets evicted); a Go duration like "30m" frees
+# VRAM when idle. Pin only if the model comfortably fits alongside others.
+OLLAMA_KEEP_ALIVE=-1
 
 # --- OpenAI settings (used when EMBEDDING_PROVIDER=openai) ---
 # Required when provider=openai; server refuses to start otherwise.

--- a/src/config.py
+++ b/src/config.py
@@ -7,6 +7,12 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     database_url: str = "postgresql+asyncpg://obsidian_mcp:changeme@postgres:5432/obsidian_mcp"
     ollama_url: str = "http://ollama:11434"
+    # How long Ollama keeps the embedding model resident after a call.
+    # "-1" pins it in VRAM indefinitely (sent as the integer Ollama requires),
+    # which avoids the ~15s cold reload when semantic_search runs infrequently
+    # and the model has been evicted. A Go duration like "30m" instead frees
+    # VRAM when idle. Ollama provider only — ignored by the OpenAI provider.
+    ollama_keep_alive: str = "-1"
     vault_path: str = "/obsidian"
     secret_key: str = "changeme"
     index_interval_seconds: int = Field(300, ge=1)

--- a/src/main.py
+++ b/src/main.py
@@ -60,6 +60,28 @@ async def _check_embedding_dim() -> None:
         sys.exit(1)
 
 
+async def _warm_embedding_model() -> None:
+    """Pre-load the embedding model so the first semantic_search after startup
+    isn't a cold reload. Combined with OLLAMA_KEEP_ALIVE the model then stays
+    resident. Best-effort: any failure is logged, never fatal. Ollama only —
+    the OpenAI provider has no local warm state.
+    """
+    if settings.embedding_provider != "ollama":
+        return
+    try:
+        from src.services.embeddings import get_provider
+
+        await get_provider().embed_one("warmup")
+        logging.getLogger(__name__).info(
+            "Embedding model warm-up complete (keep_alive=%s)",
+            settings.ollama_keep_alive,
+        )
+    except Exception as e:  # noqa: BLE001 - warm-up must never block startup
+        logging.getLogger(__name__).warning(
+            "Embedding model warm-up failed (non-fatal): %s", e
+        )
+
+
 def _on_indexer_done(task: asyncio.Task) -> None:
     if task.cancelled():
         logging.getLogger(__name__).info("Indexer task cancelled (lifespan shutdown)")
@@ -84,12 +106,16 @@ async def lifespan(app: FastAPI):
             yield
         return
     await _check_embedding_dim()
+    # Fire-and-forget so a ~15s cold load doesn't block the app from serving.
+    # The lifespan frame stays suspended at `yield`, keeping this referenced.
+    warmup_task = asyncio.create_task(_warm_embedding_model())
     indexer_task = asyncio.create_task(run_indexer_loop())
     indexer_task.add_done_callback(_on_indexer_done)
     try:
         async with mcp.session_manager.run():
             yield
     finally:
+        warmup_task.cancel()
         indexer_task.cancel()
         try:
             await asyncio.wait_for(asyncio.shield(indexer_task), timeout=10.0)

--- a/src/services/embeddings.py
+++ b/src/services/embeddings.py
@@ -67,15 +67,34 @@ class EmbeddingProvider(Protocol):
     async def embed_batch(self, texts: list[str]) -> list[list[float]]: ...
 
 
+def _coerce_keep_alive(value: str):
+    """Normalize `settings.ollama_keep_alive` for the `/api/embed` payload.
+
+    Ollama's `keep_alive` JSON field wants an *integer* for second-counts and
+    for -1 (pin in VRAM forever); a bare string like "-1" is rejected by its
+    Go duration parser ("missing unit in duration"). So integer-like values
+    are sent as ints, while duration strings ("30m", "1h") pass through.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return value
+
+
 class OllamaProvider:
     """Default provider — POSTs to a self-hosted Ollama instance, one input
-    per request. Matches pre-change behavior exactly."""
+    per request. Sends `keep_alive` so the model stays resident between
+    (often infrequent) calls instead of paying a cold reload each time."""
 
     async def embed_one(self, text: str) -> list[float]:
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(
                 f"{settings.ollama_url}/api/embed",
-                json={"model": settings.embedding_model, "input": text},
+                json={
+                    "model": settings.embedding_model,
+                    "input": text,
+                    "keep_alive": _coerce_keep_alive(settings.ollama_keep_alive),
+                },
             )
             response.raise_for_status()
             data = response.json()

--- a/tests/test_ollama_provider.py
+++ b/tests/test_ollama_provider.py
@@ -1,0 +1,70 @@
+"""Unit tests for OllamaProvider: keep_alive handling on /api/embed.
+
+Uses respx to intercept httpx calls so no real Ollama instance is required.
+"""
+import json
+
+import pytest
+import respx
+from httpx import Response
+
+from src.config import settings
+from src.services.embeddings import OllamaProvider, _coerce_keep_alive
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("-1", -1),     # pin forever — must be an int, not the string "-1"
+        ("0", 0),       # unload immediately
+        ("300", 300),   # seconds
+        ("30m", "30m"), # Go duration string — passes through unchanged
+        ("1h", "1h"),
+    ],
+)
+def test_coerce_keep_alive(value, expected):
+    assert _coerce_keep_alive(value) == expected
+
+
+@pytest.fixture
+def ollama_settings(monkeypatch):
+    monkeypatch.setattr(settings, "ollama_url", "http://ollama:11434")
+    monkeypatch.setattr(settings, "embedding_model", "bge-m3")
+    return settings
+
+
+@pytest.mark.asyncio
+async def test_embed_one_pins_model_with_int_keep_alive(ollama_settings, monkeypatch):
+    """`-1` is sent as the integer Ollama needs (the string "-1" is rejected
+    by its Go duration parser), alongside the model and input."""
+    monkeypatch.setattr(settings, "ollama_keep_alive", "-1")
+    provider = OllamaProvider()
+
+    with respx.mock(base_url="http://ollama:11434") as mock:
+        route = mock.post("/api/embed").mock(
+            return_value=Response(200, json={"embeddings": [[0.1, 0.2, 0.3]]})
+        )
+        out = await provider.embed_one("hello")
+
+    assert out == [0.1, 0.2, 0.3]
+    body = json.loads(route.calls[0].request.read())
+    # `== -1` already fails for the string "-1" (since "-1" == -1 is False),
+    # so this asserts the integer form Ollama requires.
+    assert body["keep_alive"] == -1
+    assert body["model"] == "bge-m3"
+    assert body["input"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_embed_one_passes_duration_string_through(ollama_settings, monkeypatch):
+    monkeypatch.setattr(settings, "ollama_keep_alive", "30m")
+    provider = OllamaProvider()
+
+    with respx.mock(base_url="http://ollama:11434") as mock:
+        route = mock.post("/api/embed").mock(
+            return_value=Response(200, json={"embeddings": [[1.0]]})
+        )
+        await provider.embed_one("hi")
+
+    body = json.loads(route.calls[0].request.read())
+    assert body["keep_alive"] == "30m"


### PR DESCRIPTION
## Problem
`semantic_search` is slow (~15s) on infrequent use. Confirmed root cause on the live host: `OllamaProvider.embed_one` sent **no `keep_alive`**, so bge-m3 inherited Ollama's **5-minute idle eviction**. Between searches the model gets evicted from VRAM, and the next query absorbs the full cold reload. The shared 8 GB GPU (qwen3.5:4b resident at ~5.6 GB) adds memory pressure that makes the reload slower still.

**Measured:** cold embed **14.8s** → warm embed **0.29s** (~50×).

## Fix
- Add `OLLAMA_KEEP_ALIVE` setting (default `-1` = pin in VRAM indefinitely), sent on every `/api/embed` call. bge-m3 is only ~1.1 GB, so it fits alongside qwen (6.8/8 GB).
- Coerce integer-like values to `int` — Ollama rejects the JSON **string** `"-1"` (`time: missing unit in duration "-1"`) but accepts the **int** `-1`; duration strings like `30m` pass through unchanged. Verified both against the live server.
- Warm the model once at startup (best-effort, fire-and-forget, non-fatal) so the first search after a deploy/restart isn't cold either.

Scoped deliberately to this app's embed requests rather than a server-wide `OLLAMA_KEEP_ALIVE` env, because that Ollama instance is shared with other models on a tight GPU.

## Tests
- `_coerce_keep_alive` table (`-1`/`0`/`300` → int, `30m`/`1h` → str).
- respx: `embed_one` sends the **int** `keep_alive` and passes durations through.
- Full suite still collects clean (147 tests, +7 new). New unit tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)