### PR TITLE
feat(deploy): docker-compose.proxy.yml for external reverse proxies

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -15,10 +15,13 @@ together:
 4. Embeddings. OpenAI API for VPS deployments without GPUs (Ollama on
    a CPU-only VPS is too slow to be usable).
 5. TLS and reverse proxy. Caddy for the simplest path, Traefik if you
-   already run it.
+   already run it, or your own external proxy (Nginx Proxy Manager,
+   nginx, …) if you already terminate TLS elsewhere.
 
 The included `docker-compose.simple.yml` bundles 1, 2, and 5 plus the
-MCP server itself. You handle 3 and 4 separately.
+MCP server itself. You handle 3 and 4 separately. If you already run a
+reverse proxy, use `docker-compose.proxy.yml` instead — see
+[Already have a reverse proxy?](#already-have-a-reverse-proxy) below.
 
 ## What you need before starting
 
@@ -118,6 +121,34 @@ You should see "Application startup complete" within ~30 seconds, then
 "Starting vault index scan..." (which will report 0 files until Step
 4). The control panel is at `https://your-hostname/admin`. You'll set
 up auth on it in Step 6.
+
+### Already have a reverse proxy?
+
+If you already run Nginx Proxy Manager (NPM), a standalone nginx, or
+another external proxy that terminates TLS, use
+`docker-compose.proxy.yml` instead. It brings up Postgres and the MCP
+server on plain HTTP — no bundled Caddy — and lets your existing proxy
+own certificates and HTTPS:
+
+```bash
+docker compose -f docker-compose.proxy.yml build
+docker compose -f docker-compose.proxy.yml up -d
+```
+
+Set `MCP_HOSTNAME` in `.env` to the public hostname your proxy serves
+— the app derives `base_url` (and the OAuth discovery URLs) from it.
+Point your proxy at the container (`http://obsidian-mcp:8000` over a
+shared Docker network, or `http://<host>:${MCP_PORT:-8000}`), forward
+`Host` + `X-Forwarded-Proto: https`, and enable WebSocket / streaming
+passthrough on `/mcp`. The file's header comment walks through both
+wiring patterns and the exact headers your proxy must forward.
+
+> [!WARNING]
+> `docker-compose.proxy.yml` trusts proxy headers and, in single-user
+> mode, relies on your reverse proxy to protect `/admin`. Keep the app's
+> upstream private to the proxy (shared Docker network, or a
+> loopback/firewalled published port). Do not expose the MCP container
+> port publicly.
 
 ## Step 4. Get your vault onto the VPS
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -137,11 +137,22 @@ docker compose -f docker-compose.proxy.yml up -d
 
 Set `MCP_HOSTNAME` in `.env` to the public hostname your proxy serves
 — the app derives `base_url` (and the OAuth discovery URLs) from it.
-Point your proxy at the container (`http://obsidian-mcp:8000` over a
-shared Docker network, or `http://<host>:${MCP_PORT:-8000}`), forward
-`Host` + `X-Forwarded-Proto: https`, and enable WebSocket / streaming
-passthrough on `/mcp`. The file's header comment walks through both
-wiring patterns and the exact headers your proxy must forward.
+Then wire your proxy to the container via one of two paths:
+
+- **Proxy in Docker (e.g. NPM):** put the proxy and this stack on a
+  shared Docker network — in `docker-compose.proxy.yml`, uncomment the
+  `proxy_net` blocks (under the service and under `networks:`) and
+  **remove the `ports:` mapping** — then forward your proxy to
+  `http://obsidian-mcp:8000`. Nothing is published to the host.
+- **Proxy on the host / another machine:** keep the default
+  loopback-bound `ports:` mapping and forward to
+  `http://127.0.0.1:${MCP_PORT:-8000}` (same host) or widen the bind and
+  firewall the port to the proxy (another host).
+
+Either way, forward `Host` + `X-Forwarded-Proto: https` and enable
+WebSocket / streaming passthrough on `/mcp`. The file's header comment
+walks through both patterns and the exact headers your proxy must
+forward.
 
 > [!WARNING]
 > `docker-compose.proxy.yml` trusts proxy headers and, in single-user

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -40,9 +40,12 @@
 #     (disable response buffering; in NPM, tick "Websockets Support" and add
 #     `proxy_buffering off;` in the Advanced tab).
 #
-# The app trusts those headers via --proxy-headers + FORWARDED_ALLOW_IPS=* below.
-# That trusts ANY client that can reach the port, so keep the published port
-# private to the proxy (pattern A, or the 127.0.0.1 bind in pattern B).
+# The app already honors X-Forwarded-* via its built-in ProxyHeadersMiddleware,
+# scoped in main.py to loopback + private (RFC1918) ranges — which covers both a
+# loopback-published port (pattern B) and a shared Docker network (pattern A). So
+# no `--proxy-headers` flag or `FORWARDED_ALLOW_IPS=*` is needed here, and we
+# avoid the trust-any-peer footgun. Still keep the published port private to the
+# proxy.
 #
 # Note: /mcp is always API-key protected at the application layer. The proxy is
 # only responsible for TLS and (optionally) protecting the human-facing /admin UI.
@@ -78,10 +81,9 @@ services:
         condition: service_healthy
     env_file:
       - .env
-    environment:
-      # Honor X-Forwarded-* from the reverse proxy (see header notes above).
-      # Keep the published port private to the proxy, since this trusts all peers.
-      FORWARDED_ALLOW_IPS: "*"
+    # Forwarded headers (X-Forwarded-Proto/For) are handled by the app's built-in
+    # ProxyHeadersMiddleware (main.py), scoped to loopback + private ranges — no
+    # FORWARDED_ALLOW_IPS / --proxy-headers needed here.
     # Pattern B: publish a host port for a proxy that forwards by IP/port.
     # Default is loopback-only; change to "${MCP_PORT:-8000}:8000" only if your
     # proxy runs on another host and you firewall the port to that proxy.
@@ -103,7 +105,7 @@ services:
       start_period: 60s
     command: >
       sh -c "alembic upgrade head &&
-             uvicorn src.main:app --host 0.0.0.0 --port 8000 --proxy-headers"
+             uvicorn src.main:app --host 0.0.0.0 --port 8000"
 
 networks:
   mcp_internal:

--- a/docker-compose.proxy.yml
+++ b/docker-compose.proxy.yml
@@ -1,0 +1,118 @@
+# Deployment behind an EXTERNAL reverse proxy.
+#
+# Use this when something else already terminates TLS — Nginx Proxy Manager
+# (NPM), a standalone nginx, an existing Traefik, or a Caddy you run yourself.
+# Unlike docker-compose.simple.yml, this bundles NO TLS and NO Caddy: your
+# proxy owns the certificate and HTTPS. This stack only brings up Postgres and
+# the MCP server, listening on plain HTTP for the proxy to forward to.
+#
+#   docker compose -f docker-compose.proxy.yml up -d
+#
+# ── Required .env (copy from .env.example) ────────────────────────────────
+#   MCP_HOSTNAME      Public hostname your proxy serves (e.g. obsidian.example.com).
+#                     The app derives base_url / allowed_origins / allowed_hosts
+#                     from it, so OAuth discovery and the 401 WWW-Authenticate
+#                     metadata URL resolve to the correct https:// origin. Without
+#                     it, base_url falls back to http://localhost:8000 and MCP
+#                     clients like claude.ai cannot complete the OAuth flow.
+#   SECRET_KEY        itsdangerous signer. python3 -c "import secrets; print(secrets.token_hex(32))"
+#   VAULT_HOST_PATH   Host path to your Obsidian vault (bind-mounted at /obsidian).
+#   POSTGRES_PASSWORD Strong DB password (also propagate into DATABASE_URL in .env).
+#   OPENAI_API_KEY    If EMBEDDING_PROVIDER=openai (the realistic path without a GPU).
+#
+# ── Point your proxy at the app — pick ONE pattern ────────────────────────
+#   A) Proxy runs in Docker (typical for Nginx Proxy Manager).
+#      Put the proxy and this stack on a shared Docker network and forward to
+#      http://obsidian-mcp:8000. Uncomment the two `proxy_net` blocks below and
+#      DELETE the `ports:` entry — nothing needs publishing to the host. Most
+#      secure: the app is unreachable except through the proxy.
+#
+#   B) Proxy reaches the host by IP/port.
+#      Keep the `ports:` mapping and point your proxy at http://<host-ip>:${MCP_PORT:-8000}.
+#      If the proxy is on the SAME host, bind to loopback so the port isn't world-
+#      reachable: set the mapping to "127.0.0.1:${MCP_PORT:-8000}:8000".
+#
+# ── Your proxy MUST forward ───────────────────────────────────────────────
+#   - the original Host header,
+#   - X-Forwarded-Proto: https      (so the app knows the public scheme),
+#   - X-Forwarded-For,
+#   - and support streaming / chunked responses + the WebSocket upgrade on /mcp
+#     (disable response buffering; in NPM, tick "Websockets Support" and add
+#     `proxy_buffering off;` in the Advanced tab).
+#
+# The app trusts those headers via --proxy-headers + FORWARDED_ALLOW_IPS=* below.
+# That trusts ANY client that can reach the port, so keep the published port
+# private to the proxy (pattern A, or the 127.0.0.1 bind in pattern B).
+#
+# Note: /mcp is always API-key protected at the application layer. The proxy is
+# only responsible for TLS and (optionally) protecting the human-facing /admin UI.
+
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: obsidian-mcp-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: obsidian_mcp
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-changeme}
+      POSTGRES_DB: obsidian_mcp
+    volumes:
+      - pg_data:/var/lib/postgresql/data
+      - ./docker/db-init-simple.sql:/docker-entrypoint-initdb.d/01-init.sql:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U obsidian_mcp -d obsidian_mcp"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+    networks:
+      - mcp_internal
+
+  obsidian-mcp:
+    build: .
+    image: obsidian-mcp:local
+    container_name: obsidian-mcp
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+    env_file:
+      - .env
+    environment:
+      # Honor X-Forwarded-* from the reverse proxy (see header notes above).
+      # Keep the published port private to the proxy, since this trusts all peers.
+      FORWARDED_ALLOW_IPS: "*"
+    # Pattern B: publish a host port for a proxy that forwards by IP/port.
+    # Default is loopback-only; change to "${MCP_PORT:-8000}:8000" only if your
+    # proxy runs on another host and you firewall the port to that proxy.
+    # Pattern A (NPM/Traefik in Docker): delete this and use proxy_net below.
+    ports:
+      - "127.0.0.1:${MCP_PORT:-8000}:8000"
+    volumes:
+      - ${VAULT_HOST_PATH:-./vault}:/obsidian
+    networks:
+      - mcp_internal
+      # Pattern A: also attach to your proxy's network and forward to
+      # http://obsidian-mcp:8000 (then remove the `ports:` block above).
+      # - proxy_net
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 60s
+    command: >
+      sh -c "alembic upgrade head &&
+             uvicorn src.main:app --host 0.0.0.0 --port 8000 --proxy-headers"
+
+networks:
+  mcp_internal:
+    driver: bridge
+  # Pattern A: the external network your reverse proxy already runs on.
+  # Create it once (docker network create proxy_net) or name your proxy's
+  # existing network here, then uncomment the proxy_net line under the service.
+  # proxy_net:
+  #   external: true
+
+volumes:
+  pg_data:


### PR DESCRIPTION
## What

A third deployment recipe alongside the existing two:

| File | TLS / proxy |
| --- | --- |
| `docker-compose.simple.yml` | bundles **Caddy** (auto Let's Encrypt) |
| `docker-compose.yml` | **Traefik** homelab reference (external `t2_proxy`) |
| **`docker-compose.proxy.yml`** (new) | **your own external proxy** — NPM, nginx, existing Traefik |

For when TLS is already terminated elsewhere. Brings up Postgres + the MCP server on plain HTTP (no bundled Caddy). The app honors `X-Forwarded-Proto` / `X-Forwarded-For` from the proxy via its built-in `ProxyHeadersMiddleware`, which is already scoped to loopback + RFC1918 ranges in `main.py` — so **no** `--proxy-headers` flag or `FORWARDED_ALLOW_IPS=*` is needed here, avoiding the trust-any-peer footgun. (Earlier drafts of this PR mentioned those flags; the committed file deliberately omits them.)

## Security default

The published port binds to **loopback (`127.0.0.1`) by default**, so the control panel can't be reached directly (bypassing the proxy's auth). Users with a remote proxy widen it and firewall the port to the proxy. A `> [!WARNING]` in the docs spells this out.

## Docs

The file's header comment walks through:
- both wiring patterns — shared Docker network (`http://obsidian-mcp:8000`, recommended for NPM/Traefik-in-Docker) or a published host port,
- the headers the proxy must forward (`Host`, `X-Forwarded-Proto: https`, `X-Forwarded-For`) and WebSocket/streaming passthrough on `/mcp`,
- how `MCP_HOSTNAME` drives `base_url` (and therefore the OAuth discovery URLs).

`DEPLOYMENT.md` gains an "Already have a reverse proxy?" subsection under Step 3 and a pointer in the intro.

## Validation

`docker compose -f docker-compose.proxy.yml config` validates. This is the deployment pattern (app behind an external NPM-terminated TLS proxy) used in production.
