### PR TITLE
feat(search): configurable full-text search language(s)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,18 @@ MCP_HOSTNAME=obsidian-mcp.example.com
 # Indexer
 INDEX_INTERVAL_SECONDS=300
 
+# Full-text (keyword) search configuration(s). PostgreSQL text-search config
+# names, applied at both index and query time. JSON list or comma-separated.
+#   english             default — English Snowball stemmer (current behavior)
+#   simple              language-agnostic, exact word forms, no stemming
+#   english,norwegian   both stemmers — good for a mixed-language vault
+#   simple,norwegian    verbatim lexemes PLUS Norwegian stems
+# A note is indexed under every listed config and a query matches if ANY
+# config's parse hits. Changing this makes stored tsvectors stale — after
+# editing, redeploy and run `make rebuild-tsvectors` (keyword index only;
+# does NOT touch embeddings and makes NO API calls — unlike reset-embeddings).
+# FTS_CONFIGS=english
+
 # Chunk size in tokens (~4 chars/token heuristic). 512 matches bge-m3's
 # design point. Changing post-deploy requires `make reset-embeddings`.
 CHUNK_SIZE=512

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,14 @@ hostnames) must stay out of tracked files. The mechanism:
   implementations (Ollama, OpenAI). Single `EMBEDDING_PROVIDER` env var
   picks the backend; `get_provider()` is a cached singleton. Default is
   Ollama bge-m3 at 1024 dim, 512 token chunks, no overlap.
-- Full-text search via PostgreSQL tsvector
+- Full-text search via PostgreSQL tsvector. The text-search config(s) are
+  configurable via `FTS_CONFIGS` (default `["english"]`; e.g. `["simple"]` or
+  `["english","norwegian"]`). Index- and query-time configs are kept in sync
+  through `src/services/fts.py` (`index_tsvector_sql` / `combined_tsquery`).
+  A note is indexed under every config (tsvectors `||`-concatenated) and a
+  query matches if any config hits (tsqueries OR'd). Startup validates the
+  config names against `pg_ts_config`. Changing `FTS_CONFIGS` requires `make
+  rebuild-tsvectors` — keyword index only, no embeddings, no API calls.
 - Vector search via pgvector HNSW index on `note_embeddings.embedding`
   (`vector_cosine_ops`, `m=16, ef_construction=64`); `semantic_search`
   sets `hnsw.ef_search=80` per query and dedupes per note in Python

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ YELLOW := \033[0;33m
 RED := \033[0;31m
 NC := \033[0m
 
-.PHONY: help init build build-cached push image deploy up down restart logs shell db-init db-migrate db-backup db-restore status clean reindex reset-embeddings audit trivy
+.PHONY: help init build build-cached push image deploy up down restart logs shell db-init db-migrate db-backup db-restore status clean reindex reset-embeddings rebuild-tsvectors audit trivy
 
 help:
 	@echo "$(GREEN)Obsidian MCP Server$(NC)"
@@ -51,6 +51,7 @@ help:
 	@echo "$(YELLOW)Operations:$(NC)"
 	@echo "  make reindex      - Trigger full vault reindex"
 	@echo "  make reset-embeddings - Drop & recreate embedding column at configured dim"
+	@echo "  make rebuild-tsvectors - Recompute keyword index for FTS_CONFIGS (no embeddings, no API calls)"
 	@echo "  make status       - Show container and health status"
 	@echo "  make clean        - Remove containers and images"
 	@echo ""
@@ -163,6 +164,11 @@ reset-embeddings:
 	@sleep 5
 	$(COMPOSE) exec obsidian-mcp python -m scripts.reset_embeddings
 	@echo "$(GREEN)Done. The next indexer pass will re-embed all notes.$(NC)"
+
+rebuild-tsvectors:
+	@echo "$(YELLOW)Rebuilding keyword (FTS) index for the configured FTS_CONFIGS...$(NC)"
+	$(COMPOSE) exec obsidian-mcp python -m scripts.rebuild_tsvectors
+	@echo "$(GREEN)Done. Keyword search now reflects FTS_CONFIGS (embeddings untouched, no API calls).$(NC)"
 
 status:
 	@echo "$(GREEN)Obsidian MCP Status:$(NC)"

--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ The server exposes 17 MCP tools across five concerns.
 
 ### Search and discovery
 - `keyword_search(query, folder?, tags?, frontmatter?, limit=20)`,
-  full-text via PostgreSQL `tsvector`
+  full-text via PostgreSQL `tsvector`; the text-search config(s) are
+  configurable via `FTS_CONFIGS` (see
+  [Full-text search language(s)](#full-text-search-languages))
 - `semantic_search(query, folder?, tags?, frontmatter?, limit=15)`,
   vector similarity via pgvector, one preview chunk per note
 - `list_notes(folder?, limit=50)`, sorted by modified time
@@ -572,6 +574,7 @@ to multi-user later resumes where you left off without re-bootstrapping
 | `VAULT_PATH` | `/obsidian` | In-container vault mount |
 | `SECRET_KEY` | — | itsdangerous signer key |
 | `INDEX_INTERVAL_SECONDS` | `300` | Periodic reindex cadence |
+| `FTS_CONFIGS` | `english` | Keyword-search text-search config(s). JSON or CSV. See [Full-text search language(s)](#full-text-search-languages). |
 | `EMBEDDING_PROVIDER` | `ollama` | `ollama` or `openai` |
 | `EMBEDDING_DIMENSIONS` | `1024` | pgvector column width |
 | `OLLAMA_URL` | — | Used when provider is Ollama |
@@ -604,6 +607,56 @@ control panel, which performs the same SQL while the server is running
 If you change `EMBEDDING_DIMENSIONS` without running the reset, the
 server detects the mismatch at startup and exits non-zero with a
 pointer to the reset target.
+
+### Full-text search language(s)
+
+`keyword_search` runs over a PostgreSQL `tsvector`. The *text-search
+configuration* it uses — the stemmer and stop-word dictionary — is
+controlled by `FTS_CONFIGS`. It defaults to `english`, which reproduces
+the historical behavior exactly, so existing deployments need no action.
+
+`FTS_CONFIGS` is a **list**, settable as JSON
+(`FTS_CONFIGS=["simple","norwegian"]`) or comma-separated
+(`FTS_CONFIGS=simple,norwegian`). Each note is indexed under *every*
+listed config, and a query matches if *any* listed config's parse hits.
+This is what makes a mixed-language vault work:
+
+| `FTS_CONFIGS` | Behavior |
+| --- | --- |
+| `english` | English Snowball stemmer (default; `running` ↔ `run`). |
+| `simple` | Language-agnostic. No stemming or stop-words — matches exact word *forms*. A principled default for mixed-language vaults: keyword search is the exact-match arm, while `semantic_search` (bge-m3 is multilingual) handles morphological recall. |
+| `english,norwegian` | Both stemmers applied — keyword-side morphology for two languages at once. |
+| `simple,norwegian` | Verbatim lexemes **plus** Norwegian stems. |
+
+The setting is **global** — applied to every vault (consistent with
+`EMBEDDING_MODEL`, `CHUNK_SIZE`, etc., which are global too). For a
+mixed-language multi-user instance, set a superset (e.g.
+`["english","norwegian"]`, or `["simple"]`). Per-user FTS config is a
+clean future extension but is not implemented.
+
+A typo'd or uninstalled config name fails fast at startup with a message
+listing the configs available in your Postgres instance, rather than
+producing silent zero-result searches.
+
+**Changing `FTS_CONFIGS` requires a rebuild.** Stored tsvectors are
+computed at index time, so they go stale when the config list changes.
+After editing `.env` and redeploying, run:
+
+```
+make rebuild-tsvectors
+```
+
+This re-reads each note and recomputes its `content_tsvector` under the
+new config(s). It rebuilds the **keyword index only** — it does **not**
+touch embeddings/vectors and makes **no API calls**, so it finishes in
+seconds for a few thousand notes. (Do not confuse it with the expensive
+`make reset-embeddings` flow.)
+
+> **Tokenization caveat:** the tsvector *parser* still splits on
+> punctuation and hyphens regardless of config, so `bge-m3` tokenizes to
+> `bge` + `m3`. `simple` preserves word *forms*, not punctuation-bearing
+> strings; exact-string-with-punctuation matching would need a trigram
+> index and is out of scope.
 
 ## Architecture
 
@@ -728,6 +781,7 @@ make db-backup        Dump database to backups dir
 make logs             Tail container logs
 make reindex          Trigger a reindex via the API
 make reset-embeddings Drop and recreate embedding column at configured dim
+make rebuild-tsvectors Recompute keyword index for FTS_CONFIGS (no embeddings, no API calls)
 make status           Show container and health status
 ```
 

--- a/scripts/rebuild_tsvectors.py
+++ b/scripts/rebuild_tsvectors.py
@@ -1,0 +1,45 @@
+"""Recompute every note's `content_tsvector` under the currently configured
+`FTS_CONFIGS` (see `src/config.py` and `src/services/fts.py`).
+
+Run this after changing `FTS_CONFIGS` in `.env` and redeploying. Stored
+tsvectors are built at index time and go stale when the config list changes;
+this script re-reads each note's file and rebuilds them.
+
+Invoked by `make rebuild-tsvectors`. This rebuilds the KEYWORD index only — it
+does NOT touch embeddings/vectors and makes NO API calls, so it completes in
+seconds for a few thousand notes (unlike the expensive `make reset-embeddings`
+flow, which it must not be confused with).
+"""
+import asyncio
+import sys
+
+from src.config import settings
+from src.database import async_session, engine
+from src.services.fts import validate_fts_configs
+from src.services.indexer import _active_user_ids, rebuild_tsvectors
+
+
+async def main() -> None:
+    print(f"Rebuilding tsvectors for FTS_CONFIGS={settings.fts_configs}...")
+    async with async_session() as session:
+        # Fail fast on an unknown config name before touching any rows.
+        await validate_fts_configs(session)
+        if settings.multi_user_mode:
+            total = 0
+            for uid in await _active_user_ids():
+                total += await rebuild_tsvectors(session, user_id=uid)
+        else:
+            total = await rebuild_tsvectors(session, user_id=None)
+    await engine.dispose()
+    print(
+        f"Done. Recomputed tsvectors for {total} note(s). Keyword search now "
+        "reflects FTS_CONFIGS; embeddings were not touched."
+    )
+
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except Exception as e:
+        print(f"rebuild_tsvectors failed: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,7 @@
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import Field, model_validator
-from pydantic_settings import BaseSettings
+from pydantic import Field, field_validator, model_validator
+from pydantic_settings import BaseSettings, NoDecode
 
 
 class Settings(BaseSettings):
@@ -34,6 +34,23 @@ class Settings(BaseSettings):
     allowed_origins: list[str] | None = None
     allowed_hosts: list[str] | None = None
 
+    # PostgreSQL text-search configuration(s) for full-text (keyword) search,
+    # applied at both index and query time. A note is indexed under every
+    # listed config (lexeme sets concatenated) and a query matches if ANY
+    # config's parse hits (tsqueries OR'd). See `src/services/fts.py`.
+    #   ["english"]            current/default behavior (English stemmer)
+    #   ["simple"]             language-agnostic, exact word forms, no stemming
+    #   ["english","norwegian"] both stemmers — mixed-language vault
+    #   ["simple","norwegian"]  verbatim lexemes PLUS Norwegian stems
+    # Named `fts_configs` (not `fts_languages`) because `simple` is a config,
+    # not a language. Env `FTS_CONFIGS` accepts JSON (`["simple","norwegian"]`)
+    # or comma-separated (`simple,norwegian`). Changing this makes stored
+    # tsvectors stale — run `make rebuild-tsvectors` (keyword index only; no
+    # embeddings touched, no API calls). `NoDecode` defers env parsing to the
+    # validator below so the CSV form doesn't trip pydantic-settings' JSON
+    # decode of complex (list) fields.
+    fts_configs: Annotated[list[str], NoDecode] = ["english"]
+
     embedding_provider: Literal["ollama", "openai"] = "ollama"
     openai_api_key: str | None = None
     openai_base_url: str = "https://api.openai.com/v1"
@@ -51,6 +68,39 @@ class Settings(BaseSettings):
     mcp_sandbox_mode: bool = False
 
     model_config = {"env_file": ".env"}
+
+    @field_validator("fts_configs", mode="before")
+    @classmethod
+    def _parse_fts_configs(cls, v):
+        """Accept a JSON list, a comma-separated string, or a list; then strip,
+        lowercase, drop empties, and dedupe (order-preserving). Reject empty."""
+        if isinstance(v, str):
+            s = v.strip()
+            parsed = None
+            if s.startswith("["):
+                import json
+
+                try:
+                    parsed = json.loads(s)
+                except ValueError:
+                    parsed = None
+            v = parsed if isinstance(parsed, list) else s.split(",")
+        if not isinstance(v, (list, tuple)):
+            raise ValueError(
+                "FTS_CONFIGS must be a list of PostgreSQL text-search config "
+                "names (JSON or comma-separated)"
+            )
+        seen: set[str] = set()
+        out: list[str] = []
+        for item in v:
+            name = str(item).strip().lower()
+            if not name or name in seen:
+                continue
+            seen.add(name)
+            out.append(name)
+        if not out:
+            raise ValueError("FTS_CONFIGS must contain at least one config name")
+        return out
 
     @model_validator(mode="after")
     def _derive_public_urls(self) -> "Settings":

--- a/src/config.py
+++ b/src/config.py
@@ -76,15 +76,24 @@ class Settings(BaseSettings):
         lowercase, drop empties, and dedupe (order-preserving). Reject empty."""
         if isinstance(v, str):
             s = v.strip()
-            parsed = None
             if s.startswith("["):
                 import json
 
                 try:
                     parsed = json.loads(s)
-                except ValueError:
-                    parsed = None
-            v = parsed if isinstance(parsed, list) else s.split(",")
+                except ValueError as e:
+                    # Looks like JSON (leading "[") but isn't — fail loudly
+                    # rather than silently CSV-splitting into junk config names.
+                    raise ValueError(
+                        f"FTS_CONFIGS looks like JSON but failed to parse: {e}. "
+                        'Use a JSON list (["simple","norwegian"]) or a '
+                        "comma-separated string (simple,norwegian)."
+                    ) from e
+                if not isinstance(parsed, list):
+                    raise ValueError("FTS_CONFIGS JSON must be a list of config names")
+                v = parsed
+            else:
+                v = s.split(",")
         if not isinstance(v, (list, tuple)):
             raise ValueError(
                 "FTS_CONFIGS must be a list of PostgreSQL text-search config "

--- a/src/main.py
+++ b/src/main.py
@@ -60,6 +60,18 @@ async def _check_embedding_dim() -> None:
         sys.exit(1)
 
 
+async def _validate_fts_configs() -> None:
+    """Fail fast at startup if `FTS_CONFIGS` names a text-search config that
+    isn't installed in this Postgres instance (e.g. a typo), so a bad config
+    surfaces with a clear message instead of silent zero-result keyword
+    searches. Delegates to `src.services.fts.validate_fts_configs`.
+    """
+    from src.services.fts import validate_fts_configs
+
+    async with async_session() as session:
+        await validate_fts_configs(session)
+
+
 async def _warm_embedding_model() -> None:
     """Pre-load the embedding model so the first semantic_search after startup
     isn't a cold reload. Combined with OLLAMA_KEEP_ALIVE the model then stays
@@ -106,6 +118,7 @@ async def lifespan(app: FastAPI):
             yield
         return
     await _check_embedding_dim()
+    await _validate_fts_configs()
     # Fire-and-forget so a ~15s cold load doesn't block the app from serving.
     # The lifespan frame stays suspended at `yield`, keeping this referenced.
     warmup_task = asyncio.create_task(_warm_embedding_model())

--- a/src/services/fts.py
+++ b/src/services/fts.py
@@ -1,0 +1,91 @@
+"""Single source of truth for the full-text-search (keyword) configuration.
+
+PostgreSQL full-text search parses text into lexemes using a *text-search
+configuration* (a stemmer + stop-word dictionary). ``'english'`` applies the
+English Snowball stemmer; ``'simple'`` does neither (just lowercases and
+tokenizes, preserving exact word forms); ``'norwegian'`` applies the Norwegian
+stemmer, and so on.
+
+The configuration used at index time (building ``content_tsvector``) and at
+query time (building the ``tsquery``) must agree, or stems won't align. To keep
+the two from drifting, both the indexer and the search service build their SQL
+through the helpers here, driven by the single ``settings.fts_configs`` list.
+
+Multiple configs compose cleanly:
+
+* ``tsvector || tsvector`` concatenates lexeme sets (duplicates merge), so a
+  note is indexed under *every* configured config.
+* ``tsquery || tsquery`` is a logical OR, so a query matches if *any* config's
+  parse of it hits.
+
+A single-element list reproduces the historical single-call behavior exactly.
+
+Config names originate from the environment, never from end users, but are
+still passed as bound parameters (index side: bound param + ``::regconfig``
+cast; query side: bound argument to ``websearch_to_tsquery``) and never
+string-interpolated. The startup allowlist check in :func:`validate_fts_configs`
+exists for clear error messages, not as the primary injection defense.
+"""
+from functools import reduce
+
+from sqlalchemy import func, text
+
+from src.config import settings
+
+
+def index_tsvector_sql(content_bind: str = "content") -> tuple[str, dict]:
+    """Build the SQL fragment + bind params for ``content_tsvector``.
+
+    Returns ``(fragment, params)`` where ``fragment`` is a ``to_tsvector(...)``
+    expression (concatenated with ``||`` across every configured FTS config)
+    suitable for embedding in a larger ``UPDATE ... SET content_tsvector =
+    <fragment>`` statement, and ``params`` are the config-name bind values to
+    merge into the statement's parameter dict.
+
+    The caller supplies the body text under the ``content_bind`` parameter name
+    (default ``"content"``); this helper only varies *which configs* parse it.
+
+    Example (two configs)::
+
+        to_tsvector(CAST(:fts_cfg_0 AS regconfig), :content)
+          || to_tsvector(CAST(:fts_cfg_1 AS regconfig), :content)
+    """
+    cfgs = settings.fts_configs
+    frag = " || ".join(
+        f"to_tsvector(CAST(:fts_cfg_{i} AS regconfig), :{content_bind})"
+        for i in range(len(cfgs))
+    )
+    params = {f"fts_cfg_{i}": cfg for i, cfg in enumerate(cfgs)}
+    return frag, params
+
+
+def combined_tsquery(query: str):
+    """Return a SQLAlchemy expression OR-ing ``websearch_to_tsquery`` over every
+    configured FTS config.
+
+    For a single config this is identical to a bare
+    ``func.websearch_to_tsquery(cfg, query)`` call. Use the same expression for
+    both the ``ts_rank_cd`` rank and the ``@@`` match so ranking and matching
+    stay consistent.
+    """
+    parts = [func.websearch_to_tsquery(cfg, query) for cfg in settings.fts_configs]
+    return reduce(lambda a, b: a.op("||")(b), parts)
+
+
+async def validate_fts_configs(session) -> None:
+    """Fail fast if any configured FTS config is not installed in this Postgres
+    instance.
+
+    A typo'd or missing config name would otherwise produce silent zero-result
+    keyword searches (the ``::regconfig`` cast errors only when the query
+    actually runs). Called during startup alongside the embedding-dimension
+    guard so the failure surfaces immediately with a helpful message.
+    """
+    rows = await session.execute(text("SELECT cfgname FROM pg_ts_config"))
+    available = {r[0] for r in rows}
+    missing = [c for c in settings.fts_configs if c not in available]
+    if missing:
+        raise SystemExit(
+            f"FTS_CONFIGS contains unknown text-search config(s): {missing}. "
+            f"Available: {sorted(available)}"
+        )

--- a/src/services/indexer.py
+++ b/src/services/indexer.py
@@ -243,9 +243,9 @@ async def index_vault(user_id: int | None = None):
         if to_upsert:
             paths = [n["file_path"] for n in to_upsert]
             # In multi-user mode the same `file_path` can exist for multiple
-            # users; the UPDATE must also scope by `user_id IS NOT DISTINCT
-            # FROM :uid` (NULL-safe equality so single-user rows match).
-            # The tsvector expression is built from `settings.fts_configs`
+            # users, so the UPDATE scopes by user: `user_id IS NULL` in
+            # single-user mode, `user_id = :uid` (never NULL) in multi-user
+            # mode. The tsvector expression is built from `settings.fts_configs`
             # (see `src/services/fts.py`) so index-time configs match the
             # query-time configs in `search.py`.
             tsv_frag, tsv_params = index_tsvector_sql("content")
@@ -613,7 +613,7 @@ async def rebuild_tsvectors(session, user_id: int | None = None) -> int:
     `reset-embeddings`.
 
     Scoped to `user_id` when set (multi-user mode); single-user mode passes
-    `None` and rebuilds every note. Reuses the §5.1 helper so the rebuilt
+    `None` and rebuilds every note. Reuses `index_tsvector_sql` so the rebuilt
     tsvector is byte-identical to what the indexer would write for the same
     config(s).
     """

--- a/src/services/indexer.py
+++ b/src/services/indexer.py
@@ -13,6 +13,7 @@ from src.config import settings
 from src.database import async_session
 from src.models.db import NoteEmbedding, NoteLink, NoteMetadata, OAuthCode, OAuthToken, User
 from src.services.embeddings import embed_note
+from src.services.fts import index_tsvector_sql
 from src.services.links import build_vault_index, extract_links, resolve_target
 from src.services.vault import (
     _vault_root,
@@ -244,17 +245,21 @@ async def index_vault(user_id: int | None = None):
             # In multi-user mode the same `file_path` can exist for multiple
             # users; the UPDATE must also scope by `user_id IS NOT DISTINCT
             # FROM :uid` (NULL-safe equality so single-user rows match).
+            # The tsvector expression is built from `settings.fts_configs`
+            # (see `src/services/fts.py`) so index-time configs match the
+            # query-time configs in `search.py`.
+            tsv_frag, tsv_params = index_tsvector_sql("content")
             if user_id is None:
-                tsv_sql = """
+                tsv_sql = f"""
                     UPDATE notes_metadata
-                    SET content_tsvector = to_tsvector('english', :content)
+                    SET content_tsvector = {tsv_frag}
                     WHERE file_path = :path
                       AND user_id IS NULL
                 """
             else:
-                tsv_sql = """
+                tsv_sql = f"""
                     UPDATE notes_metadata
-                    SET content_tsvector = to_tsvector('english', :content)
+                    SET content_tsvector = {tsv_frag}
                     WHERE file_path = :path
                       AND user_id = :uid
                 """
@@ -266,7 +271,7 @@ async def index_vault(user_id: int | None = None):
                     continue
                 content = path_to_content[path]
                 try:
-                    params: dict = {"content": content[:100000], "path": path}
+                    params: dict = {"content": content[:100000], "path": path, **tsv_params}
                     if user_id is not None:
                         params["uid"] = user_id
                     await session.execute(text(tsv_sql), params)
@@ -594,6 +599,55 @@ async def embed_vault(user_id: int | None = None):
             f"Embedding complete{log_suffix}: {len(unembedded)} notes, {total_chunks} chunks"
             + (f", {skipped_excluded} skipped by exclude patterns" if skipped_excluded else "")
         )
+
+
+async def rebuild_tsvectors(session, user_id: int | None = None) -> int:
+    """Recompute `content_tsvector` for every indexed note under the currently
+    configured `FTS_CONFIGS` (see `src/services/fts.py`). Returns the count of
+    notes updated.
+
+    Run this after changing `FTS_CONFIGS`, since `notes_metadata` stores no raw
+    body column — the tsvector must be rebuilt by re-reading each note's file.
+    This rebuilds the KEYWORD index only: it does NOT touch embeddings and makes
+    NO API calls, so it's cheap (seconds for a few thousand notes), unlike
+    `reset-embeddings`.
+
+    Scoped to `user_id` when set (multi-user mode); single-user mode passes
+    `None` and rebuilds every note. Reuses the §5.1 helper so the rebuilt
+    tsvector is byte-identical to what the indexer would write for the same
+    config(s).
+    """
+    vault = _vault_root(user_id)
+    log_suffix = f" (user_id={user_id})" if user_id is not None else ""
+    tsv_frag, tsv_params = index_tsvector_sql("content")
+    upd_sql = text(
+        f"UPDATE notes_metadata SET content_tsvector = {tsv_frag} WHERE id = :id"
+    )
+
+    rows_stmt = select(NoteMetadata.id, NoteMetadata.file_path)
+    if user_id is not None:
+        rows_stmt = rows_stmt.where(NoteMetadata.user_id == user_id)
+    rows = (await session.execute(rows_stmt)).all()
+    logger.info(f"Rebuilding tsvectors for {len(rows)} notes{log_suffix}")
+
+    updated = 0
+    for row in rows:
+        full_path = vault / row.file_path
+        try:
+            raw = full_path.read_text(encoding="utf-8", errors="strict")
+        except (UnicodeDecodeError, FileNotFoundError, OSError):
+            continue
+        _, content = parse_frontmatter(raw)
+        await session.execute(
+            upd_sql, {"content": content[:100000], "id": row.id, **tsv_params}
+        )
+        updated += 1
+        if updated % 500 == 0:
+            await session.commit()
+            logger.info(f"rebuild_tsvectors: {updated}/{len(rows)} notes{log_suffix}")
+    await session.commit()
+    logger.info(f"rebuild_tsvectors complete: {updated} notes{log_suffix}")
+    return updated
 
 
 async def cleanup_expired_tokens():

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -3,6 +3,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.db import NoteMetadata
 from src.services.filters import apply_note_filters
+from src.services.fts import combined_tsquery
 
 
 async def full_text_search(
@@ -14,8 +15,12 @@ async def full_text_search(
     frontmatter: dict | None = None,
     user_id: int | None = None,
 ) -> list[dict]:
-    """Full-text search over notes_metadata using tsvector."""
-    tsquery = func.websearch_to_tsquery("english", query)
+    """Full-text search over notes_metadata using tsvector.
+
+    The tsquery is built from `settings.fts_configs` (see `src/services/fts.py`)
+    so query-time configs match the index-time configs in `indexer.py`.
+    """
+    tsquery = combined_tsquery(query)
     rank = func.ts_rank_cd(NoteMetadata.content_tsvector, tsquery).label("rank")
 
     stmt = (

--- a/tests/test_fts.py
+++ b/tests/test_fts.py
@@ -63,6 +63,18 @@ def test_fts_configs_rejects_whitespace_only():
         Settings(fts_configs="   ,  ", _env_file=None)
 
 
+def test_fts_configs_rejects_invalid_bracketed_json():
+    # Leading "[" signals JSON intent; malformed JSON must fail loudly rather
+    # than silently CSV-splitting into junk config names.
+    with pytest.raises(ValidationError):
+        Settings(fts_configs="[english, norwegian", _env_file=None)
+
+
+def test_fts_configs_rejects_non_list_json():
+    with pytest.raises(ValidationError):
+        Settings(fts_configs='["english"', _env_file=None)
+
+
 # ── index_tsvector_sql ───────────────────────────────────────────────────
 
 
@@ -228,3 +240,36 @@ async def test_rebuild_tsvectors_updates_every_note(monkeypatch, tmp_path):
         assert "CAST(:fts_cfg_0 AS regconfig)" in text_sql
         assert "CAST(:fts_cfg_1 AS regconfig)" in text_sql
         assert "body" in p["content"]
+
+
+# ── validate_fts_configs (offline: fake session over pg_ts_config) ────────
+
+
+class _ConfigRowsSession:
+    """Minimal async session whose execute() returns a fixed set of
+    `pg_ts_config` rows, mimicking the (cfgname,) tuples the real query yields."""
+
+    def __init__(self, available):
+        self._rows = [(name,) for name in available]
+
+    async def execute(self, *args, **kwargs):
+        return self._rows  # iterating yields (cfgname,) tuples
+
+
+@pytest.mark.asyncio
+async def test_validate_fts_configs_passes_when_all_present(monkeypatch):
+    fts = _set_configs(monkeypatch, ["english", "norwegian"])
+    session = _ConfigRowsSession(["english", "norwegian", "simple"])
+    # Must not raise.
+    await fts.validate_fts_configs(session)
+
+
+@pytest.mark.asyncio
+async def test_validate_fts_configs_raises_on_unknown(monkeypatch):
+    fts = _set_configs(monkeypatch, ["english", "klingon"])
+    session = _ConfigRowsSession(["english", "norwegian", "simple"])
+    with pytest.raises(SystemExit) as exc:
+        await fts.validate_fts_configs(session)
+    msg = str(exc.value)
+    assert "klingon" in msg  # the offending config is named
+    assert "english" not in msg.split("Available:")[0]  # not flagged as missing

--- a/tests/test_fts.py
+++ b/tests/test_fts.py
@@ -1,0 +1,230 @@
+"""Unit tests for the configurable full-text-search layer.
+
+Covers the `FTS_CONFIGS` config parser/validator and the SQL-building helpers
+in `src/services/fts.py`. Integration behavior (real Postgres stemming) lives
+in `test_fts_integration.py`, which is skipped without a database.
+"""
+import pytest
+from pydantic import ValidationError
+
+from src.config import Settings
+
+
+# ── Config parsing / validation ──────────────────────────────────────────
+
+
+def test_fts_configs_default_is_english():
+    s = Settings(_env_file=None)
+    assert s.fts_configs == ["english"]
+
+
+def test_fts_configs_parses_json_list():
+    s = Settings(fts_configs='["simple","norwegian"]', _env_file=None)
+    assert s.fts_configs == ["simple", "norwegian"]
+
+
+def test_fts_configs_parses_csv():
+    s = Settings(fts_configs="simple, norwegian", _env_file=None)
+    assert s.fts_configs == ["simple", "norwegian"]
+
+
+def test_fts_configs_lowercases_and_strips():
+    s = Settings(fts_configs="  English , NORWEGIAN ", _env_file=None)
+    assert s.fts_configs == ["english", "norwegian"]
+
+
+def test_fts_configs_dedupes_preserving_order():
+    s = Settings(fts_configs="english,english,simple,english", _env_file=None)
+    assert s.fts_configs == ["english", "simple"]
+
+
+def test_fts_configs_accepts_python_list():
+    s = Settings(fts_configs=["English", " simple "], _env_file=None)
+    assert s.fts_configs == ["english", "simple"]
+
+
+def test_fts_configs_drops_empty_entries():
+    s = Settings(fts_configs="english,,  ,simple", _env_file=None)
+    assert s.fts_configs == ["english", "simple"]
+
+
+def test_fts_configs_rejects_empty_string():
+    with pytest.raises(ValidationError):
+        Settings(fts_configs="", _env_file=None)
+
+
+def test_fts_configs_rejects_empty_list():
+    with pytest.raises(ValidationError):
+        Settings(fts_configs=[], _env_file=None)
+
+
+def test_fts_configs_rejects_whitespace_only():
+    with pytest.raises(ValidationError):
+        Settings(fts_configs="   ,  ", _env_file=None)
+
+
+# ── index_tsvector_sql ───────────────────────────────────────────────────
+
+
+def _set_configs(monkeypatch, cfgs):
+    """Point the fts module's `settings.fts_configs` at `cfgs` for one test."""
+    from src.services import fts
+
+    monkeypatch.setattr(fts.settings, "fts_configs", cfgs, raising=False)
+    return fts
+
+
+def test_index_tsvector_sql_single_config(monkeypatch):
+    fts = _set_configs(monkeypatch, ["english"])
+    frag, params = fts.index_tsvector_sql("content")
+    assert frag == "to_tsvector(CAST(:fts_cfg_0 AS regconfig), :content)"
+    assert params == {"fts_cfg_0": "english"}
+
+
+def test_index_tsvector_sql_two_configs(monkeypatch):
+    fts = _set_configs(monkeypatch, ["english", "norwegian"])
+    frag, params = fts.index_tsvector_sql("content")
+    assert frag == (
+        "to_tsvector(CAST(:fts_cfg_0 AS regconfig), :content)"
+        " || to_tsvector(CAST(:fts_cfg_1 AS regconfig), :content)"
+    )
+    assert params == {"fts_cfg_0": "english", "fts_cfg_1": "norwegian"}
+
+
+def test_index_tsvector_sql_three_configs(monkeypatch):
+    fts = _set_configs(monkeypatch, ["simple", "english", "norwegian"])
+    frag, params = fts.index_tsvector_sql("content")
+    assert frag.count("to_tsvector(") == 3
+    assert frag.count(" || ") == 2
+    assert params == {
+        "fts_cfg_0": "simple",
+        "fts_cfg_1": "english",
+        "fts_cfg_2": "norwegian",
+    }
+
+
+def test_index_tsvector_sql_honors_content_bind(monkeypatch):
+    fts = _set_configs(monkeypatch, ["english"])
+    frag, _ = fts.index_tsvector_sql("body")
+    assert frag == "to_tsvector(CAST(:fts_cfg_0 AS regconfig), :body)"
+
+
+def test_index_tsvector_sql_never_interpolates_config_name(monkeypatch):
+    # A hostile config name must appear only as a bound value, never inline.
+    fts = _set_configs(monkeypatch, ["english'; DROP TABLE notes_metadata; --"])
+    frag, params = fts.index_tsvector_sql("content")
+    assert "DROP TABLE" not in frag
+    assert params["fts_cfg_0"] == "english'; DROP TABLE notes_metadata; --"
+
+
+# ── combined_tsquery ─────────────────────────────────────────────────────
+
+
+def _compile(expr):
+    from sqlalchemy.dialects import postgresql
+
+    return str(expr.compile(dialect=postgresql.dialect()))
+
+
+def test_combined_tsquery_single_config(monkeypatch):
+    fts = _set_configs(monkeypatch, ["english"])
+    sql = _compile(fts.combined_tsquery("hello"))
+    assert sql.count("websearch_to_tsquery(") == 1
+    assert "||" not in sql
+
+
+def test_combined_tsquery_ors_two_configs(monkeypatch):
+    fts = _set_configs(monkeypatch, ["english", "norwegian"])
+    sql = _compile(fts.combined_tsquery("hello"))
+    assert sql.count("websearch_to_tsquery(") == 2
+    assert "||" in sql
+
+
+def test_combined_tsquery_ors_three_configs(monkeypatch):
+    fts = _set_configs(monkeypatch, ["simple", "english", "norwegian"])
+    sql = _compile(fts.combined_tsquery("hello"))
+    assert sql.count("websearch_to_tsquery(") == 3
+    assert sql.count("||") == 2
+
+
+# ── Backward-compat regression: default == historical single-english SQL ──
+
+
+def test_default_config_reproduces_single_english_behavior(monkeypatch):
+    """The default `["english"]` must build exactly one english-config
+    tsvector/tsquery — i.e. byte-for-byte the pre-feature behavior (a
+    single-element concat/OR is identical to a lone call)."""
+    s = Settings(_env_file=None)
+    assert s.fts_configs == ["english"]
+
+    fts = _set_configs(monkeypatch, s.fts_configs)
+
+    frag, params = fts.index_tsvector_sql("content")
+    assert frag == "to_tsvector(CAST(:fts_cfg_0 AS regconfig), :content)"
+    assert params == {"fts_cfg_0": "english"}
+
+    sql = _compile(fts.combined_tsquery("hello"))
+    assert sql.count("websearch_to_tsquery(") == 1
+    assert "||" not in sql
+
+
+# ── rebuild_tsvectors (offline: fake session, real file IO) ───────────────
+
+
+@pytest.mark.asyncio
+async def test_rebuild_tsvectors_updates_every_note(monkeypatch, tmp_path):
+    """`rebuild_tsvectors` re-reads each indexed note and issues an UPDATE that
+    sets `content_tsvector` under the configured config(s), carrying the FTS
+    config bind params. Fully offline — no DB, no network, no embeddings."""
+    from collections import namedtuple
+
+    import src.services.indexer as indexer
+    from sqlalchemy.sql.elements import TextClause
+
+    Row = namedtuple("Row", ["id", "file_path"])
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "a.md").write_text("---\ntitle: A\n---\nalpha body\n", encoding="utf-8")
+    (vault / "b.md").write_text("---\ntitle: B\n---\nbeta body\n", encoding="utf-8")
+
+    monkeypatch.setattr(indexer.settings, "vault_path", str(vault), raising=False)
+    monkeypatch.setattr(indexer.settings, "fts_configs", ["simple", "norwegian"], raising=False)
+
+    rows = [Row(1, "a.md"), Row(2, "b.md")]
+
+    class _Result:
+        def __init__(self, data=None):
+            self._data = data or []
+
+        def all(self):
+            return self._data
+
+    class _FakeSession:
+        def __init__(self):
+            self.updates = []
+
+        async def execute(self, stmt, params=None):
+            if isinstance(stmt, TextClause) and "content_tsvector" in stmt.text:
+                self.updates.append((stmt.text, params))
+                return _Result()
+            # The note-listing SELECT (a SQLAlchemy Select) returns our rows.
+            return _Result(rows)
+
+        async def commit(self):
+            return None
+
+    session = _FakeSession()
+    n = await indexer.rebuild_tsvectors(session, user_id=None)
+
+    assert n == 2
+    assert len(session.updates) == 2
+    ids = {p["id"] for _, p in session.updates}
+    assert ids == {1, 2}
+    for text_sql, p in session.updates:
+        # Both configs present as bound params; names never interpolated.
+        assert p["fts_cfg_0"] == "simple"
+        assert p["fts_cfg_1"] == "norwegian"
+        assert "CAST(:fts_cfg_0 AS regconfig)" in text_sql
+        assert "CAST(:fts_cfg_1 AS regconfig)" in text_sql
+        assert "body" in p["content"]

--- a/tests/test_fts_integration.py
+++ b/tests/test_fts_integration.py
@@ -1,0 +1,115 @@
+"""Integration tests for configurable FTS — exercises real PostgreSQL stemming.
+
+These verify the end-to-end semantics the unit tests can't: that the Norwegian
+stemmer matches `datasenter` against `datasenteret`, that `english` does not,
+that `simple` matches only exact forms, and that a multi-config list matches
+across languages.
+
+The index side is built through the real `index_tsvector_sql` helper; the query
+side mirrors `combined_tsquery`'s OR-of-`websearch_to_tsquery` shape in raw SQL
+so the whole match runs in one round-trip. (`combined_tsquery`'s SQLAlchemy
+structure is asserted separately in `test_fts.py`.)
+
+Requires a Postgres instance with the standard `norwegian` and `simple`
+text-search configs installed (both ship with PostgreSQL). The whole module is
+skipped when `TEST_DATABASE_URL` is unset or unreachable, so the offline suite
+in `test_fts.py` always runs while these light up in CI/dev with a database.
+
+Run with e.g.:
+    TEST_DATABASE_URL=postgresql+asyncpg://obsidian_mcp:pass@localhost/obsidian_mcp \
+        pytest tests/test_fts_integration.py
+"""
+import os
+
+import pytest
+from sqlalchemy import text
+
+import src.services.fts as fts
+from src.services.fts import index_tsvector_sql
+
+DB_URL = os.environ.get("TEST_DATABASE_URL")
+
+pytestmark = pytest.mark.skipif(
+    not DB_URL, reason="TEST_DATABASE_URL not set — skipping FTS integration tests"
+)
+
+
+@pytest.fixture
+async def conn():
+    """A throwaway async connection, rolled back after each test."""
+    from sqlalchemy.ext.asyncio import create_async_engine
+
+    engine = create_async_engine(DB_URL)
+    try:
+        async with engine.connect() as connection:
+            yield connection
+            await connection.rollback()
+    finally:
+        await engine.dispose()
+
+
+def _query_frag(configs):
+    """Raw-SQL OR of websearch_to_tsquery over `configs`, matching
+    `combined_tsquery`'s semantics with bound, cast config names."""
+    return " || ".join(
+        f"websearch_to_tsquery(CAST(:fts_cfg_{i} AS regconfig), :q)"
+        for i in range(len(configs))
+    )
+
+
+async def _matches(conn, configs, body, query):
+    """True iff `query` parsed under `configs` matches `body`'s tsvector,
+    where the tsvector is built via the production `index_tsvector_sql`."""
+    orig = fts.settings.fts_configs
+    fts.settings.fts_configs = configs
+    try:
+        tsv_frag, params = index_tsvector_sql("content")
+    finally:
+        fts.settings.fts_configs = orig
+    sql = f"SELECT ({tsv_frag}) @@ ({_query_frag(configs)})"
+    row = await conn.execute(text(sql), {"content": body, "q": query, **params})
+    return bool(row.scalar())
+
+
+# "datasenteret" = "the data center" (definite form); stem is "datasenter".
+NORWEGIAN = "Vi bygde datasenteret i fjor."
+
+
+@pytest.mark.asyncio
+async def test_norwegian_stemmer_matches_inflected_form(conn):
+    assert await _matches(conn, ["norwegian"], NORWEGIAN, "datasenter")
+
+
+@pytest.mark.asyncio
+async def test_english_config_misses_norwegian_inflection(conn):
+    assert not await _matches(conn, ["english"], NORWEGIAN, "datasenter")
+
+
+@pytest.mark.asyncio
+async def test_simple_matches_exact_form_only(conn):
+    assert await _matches(conn, ["simple"], NORWEGIAN, "datasenteret")
+    assert not await _matches(conn, ["simple"], NORWEGIAN, "datasenter")
+
+
+@pytest.mark.asyncio
+async def test_multi_config_matches_either_language(conn):
+    body = "The servers run fast. Vi bygde datasenteret."
+    assert await _matches(conn, ["english", "norwegian"], body, "server")
+    assert await _matches(conn, ["english", "norwegian"], body, "datasenter")
+
+
+@pytest.mark.asyncio
+async def test_default_english_equals_hardcoded_baseline(conn):
+    """The default `["english"]` path must agree with the historical
+    hardcoded `to_tsvector('english', …)` / `websearch_to_tsquery('english', …)`
+    SQL it replaced."""
+    body = "The servers are running."
+    assert await _matches(conn, ["english"], body, "run")
+    baseline = await conn.execute(
+        text(
+            "SELECT to_tsvector('english', :c) "
+            "@@ websearch_to_tsquery('english', :q)"
+        ),
+        {"c": body, "q": "run"},
+    )
+    assert baseline.scalar() is True

--- a/tests/test_fts_integration.py
+++ b/tests/test_fts_integration.py
@@ -36,14 +36,30 @@ pytestmark = pytest.mark.skipif(
 
 @pytest.fixture
 async def conn():
-    """A throwaway async connection, rolled back after each test."""
+    """A throwaway async connection, rolled back after each test.
+
+    Skips (rather than errors) when TEST_DATABASE_URL is set but the database is
+    unreachable, so the behavior matches the module docstring on a host without
+    a running Postgres.
+
+    A fresh engine per test is intentional, not an oversight: pytest-asyncio's
+    default function-scoped event loop means a module-scoped engine's asyncpg
+    pool would be bound to a stale loop and raise "attached to a different
+    loop". The connect cost is negligible next to the queries themselves.
+    """
     from sqlalchemy.ext.asyncio import create_async_engine
 
     engine = create_async_engine(DB_URL)
     try:
-        async with engine.connect() as connection:
+        try:
+            connection = await engine.connect()
+        except Exception as e:  # DB configured but down/misconfigured
+            pytest.skip(f"TEST_DATABASE_URL set but database unreachable: {e}")
+        try:
             yield connection
             await connection.rollback()
+        finally:
+            await connection.close()
     finally:
         await engine.dispose()
 


### PR DESCRIPTION
Make the PostgreSQL text-search configuration for keyword search a configurable list (`FTS_CONFIGS`, default `["english"]`) instead of a hardcoded `'english'` at the three aligned index/query sites.

- Add `src/services/fts.py` as the single source of truth: `index_tsvector_sql` (concatenate `to_tsvector` over configs), `combined_tsquery` (OR `websearch_to_tsquery` over configs), and `validate_fts_configs` (startup allowlist check against `pg_ts_config`). Config names are passed as bound params with a `::regconfig` cast — never string-interpolated.
- `config.py`: `fts_configs` setting parsing JSON or CSV, normalized (strip/lowercase/dedupe), rejects empty. `NoDecode` defers env parsing to the validator so the CSV form works.
- Route the indexer tsvector writes and the search tsquery through the helpers.
- Validate configs at startup so a typo fails fast instead of producing silent zero-result searches.
- Add `rebuild_tsvectors` + `scripts/rebuild_tsvectors.py` + `make rebuild-tsvectors` to recompute the keyword index after a config change (no embeddings, no API calls).
- Default `["english"]` reproduces current behavior byte-for-byte (regression test asserts this). Setting is global, no schema migration.
- Tests (unit + DB-gated integration) and docs (README, CLAUDE.md, .env.example).

https://claude.ai/code/session_014XjSpZ3KcE59cqJQTNqF4y