### PR TITLE
feat(mcp): raw file-access tools (read_file/write_file/list_files)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,14 @@ MCP_HOSTNAME=obsidian-mcp.example.com
 # Indexer
 INDEX_INTERVAL_SECONDS=300
 
+# Raw file-access tools (read_file / write_file). Size caps in bytes. The
+# read cap (default 10 MB) bounds inline/base64 responses so a large file
+# can't blow up the model context; the write cap (default 25 MB) is the
+# decoded byte ceiling for an upload. Both have defaults, so existing .env
+# files work unchanged.
+# MAX_FILE_READ_BYTES=10485760
+# MAX_FILE_WRITE_BYTES=26214400
+
 # Full-text (keyword) search configuration(s). PostgreSQL text-search config
 # names, applied at both index and query time. JSON list or comma-separated.
 #   english             default — English Snowball stemmer (current behavior)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,3 +113,11 @@ Link extraction lives in `src/services/links.py`. The extractor strips fenced/in
 - `set_frontmatter(path, updates, remove=[])` — structured YAML frontmatter mutation. Round-trips via `yaml.safe_dump` (does not preserve YAML comments). Leaves the body byte-identical.
 
 All write tools route through `src/services/vault.py::write_file`, which writes to a tmp file in the same directory and `os.replace()`s it into place — a crash mid-write cannot truncate the destination.
+
+## File-access tools (non-markdown)
+Raw read/write/browse of arbitrary vault files, distinct peers to the note tools (note tools stay markdown-only). Pure byte transport — no server-side PDF/text extraction, no embedding or indexing of non-markdown files.
+- `read_file(path, encoding="auto")` — `auto` resolves text-like MIME → text, image → inline MCP image content block (renders in-client), everything else → base64 string. `text` forces UTF-8 decode (errors on non-UTF-8); `base64` forces raw-bytes base64. Capped by `MAX_FILE_READ_BYTES` (default 10 MB), checked against on-disk size before reading. Base64 reads are token-heavy — check size with `list_files` first.
+- `write_file(path, content, encoding="base64", overwrite=False)` — `base64` decodes `content` to raw bytes; `text` writes UTF-8. No-clobber by default (`overwrite=True` to replace), auto-creates parent dirs, atomic via `vault.write_file`. Capped by `MAX_FILE_WRITE_BYTES` (default 25 MB) on decoded length.
+- `list_files(folder=".", pattern="*", recursive=False, limit=200)` — `ls`-style: immediate children (subdirs + files) by default, each file with size + mtime; glob-filterable; capped at `limit` with a truncation note.
+
+All three reuse `validate_path` (traversal guard) and a shared dot-dir guard (`is_hidden_path`) that rejects any path component starting with `.` — same visibility rule as the indexer, keeping `.obsidian`/`.git`/`.trash`/`.smart-env` out of reach. Vault helpers (`read_bytes`, `write_bytes`, `list_dir`, MIME classification) live in `src/services/vault.py`. MIME detection uses stdlib `mimetypes` plus a magic-byte sniff for PNG/JPEG/GIF/WebP. `read_file` is the first tool returning a non-`str` MCP content object.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ makes this feel natural.
 
 ## What's in the box
 
-The server exposes 17 MCP tools across five concerns.
+The server exposes 20 MCP tools across six concerns.
 
 ### Search and discovery
 - `keyword_search(query, folder?, tags?, frontmatter?, limit=20)`,
@@ -206,6 +206,27 @@ The server exposes 17 MCP tools across five concerns.
   does a hard `os.unlink`.
 - `set_frontmatter(path, updates, remove?)`, structured YAML
   mutation. Body is byte-identical when only frontmatter changes.
+
+### File access (non-markdown)
+Raw read/write/browse of arbitrary vault files (PDFs, images, skill
+assets, data files) — distinct peers to the note tools, which stay
+markdown-only. Pure byte transport: no server-side PDF/text extraction,
+no embedding or indexing of non-markdown files.
+- `read_file(path, encoding="auto")`, returns text-like files as text,
+  images as an inline image block that renders in-client, and other
+  binaries as a base64 string. `text`/`base64` force the form. Refuses
+  files over `MAX_FILE_READ_BYTES` (default 10 MB).
+- `write_file(path, content, encoding="base64", overwrite=False)`,
+  lands a file in the vault; base64 for binary, `text` for UTF-8.
+  No-clobber by default, auto-creates parent dirs, atomic write.
+  Capped at `MAX_FILE_WRITE_BYTES` (default 25 MB).
+- `list_files(folder=".", pattern="*", recursive=False, limit=200)`,
+  `ls`-style browse of files and subdirectories with size and mtime,
+  glob-filterable and result-capped.
+
+All three reuse the path-traversal guard and exclude dot-directories
+(`.obsidian`, `.git`, `.trash`, …), matching the indexer's visibility
+rule.
 
 ### Wikilink graph
 - `get_backlinks(path, limit=50)`, notes linking TO `path`
@@ -574,6 +595,8 @@ to multi-user later resumes where you left off without re-bootstrapping
 | `VAULT_PATH` | `/obsidian` | In-container vault mount |
 | `SECRET_KEY` | — | itsdangerous signer key |
 | `INDEX_INTERVAL_SECONDS` | `300` | Periodic reindex cadence |
+| `MAX_FILE_READ_BYTES` | `10485760` | `read_file` cap (10 MB); bounds inline/base64 responses |
+| `MAX_FILE_WRITE_BYTES` | `26214400` | `write_file` cap (25 MB), decoded byte length |
 | `FTS_CONFIGS` | `english` | Keyword-search text-search config(s). JSON or CSV. See [Full-text search language(s)](#full-text-search-languages). |
 | `EMBEDDING_PROVIDER` | `ollama` | `ollama` or `openai` |
 | `EMBEDDING_DIMENSIONS` | `1024` | pgvector column width |
@@ -665,7 +688,7 @@ seconds for a few thousand notes. (Do not confuse it with the expensive
 │ MCP clients  │   HTTP + Bearer key   │   FastAPI app        │
 │  Claude Desk │ ────────────────────▶ │  ┌────────────────┐  │
 │  Claude Code │                       │  │  MCP server    │  │
-│  n8n agents  │                       │  │  (17 tools)    │  │
+│  n8n agents  │                       │  │  (20 tools)    │  │
 │  OpenWebUI   │                       │  └─────┬──────────┘  │
 └──────────────┘                       │        ▼             │
                                        │  ┌────────────────┐  │

--- a/openspec/changes/archive/2026-06-26-add-nonmarkdown-file-access/.openspec.yaml
+++ b/openspec/changes/archive/2026-06-26-add-nonmarkdown-file-access/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-26

--- a/openspec/changes/archive/2026-06-26-add-nonmarkdown-file-access/design.md
+++ b/openspec/changes/archive/2026-06-26-add-nonmarkdown-file-access/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The MCP server is markdown-only: the indexer globs `*.md` and skips dot-dirs; all 17 tools return a plain `str`; there is no binary handling and no MCP *resources* registered. The vault holds ~12,800 non-markdown files. The user-facing ones (PDFs — median 0.29 MB / p90 1.9 MB, images, skill HTML/JS) live in normal folders (`Reference Docs/`, `Projects/`, `Skills/`, `Attachments/`); the heavy `.py`/`.pyc`/`.so`/`.ajson` noise lives entirely in dot-dirs (`.venv-larisa`, `.smart-env`, `.cursor`) the indexer already skips.
+
+Two driving use cases: (1) grab an existing PDF/HTML so a client-side skill can consume it; (2) save a generated file (e.g. an output PDF) back into the vault.
+
+Existing building blocks to reuse: `vault.validate_path()` (path-traversal guard), `vault.write_file()` (atomic temp-file + `os.replace`, with EXDEV fallback), and the indexer's dot-dir rule (`any(part.startswith(".") for part in rel.parts)`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Read, write, and browse arbitrary files in the vault from any MCP client, with no dependency on the client sandbox reaching an external HTTP endpoint.
+- Keep the new surface as distinct peer tools, not fused into existing note tools.
+- Stay safe: no path traversal, no dot-dir exposure, no accidental clobbering, bounded response sizes.
+
+**Non-Goals:**
+- No server-side PDF/text extraction. `read_file` is pure byte transport; a client skill decodes and parses.
+- No embedding, semantic search, or keyword indexing of non-markdown files.
+- No new HTTP download/upload endpoints; no database schema, ORM, or indexer changes.
+
+## Decisions
+
+### Inline MCP transport over out-of-band HTTP URLs
+Bytes travel inside the tool result (text / base64 / image block). **Why:** universal — works regardless of whether the client sandbox can `curl`. A signed-URL approach would be more efficient for large files but breaks the moment the client can't reach the host. Trade-off accepted: base64 inflates ~33% and passes through model context, so transport is practical only for small/medium files (hence the read cap).
+
+### Three distinct peer tools, not generalized note tools
+`read_file` / `write_file` / `list_files` are new; `read_note` / `create_note` / `list_notes` stay markdown-only and unchanged. **Why:** matches the project's established "distinct peer tools over fused primary tools" preference and keeps each tool's return shape coherent. Alternative (overloading `read_note` to branch on extension) was rejected as the fused-tool anti-pattern.
+
+### `read_file` return shape: rich image blocks, base64 otherwise
+`auto` → text for text-like MIME types, an inline MCP image content block for images (so scans/illustrations render in-client), base64 string for everything else. **Why:** images are the one type where rendering is high-value and cheap (the client downsamples; vision tokenization compresses), whereas PDFs/other binaries only need to reach a skill as bytes. PDF-as-MCP-document-block was rejected — cross-client support is uncertain. This makes `read_file` the first tool returning MCP content objects rather than `str`; FastMCP supports returning an image/content object or list.
+
+### MIME detection: stdlib + magic-byte sniff
+Use `mimetypes.guess_type` for the text/binary/image decision, confirmed by a short magic-byte sniff for the common image signatures (PNG, JPEG, GIF, WebP). **Why:** no new dependency; `mimetypes` alone is extension-trusting, so the sniff guards against mislabeled images.
+
+### Size caps: read 10 MB, write 25 MB, configurable
+`MAX_FILE_READ_BYTES` (10 MB, matches existing `MAX_NOTE_BYTES`) and `MAX_FILE_WRITE_BYTES` (25 MB) in `config.py`. Read is checked against on-disk size before reading; write against decoded byte length. **Why:** read cap covers all but ~12 vault files and guards against context blowups; write is intentional so it gets a higher ceiling.
+
+### `write_file`: no-clobber + auto-create parents, atomic
+Default `overwrite=False` errors if the target exists; missing parent folders are created; the write routes through the existing atomic `vault.write_file()`. **Why:** safest default against data loss while keeping "save to a new `Outputs/` folder" frictionless.
+
+### Shared safety helper for dot-dirs
+A small helper rejects any path whose resolved components include a dot-dir, applied in all three tools (and as a filter in `list_files`), layered on top of `validate_path()`. **Why:** one consistent visibility rule matching the indexer; keeps `.obsidian` config/secrets, `.git`, `.trash`, and `.smart-env` out of reach.
+
+## Risks / Trade-offs
+
+- **Base64 context cost** → A multi-MB PDF inlined as base64 can exceed the context window. Mitigation: read cap + tool docstring instructs checking size via `list_files` first; document that base64 reads are token-heavy.
+- **Model misreads base64 PDF as "readable"** → The model cannot interpret PDF bytes. Mitigation: docstring states `read_file` returns opaque bytes for non-text/non-image types, intended for a skill to decode; no server-side extraction implied.
+- **`list_files` on a large folder** → Could return a huge list. Mitigation: `limit` (default 200) with explicit truncation indicator; non-recursive default.
+- **MIME misdetection** → An image with a wrong extension or a text file sniffed as binary. Mitigation: magic-byte sniff for images; `encoding="text"`/`"base64"` overrides always available.
+- **New return type for `read_file`** → First non-`str` tool; must confirm the MCP/FastMCP wrapper and usage-logging path handle image/content returns. Mitigation: covered by tasks (verify content-block return + logging).
+
+## Migration Plan
+
+Additive only — no schema, indexer, or data migration. Deploy via the normal `make deploy`. New env vars have defaults, so existing `.env` files work unchanged. Rollback = revert the code; no state to undo.
+
+## Open Questions
+
+None blocking. Possible follow-ups (out of scope here): filename-in-search indexing for discovery, a feature flag to disable file tools, and optional server-side text extraction — all deferred pending real usage.

--- a/openspec/changes/archive/2026-06-26-add-nonmarkdown-file-access/proposal.md
+++ b/openspec/changes/archive/2026-06-26-add-nonmarkdown-file-access/proposal.md
@@ -1,0 +1,30 @@
+## Why
+
+The vault holds ~12,800 non-markdown files (PDFs, scans, illustrations, skill HTML/JS, data files), but the MCP server is markdown-only end to end — the indexer globs `*.md`, every tool returns a plain string, and there is no binary handling. Clients cannot grab an existing PDF/HTML to feed a skill, nor save a generated file (e.g. an output PDF) back into the vault. These files cannot be embedded or semantically indexed, but raw read/write/browse access is both feasible and valuable.
+
+## What Changes
+
+- Add three new **peer** MCP tools (`17 → 20`), exposed alongside the existing note tools:
+  - **`read_file(path, encoding="auto")`** — returns any file's contents inline. `auto` resolves text-like types to text, images to an inline MCP image block (renders in-client), and all other binaries to a base64 string. `text`/`base64` force the form. Read cap (default 10 MB).
+  - **`write_file(path, content, encoding="base64", overwrite=False)`** — lands a file in the vault. No-clobber by default; auto-creates parent folders; atomic write. Write cap (default 25 MB).
+  - **`list_files(folder=".", pattern="*", recursive=False, limit=200)`** — `ls`-style browser returning subdirectories and files with size + mtime, glob-filterable, result-capped.
+- All three tools **block dot-dirs** (`.obsidian`, `.git`, `.trash`, `.smart-env`, …), consistent with the indexer's existing visibility rule, and reuse the vault path-traversal guard.
+- Two new configurable settings: `MAX_FILE_READ_BYTES` (default 10 MB) and `MAX_FILE_WRITE_BYTES` (default 25 MB).
+- `get_vault_guide` mentions the new file tools so clients discover the capability.
+
+Non-goals (explicitly out of scope): no server-side PDF/text extraction, no embedding or semantic/keyword indexing of non-markdown files, no new HTTP download/upload endpoints, no database schema or indexer changes.
+
+## Capabilities
+
+### New Capabilities
+- `file-access`: Raw read, write, and browse access to arbitrary (non-markdown and markdown) files in the vault via MCP tools, including binary transport (base64 / inline image blocks), size caps, dot-dir exclusion, and path-traversal safety.
+
+### Modified Capabilities
+- `vault-guide`: The onboarding guide returned by `get_vault_guide` SHALL reference the new file-access tools so agents discover that raw file read/write/browse is available.
+
+## Impact
+
+- **Code**: new tool implementations in `src/mcp_server/tools.py` and registration in `src/mcp_server/server.py`; helper(s) in `src/services/vault.py` for dot-dir checks and binary read (reusing existing `validate_path` and atomic `write_file`); MIME detection via stdlib `mimetypes` + magic-byte sniff for images; `get_vault_guide` text update.
+- **Config**: `MAX_FILE_READ_BYTES`, `MAX_FILE_WRITE_BYTES` in `src/config.py` (pydantic-settings) and `.env` docs.
+- **Return types**: `read_file` introduces MCP content objects (image blocks) — the first tool not returning a plain `str`.
+- **No impact** to: database schema/ORM, the indexer, embeddings, full-text search, migrations.

--- a/openspec/changes/archive/2026-06-26-add-nonmarkdown-file-access/specs/file-access/spec.md
+++ b/openspec/changes/archive/2026-06-26-add-nonmarkdown-file-access/specs/file-access/spec.md
@@ -1,0 +1,190 @@
+## ADDED Requirements
+
+### Requirement: read_file tool
+
+The MCP server SHALL expose a tool named `read_file` that returns the contents of an arbitrary file in the vault. The tool SHALL accept `path` (string, required) and `encoding` (string, optional, default `"auto"`, one of `"auto"`, `"text"`, `"base64"`).
+
+The tool SHALL resolve the encoding as follows:
+- `"auto"`: text-like files (by MIME type, e.g. `text/*`, `application/json`, `application/javascript`, `*+xml`) SHALL be returned as a text payload; image files (e.g. `image/png`, `image/jpeg`, `image/gif`, `image/webp`) SHALL be returned as an inline MCP image content block; all other files SHALL be returned as a base64-encoded string.
+- `"text"`: the file SHALL be decoded as UTF-8 and returned as text; if it is not valid UTF-8 the tool SHALL return an error rather than corrupt output.
+- `"base64"`: the file's raw bytes SHALL be returned as a base64-encoded string regardless of type.
+
+File type SHALL be detected using the standard-library `mimetypes` mapping, with a magic-byte sniff used to confirm image types.
+
+#### Scenario: Tool is registered
+
+- **WHEN** an MCP client lists available tools on the server
+- **THEN** the listing SHALL contain `read_file`
+
+#### Scenario: Auto encoding returns text for a text-like file
+
+- **WHEN** `read_file` is invoked on an existing `.html` or `.txt` file with `encoding="auto"`
+- **THEN** the response SHALL contain the file's contents as readable text
+- **AND** the response SHALL NOT be base64-encoded
+
+#### Scenario: Auto encoding returns an inline image block for an image
+
+- **WHEN** `read_file` is invoked on an existing `.png` or `.jpg` file with `encoding="auto"`
+- **THEN** the response SHALL include an MCP image content block carrying the image data and its MIME type
+
+#### Scenario: Auto encoding returns base64 for other binaries
+
+- **WHEN** `read_file` is invoked on an existing `.pdf` file with `encoding="auto"`
+- **THEN** the response SHALL contain a base64-encoded string of the file's bytes
+- **AND** the response SHALL indicate the encoding is base64
+
+#### Scenario: Forced base64 on a text file
+
+- **WHEN** `read_file` is invoked on a `.txt` file with `encoding="base64"`
+- **THEN** the response SHALL contain the base64 encoding of the file's raw bytes
+
+#### Scenario: Missing file
+
+- **WHEN** `read_file` is invoked on a path that does not exist
+- **THEN** the tool SHALL return an error message identifying the path
+- **AND** the tool SHALL NOT raise an unhandled exception
+
+### Requirement: read_file size cap
+
+The `read_file` tool SHALL refuse to read files larger than a configurable limit `MAX_FILE_READ_BYTES` (default 10 MB). When a file exceeds the limit, the tool SHALL return an error that reports the file's size and path rather than returning partial or truncated content.
+
+#### Scenario: File within the cap
+
+- **WHEN** `read_file` is invoked on a file whose size is at or below `MAX_FILE_READ_BYTES`
+- **THEN** the file's contents SHALL be returned
+
+#### Scenario: File exceeds the cap
+
+- **WHEN** `read_file` is invoked on a file whose size exceeds `MAX_FILE_READ_BYTES`
+- **THEN** the tool SHALL return an error that states the file's actual size and path
+- **AND** the tool SHALL NOT return file contents
+
+### Requirement: write_file tool
+
+The MCP server SHALL expose a tool named `write_file` that writes a file into the vault. The tool SHALL accept `path` (string, required), `content` (string, required), `encoding` (string, optional, default `"base64"`, one of `"base64"`, `"text"`), and `overwrite` (boolean, optional, default `false`).
+
+When `encoding="base64"`, the tool SHALL base64-decode `content` and write the resulting raw bytes. When `encoding="text"`, the tool SHALL write `content` as UTF-8 text. The write SHALL be atomic, reusing the existing same-directory temp-file-plus-`os.replace` mechanism so a crash mid-write cannot truncate the destination.
+
+The tool SHALL create any missing parent directories of `path` before writing.
+
+#### Scenario: Tool is registered
+
+- **WHEN** an MCP client lists available tools on the server
+- **THEN** the listing SHALL contain `write_file`
+
+#### Scenario: Write a new binary file via base64
+
+- **WHEN** `write_file` is invoked with a non-existent `path`, base64 `content`, and `encoding="base64"`
+- **THEN** the decoded bytes SHALL be written to that path
+- **AND** the tool SHALL report success
+
+#### Scenario: Write text content
+
+- **WHEN** `write_file` is invoked with `encoding="text"` and a string body
+- **THEN** the body SHALL be written verbatim as UTF-8
+
+#### Scenario: Parent directories are created
+
+- **WHEN** `write_file` is invoked with a `path` whose parent folder does not yet exist
+- **THEN** the missing parent folders SHALL be created
+- **AND** the file SHALL be written
+
+#### Scenario: Invalid base64 content
+
+- **WHEN** `write_file` is invoked with `encoding="base64"` and `content` that is not valid base64
+- **THEN** the tool SHALL return an error
+- **AND** no file SHALL be written
+
+### Requirement: write_file no-clobber default
+
+The `write_file` tool SHALL NOT overwrite an existing file unless `overwrite=true` is passed. When the target exists and `overwrite` is `false`, the tool SHALL return an error and leave the existing file unchanged.
+
+#### Scenario: Existing file without overwrite
+
+- **WHEN** `write_file` targets an existing file with `overwrite=false`
+- **THEN** the tool SHALL return an error indicating the file already exists
+- **AND** the existing file's contents SHALL be unchanged
+
+#### Scenario: Existing file with overwrite
+
+- **WHEN** `write_file` targets an existing file with `overwrite=true`
+- **THEN** the file SHALL be replaced atomically with the new content
+
+### Requirement: write_file size cap
+
+The `write_file` tool SHALL refuse to write content larger than a configurable limit `MAX_FILE_WRITE_BYTES` (default 25 MB), measured by the decoded byte length. When the content exceeds the limit, the tool SHALL return an error and SHALL NOT write any file.
+
+#### Scenario: Content exceeds the cap
+
+- **WHEN** `write_file` is invoked with decoded content larger than `MAX_FILE_WRITE_BYTES`
+- **THEN** the tool SHALL return an error reporting the size limit
+- **AND** no file SHALL be written
+
+### Requirement: list_files tool
+
+The MCP server SHALL expose a tool named `list_files` that browses the vault filesystem. The tool SHALL accept `folder` (string, optional, default `"."` meaning the vault root), `pattern` (string glob, optional, default `"*"`), `recursive` (boolean, optional, default `false`), and `limit` (integer, optional, default 200).
+
+By default (`recursive=false`) the tool SHALL list the immediate children of `folder` only: both subdirectories and files, including markdown files. Each file entry SHALL include its vault-relative path, size in bytes, and modification time; directory entries SHALL be distinguishable from file entries. The `pattern` glob SHALL filter file entries. When the number of matching entries exceeds `limit`, the tool SHALL return at most `limit` entries and SHALL indicate that the result was truncated.
+
+#### Scenario: Tool is registered
+
+- **WHEN** an MCP client lists available tools on the server
+- **THEN** the listing SHALL contain `list_files`
+
+#### Scenario: Non-recursive listing of a folder
+
+- **WHEN** `list_files` is invoked on a folder that contains both files and subfolders, with `recursive=false`
+- **THEN** the response SHALL list the folder's immediate files (with size and mtime) and its immediate subdirectories
+- **AND** the response SHALL NOT include entries from nested subfolders
+
+#### Scenario: Glob pattern filter
+
+- **WHEN** `list_files` is invoked with `pattern="*.pdf"`
+- **THEN** the response SHALL include only files whose names match `*.pdf`
+
+#### Scenario: Recursive listing
+
+- **WHEN** `list_files` is invoked with `recursive=true`
+- **THEN** the response SHALL include matching files from nested subfolders beneath `folder`
+
+#### Scenario: Result is capped
+
+- **WHEN** the number of matching entries exceeds `limit`
+- **THEN** the response SHALL contain at most `limit` entries
+- **AND** the response SHALL indicate that the listing was truncated
+
+### Requirement: Dot-dir exclusion and path-traversal safety
+
+The `read_file`, `write_file`, and `list_files` tools SHALL reject any path that resolves outside the vault root, reusing the existing vault path-traversal guard. In addition, these tools SHALL reject any path that contains a directory component beginning with a dot (e.g. `.obsidian`, `.git`, `.trash`, `.smart-env`), consistent with the indexer's existing visibility rule. `list_files` SHALL omit dot-directories and their contents from results.
+
+#### Scenario: Path traversal is rejected
+
+- **WHEN** any of the three tools is invoked with a `path` that escapes the vault root (e.g. via `../`)
+- **THEN** the tool SHALL return an error
+- **AND** no file SHALL be read or written
+
+#### Scenario: Dot-dir path is rejected
+
+- **WHEN** `read_file` or `write_file` is invoked with a `path` inside a dot-directory (e.g. `.obsidian/config.json`)
+- **THEN** the tool SHALL return an error
+- **AND** no file SHALL be read or written
+
+#### Scenario: list_files hides dot-dirs
+
+- **WHEN** `list_files` is invoked on a folder that contains a dot-directory
+- **THEN** the dot-directory SHALL NOT appear in the results
+- **AND** invoking `list_files` with `folder` set to a dot-directory SHALL return an error
+
+### Requirement: Configurable file size limits
+
+The server configuration SHALL expose `MAX_FILE_READ_BYTES` (default 10 MB) and `MAX_FILE_WRITE_BYTES` (default 25 MB) as settings loadable from the environment, governing `read_file` and `write_file` respectively.
+
+#### Scenario: Defaults apply when unset
+
+- **WHEN** neither environment variable is set
+- **THEN** `MAX_FILE_READ_BYTES` SHALL default to 10 MB and `MAX_FILE_WRITE_BYTES` SHALL default to 25 MB
+
+#### Scenario: Overrides are honored
+
+- **WHEN** `MAX_FILE_READ_BYTES` or `MAX_FILE_WRITE_BYTES` is set in the environment
+- **THEN** the corresponding tool SHALL enforce the configured value

--- a/openspec/changes/archive/2026-06-26-add-nonmarkdown-file-access/specs/vault-guide/spec.md
+++ b/openspec/changes/archive/2026-06-26-add-nonmarkdown-file-access/specs/vault-guide/spec.md
@@ -1,0 +1,11 @@
+## ADDED Requirements
+
+### Requirement: Guide references the file-access tools
+
+The guide returned by `get_vault_guide` SHALL reference the raw file-access tools (`read_file`, `write_file`, `list_files`) so that an agent discovers it can read, write, and browse non-markdown files (PDFs, images, skill assets) in the vault. The reference SHALL use neutral framing consistent with how other peer tools are described.
+
+#### Scenario: Guide mentions the file tools
+
+- **WHEN** `get_vault_guide` is invoked
+- **THEN** the response SHALL mention the `read_file`, `write_file`, and `list_files` tools
+- **AND** the response SHALL indicate they operate on arbitrary (including non-markdown) files

--- a/openspec/changes/archive/2026-06-26-add-nonmarkdown-file-access/tasks.md
+++ b/openspec/changes/archive/2026-06-26-add-nonmarkdown-file-access/tasks.md
@@ -1,0 +1,39 @@
+## 1. Config
+
+- [x] 1.1 Add `max_file_read_bytes: int = Field(10 * 1024 * 1024, ge=1)` and `max_file_write_bytes: int = Field(25 * 1024 * 1024, ge=1)` to `Settings` in `src/config.py` (env: `MAX_FILE_READ_BYTES`, `MAX_FILE_WRITE_BYTES`).
+- [x] 1.2 Document both vars in `.env.example` / `.env` docs and in `CLAUDE.md`'s key-decisions section.
+
+## 2. Vault service helpers
+
+- [x] 2.1 Add a dot-dir guard helper in `src/services/vault.py` (e.g. `is_hidden_path(rel) -> bool` / `validate_visible_path()`) that rejects any path whose vault-relative components include a part starting with `.`, layered on top of `validate_path`. Reuse the indexer's existing rule.
+- [x] 2.2 Add `read_bytes(path) -> bytes` (or extend read) that validates path + dot-dir, stat-checks size against the cap before reading, and returns raw bytes.
+- [x] 2.3 Add `write_bytes(path, data, overwrite)` that validates path + dot-dir, enforces no-clobber unless `overwrite`, creates missing parent dirs, and routes through the existing atomic temp-file + `os.replace` write.
+- [x] 2.4 Add a `list_dir(folder, pattern, recursive, limit)` helper returning entries (relative path, is_dir, size, mtime), excluding dot-dirs, applying the glob, capping at `limit`, and reporting truncation.
+- [x] 2.5 Add MIME helpers: classify a path as text-like / image / other via `mimetypes` plus a magic-byte sniff for PNG/JPEG/GIF/WebP.
+
+## 3. MCP tools
+
+- [x] 3.1 Implement `read_file_impl(path, encoding="auto")` in `src/mcp_server/tools.py`: resolve `auto` (text-like → text, image → MCP image content block, else → base64 string), honor forced `text`/`base64`, return clear errors for missing file, over-cap size, and non-UTF-8 under `encoding="text"`. Return an MCP image/content object for images.
+- [x] 3.2 Implement `write_file_impl(path, content, encoding="base64", overwrite=False)`: base64-decode or treat as text, enforce `MAX_FILE_WRITE_BYTES` on decoded length, no-clobber default, auto-create parents, atomic write; clear errors for invalid base64 and existing-file-without-overwrite.
+- [x] 3.3 Implement `list_files_impl(folder=".", pattern="*", recursive=False, limit=200)`: list immediate children (files + subdirs) by default, include size + mtime, distinguish dirs, filter by glob, cap + truncation note, reject dot-dir `folder`.
+- [x] 3.4 Add `MAX_FILE_READ_BYTES`/`MAX_FILE_WRITE_BYTES` references via `settings`; keep `MAX_NOTE_BYTES` untouched.
+
+## 4. Registration & guide
+
+- [x] 4.1 Register `read_file`, `write_file`, `list_files` as `@mcp.tool()` peers in `src/mcp_server/server.py` with thorough docstrings (incl. base64 token-cost note for `read_file`, "opaque bytes for a skill to decode" framing, neutral cross-references).
+- [x] 4.2 Wire the three new `_impl` functions into the imports in `server.py`.
+- [x] 4.3 Update `get_vault_guide_impl` text to mention `read_file` / `write_file` / `list_files` with neutral framing and note they work on non-markdown files.
+- [x] 4.4 Confirm usage logging records the three new tool names (verify the logging path handles non-`str` / content-block returns from `read_file`).
+
+## 5. Tests
+
+- [x] 5.1 `read_file`: text-like → text, image → image content block (assert MIME), pdf/binary → base64; forced `base64` on text; missing file error; over-`MAX_FILE_READ_BYTES` error reports size + path; non-UTF-8 under `text` errors.
+- [x] 5.2 `write_file`: new binary via base64 round-trips; text mode; parent-dir creation; no-clobber error leaves existing file unchanged; `overwrite=True` replaces atomically; invalid base64 errors and writes nothing; over-`MAX_FILE_WRITE_BYTES` errors and writes nothing.
+- [x] 5.3 `list_files`: non-recursive lists files+subdirs with size/mtime; `pattern="*.pdf"` filters; `recursive=True` descends; `limit` caps + truncation indicated.
+- [x] 5.4 Safety: path traversal (`../`) rejected for all three; dot-dir path rejected for read/write; `list_files` hides dot-dirs and rejects a dot-dir `folder`.
+- [x] 5.5 `get_vault_guide` response mentions the three new tools.
+
+## 6. Verify
+
+- [x] 6.1 Run the test suite; run `openspec validate add-nonmarkdown-file-access --strict`.
+- [x] 6.2 Manual smoke against a running server: `list_files` a folder, `read_file` a PNG (renders) and a PDF (base64), `write_file` a small PDF then re-read it; confirm caps and dot-dir blocks behave.

--- a/openspec/specs/file-access/spec.md
+++ b/openspec/specs/file-access/spec.md
@@ -1,0 +1,194 @@
+# file-access Specification
+
+## Purpose
+Raw read, write, and browse access to arbitrary (non-markdown and markdown) files in the vault via MCP tools, including binary transport (base64 / inline image blocks), size caps, dot-dir exclusion, and path-traversal safety. Distinct peers to the markdown-only note tools; pure byte transport with no server-side extraction, embedding, or indexing of non-markdown files.
+
+## Requirements
+### Requirement: read_file tool
+
+The MCP server SHALL expose a tool named `read_file` that returns the contents of an arbitrary file in the vault. The tool SHALL accept `path` (string, required) and `encoding` (string, optional, default `"auto"`, one of `"auto"`, `"text"`, `"base64"`).
+
+The tool SHALL resolve the encoding as follows:
+- `"auto"`: text-like files (by MIME type, e.g. `text/*`, `application/json`, `application/javascript`, `*+xml`) SHALL be returned as a text payload; image files (e.g. `image/png`, `image/jpeg`, `image/gif`, `image/webp`) SHALL be returned as an inline MCP image content block; all other files SHALL be returned as a base64-encoded string.
+- `"text"`: the file SHALL be decoded as UTF-8 and returned as text; if it is not valid UTF-8 the tool SHALL return an error rather than corrupt output.
+- `"base64"`: the file's raw bytes SHALL be returned as a base64-encoded string regardless of type.
+
+File type SHALL be detected using the standard-library `mimetypes` mapping, with a magic-byte sniff used to confirm image types.
+
+#### Scenario: Tool is registered
+
+- **WHEN** an MCP client lists available tools on the server
+- **THEN** the listing SHALL contain `read_file`
+
+#### Scenario: Auto encoding returns text for a text-like file
+
+- **WHEN** `read_file` is invoked on an existing `.html` or `.txt` file with `encoding="auto"`
+- **THEN** the response SHALL contain the file's contents as readable text
+- **AND** the response SHALL NOT be base64-encoded
+
+#### Scenario: Auto encoding returns an inline image block for an image
+
+- **WHEN** `read_file` is invoked on an existing `.png` or `.jpg` file with `encoding="auto"`
+- **THEN** the response SHALL include an MCP image content block carrying the image data and its MIME type
+
+#### Scenario: Auto encoding returns base64 for other binaries
+
+- **WHEN** `read_file` is invoked on an existing `.pdf` file with `encoding="auto"`
+- **THEN** the response SHALL contain a base64-encoded string of the file's bytes
+- **AND** the response SHALL indicate the encoding is base64
+
+#### Scenario: Forced base64 on a text file
+
+- **WHEN** `read_file` is invoked on a `.txt` file with `encoding="base64"`
+- **THEN** the response SHALL contain the base64 encoding of the file's raw bytes
+
+#### Scenario: Missing file
+
+- **WHEN** `read_file` is invoked on a path that does not exist
+- **THEN** the tool SHALL return an error message identifying the path
+- **AND** the tool SHALL NOT raise an unhandled exception
+
+### Requirement: read_file size cap
+
+The `read_file` tool SHALL refuse to read files larger than a configurable limit `MAX_FILE_READ_BYTES` (default 10 MB). When a file exceeds the limit, the tool SHALL return an error that reports the file's size and path rather than returning partial or truncated content.
+
+#### Scenario: File within the cap
+
+- **WHEN** `read_file` is invoked on a file whose size is at or below `MAX_FILE_READ_BYTES`
+- **THEN** the file's contents SHALL be returned
+
+#### Scenario: File exceeds the cap
+
+- **WHEN** `read_file` is invoked on a file whose size exceeds `MAX_FILE_READ_BYTES`
+- **THEN** the tool SHALL return an error that states the file's actual size and path
+- **AND** the tool SHALL NOT return file contents
+
+### Requirement: write_file tool
+
+The MCP server SHALL expose a tool named `write_file` that writes a file into the vault. The tool SHALL accept `path` (string, required), `content` (string, required), `encoding` (string, optional, default `"base64"`, one of `"base64"`, `"text"`), and `overwrite` (boolean, optional, default `false`).
+
+When `encoding="base64"`, the tool SHALL base64-decode `content` and write the resulting raw bytes. When `encoding="text"`, the tool SHALL write `content` as UTF-8 text. The write SHALL be atomic, reusing the existing same-directory temp-file-plus-`os.replace` mechanism so a crash mid-write cannot truncate the destination.
+
+The tool SHALL create any missing parent directories of `path` before writing.
+
+#### Scenario: Tool is registered
+
+- **WHEN** an MCP client lists available tools on the server
+- **THEN** the listing SHALL contain `write_file`
+
+#### Scenario: Write a new binary file via base64
+
+- **WHEN** `write_file` is invoked with a non-existent `path`, base64 `content`, and `encoding="base64"`
+- **THEN** the decoded bytes SHALL be written to that path
+- **AND** the tool SHALL report success
+
+#### Scenario: Write text content
+
+- **WHEN** `write_file` is invoked with `encoding="text"` and a string body
+- **THEN** the body SHALL be written verbatim as UTF-8
+
+#### Scenario: Parent directories are created
+
+- **WHEN** `write_file` is invoked with a `path` whose parent folder does not yet exist
+- **THEN** the missing parent folders SHALL be created
+- **AND** the file SHALL be written
+
+#### Scenario: Invalid base64 content
+
+- **WHEN** `write_file` is invoked with `encoding="base64"` and `content` that is not valid base64
+- **THEN** the tool SHALL return an error
+- **AND** no file SHALL be written
+
+### Requirement: write_file no-clobber default
+
+The `write_file` tool SHALL NOT overwrite an existing file unless `overwrite=true` is passed. When the target exists and `overwrite` is `false`, the tool SHALL return an error and leave the existing file unchanged.
+
+#### Scenario: Existing file without overwrite
+
+- **WHEN** `write_file` targets an existing file with `overwrite=false`
+- **THEN** the tool SHALL return an error indicating the file already exists
+- **AND** the existing file's contents SHALL be unchanged
+
+#### Scenario: Existing file with overwrite
+
+- **WHEN** `write_file` targets an existing file with `overwrite=true`
+- **THEN** the file SHALL be replaced atomically with the new content
+
+### Requirement: write_file size cap
+
+The `write_file` tool SHALL refuse to write content larger than a configurable limit `MAX_FILE_WRITE_BYTES` (default 25 MB), measured by the decoded byte length. When the content exceeds the limit, the tool SHALL return an error and SHALL NOT write any file.
+
+#### Scenario: Content exceeds the cap
+
+- **WHEN** `write_file` is invoked with decoded content larger than `MAX_FILE_WRITE_BYTES`
+- **THEN** the tool SHALL return an error reporting the size limit
+- **AND** no file SHALL be written
+
+### Requirement: list_files tool
+
+The MCP server SHALL expose a tool named `list_files` that browses the vault filesystem. The tool SHALL accept `folder` (string, optional, default `"."` meaning the vault root), `pattern` (string glob, optional, default `"*"`), `recursive` (boolean, optional, default `false`), and `limit` (integer, optional, default 200).
+
+By default (`recursive=false`) the tool SHALL list the immediate children of `folder` only: both subdirectories and files, including markdown files. Each file entry SHALL include its vault-relative path, size in bytes, and modification time; directory entries SHALL be distinguishable from file entries. The `pattern` glob SHALL filter file entries. When the number of matching entries exceeds `limit`, the tool SHALL return at most `limit` entries and SHALL indicate that the result was truncated.
+
+#### Scenario: Tool is registered
+
+- **WHEN** an MCP client lists available tools on the server
+- **THEN** the listing SHALL contain `list_files`
+
+#### Scenario: Non-recursive listing of a folder
+
+- **WHEN** `list_files` is invoked on a folder that contains both files and subfolders, with `recursive=false`
+- **THEN** the response SHALL list the folder's immediate files (with size and mtime) and its immediate subdirectories
+- **AND** the response SHALL NOT include entries from nested subfolders
+
+#### Scenario: Glob pattern filter
+
+- **WHEN** `list_files` is invoked with `pattern="*.pdf"`
+- **THEN** the response SHALL include only files whose names match `*.pdf`
+
+#### Scenario: Recursive listing
+
+- **WHEN** `list_files` is invoked with `recursive=true`
+- **THEN** the response SHALL include matching files from nested subfolders beneath `folder`
+
+#### Scenario: Result is capped
+
+- **WHEN** the number of matching entries exceeds `limit`
+- **THEN** the response SHALL contain at most `limit` entries
+- **AND** the response SHALL indicate that the listing was truncated
+
+### Requirement: Dot-dir exclusion and path-traversal safety
+
+The `read_file`, `write_file`, and `list_files` tools SHALL reject any path that resolves outside the vault root, reusing the existing vault path-traversal guard. In addition, these tools SHALL reject any path that contains a directory component beginning with a dot (e.g. `.obsidian`, `.git`, `.trash`, `.smart-env`), consistent with the indexer's existing visibility rule. `list_files` SHALL omit dot-directories and their contents from results.
+
+#### Scenario: Path traversal is rejected
+
+- **WHEN** any of the three tools is invoked with a `path` that escapes the vault root (e.g. via `../`)
+- **THEN** the tool SHALL return an error
+- **AND** no file SHALL be read or written
+
+#### Scenario: Dot-dir path is rejected
+
+- **WHEN** `read_file` or `write_file` is invoked with a `path` inside a dot-directory (e.g. `.obsidian/config.json`)
+- **THEN** the tool SHALL return an error
+- **AND** no file SHALL be read or written
+
+#### Scenario: list_files hides dot-dirs
+
+- **WHEN** `list_files` is invoked on a folder that contains a dot-directory
+- **THEN** the dot-directory SHALL NOT appear in the results
+- **AND** invoking `list_files` with `folder` set to a dot-directory SHALL return an error
+
+### Requirement: Configurable file size limits
+
+The server configuration SHALL expose `MAX_FILE_READ_BYTES` (default 10 MB) and `MAX_FILE_WRITE_BYTES` (default 25 MB) as settings loadable from the environment, governing `read_file` and `write_file` respectively.
+
+#### Scenario: Defaults apply when unset
+
+- **WHEN** neither environment variable is set
+- **THEN** `MAX_FILE_READ_BYTES` SHALL default to 10 MB and `MAX_FILE_WRITE_BYTES` SHALL default to 25 MB
+
+#### Scenario: Overrides are honored
+
+- **WHEN** `MAX_FILE_READ_BYTES` or `MAX_FILE_WRITE_BYTES` is set in the environment
+- **THEN** the corresponding tool SHALL enforce the configured value

--- a/openspec/specs/vault-guide/spec.md
+++ b/openspec/specs/vault-guide/spec.md
@@ -81,3 +81,13 @@ The usage-logging system SHALL record invocations of `get_vault_guide` with `too
 
 - **WHEN** the change is deployed
 - **THEN** rows previously written with `tool='get_vault_context'` SHALL remain in `usage_logs` with their original tool name unchanged
+
+### Requirement: Guide references the file-access tools
+
+The guide returned by `get_vault_guide` SHALL reference the raw file-access tools (`read_file`, `write_file`, `list_files`) so that an agent discovers it can read, write, and browse non-markdown files (PDFs, images, skill assets) in the vault. The reference SHALL use neutral framing consistent with how other peer tools are described.
+
+#### Scenario: Guide mentions the file tools
+
+- **WHEN** `get_vault_guide` is invoked
+- **THEN** the response SHALL mention the `read_file`, `write_file`, and `list_files` tools
+- **AND** the response SHALL indicate they operate on arbitrary (including non-markdown) files

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 # Core
 fastapi==0.135.1
 uvicorn[standard]==0.42.0
-python-multipart==0.0.27
+# 0.0.30 fixes CVE-2026-53539 (fixable HIGH flagged by the trivy deploy gate).
+python-multipart==0.0.30
 
 # Database
 sqlalchemy[asyncio]==2.0.48

--- a/src/config.py
+++ b/src/config.py
@@ -56,6 +56,14 @@ class Settings(BaseSettings):
     openai_base_url: str = "https://api.openai.com/v1"
     openai_embedding_model: str = "text-embedding-3-small"
 
+    # Caps for the raw file-access tools (read_file / write_file). Read is
+    # checked against on-disk size before reading; write against the decoded
+    # byte length. Read default (10 MB) matches MAX_NOTE_BYTES and guards
+    # against context blowups from base64; write is intentional so it gets a
+    # higher ceiling (25 MB). Env: MAX_FILE_READ_BYTES / MAX_FILE_WRITE_BYTES.
+    max_file_read_bytes: int = Field(10 * 1024 * 1024, ge=1)
+    max_file_write_bytes: int = Field(25 * 1024 * 1024, ge=1)
+
     multi_user_mode: bool = False
     session_max_age: int = 60 * 60 * 24 * 7
     session_cookie_name: str = "omcp_session"

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -14,12 +14,15 @@ from src.mcp_server.tools import (
     get_recent_impl,
     get_tags_impl,
     get_vault_guide_impl,
+    list_files_impl,
     list_notes_impl,
     move_note_impl,
+    read_file_impl,
     read_note_impl,
     search_notes_impl,
     semantic_search_impl,
     set_frontmatter_impl,
+    write_file_impl,
 )
 
 mcp = FastMCP(
@@ -398,3 +401,98 @@ async def set_frontmatter(
             silently ignored.
     """
     return await set_frontmatter_impl(path, updates=updates, remove=remove)
+
+
+@mcp.tool()
+async def read_file(path: str, encoding: str = "auto"):
+    """Read any file in the vault — including non-markdown (PDFs, images,
+    skill HTML/JS, data files). Peer to `read_note`, which stays markdown-only.
+
+    This is pure byte transport: the server does NOT extract or parse PDFs and
+    cannot interpret binary bytes. Non-text/non-image files come back as an
+    opaque base64 string intended for a client-side skill to decode — not as
+    something the model can read directly.
+
+    Encoding:
+    - `"auto"` (default): text-like files (HTML, JSON, CSV, source, …) return
+      as readable text; images (PNG/JPEG/GIF/WebP) return as an inline image
+      block that renders in-client; everything else returns as a labeled
+      base64 string.
+    - `"text"`: force a UTF-8 text decode; errors if the file is not valid UTF-8.
+    - `"base64"`: force a raw-bytes base64 string regardless of type.
+
+    Files larger than `MAX_FILE_READ_BYTES` (default 10 MB) are refused with a
+    size report. Base64 reads pass through the model context and inflate ~33%,
+    so they are token-heavy — check a file's size with `list_files` before
+    reading large binaries. Dot-directories (`.obsidian`, `.git`, `.trash`, …)
+    and path traversal are rejected.
+
+    Args:
+        path: Vault-relative path to the file (e.g. "Reference Docs/spec.pdf").
+        encoding: One of "auto" (default), "text", or "base64".
+    """
+    return await read_file_impl(path, encoding=encoding)
+
+
+@mcp.tool()
+async def write_file(
+    path: str,
+    content: str,
+    encoding: str = "base64",
+    overwrite: bool = False,
+) -> str:
+    """Write a file into the vault — including non-markdown (e.g. save a
+    generated PDF or image). Requires a readwrite API key. Peer to
+    `create_note`/`edit_note`, which stay markdown-only.
+
+    `content` carries the bytes: with `encoding="base64"` (default) it is
+    base64-decoded to raw bytes; with `encoding="text"` it is written verbatim
+    as UTF-8. The write is atomic (tmp file + `os.replace`), missing parent
+    folders are created, and content over `MAX_FILE_WRITE_BYTES` (default
+    25 MB, decoded length) is refused.
+
+    No-clobber by default: writing over an existing file requires
+    `overwrite=True`. Dot-directories and path traversal are rejected; invalid
+    base64 errors without writing anything.
+
+    Args:
+        path: Vault-relative destination path (e.g. "Outputs/report.pdf").
+        content: File contents — base64 string (default) or UTF-8 text.
+        encoding: "base64" (default) or "text".
+        overwrite: If True, replace an existing file. Off by default.
+    """
+    return await write_file_impl(
+        path, content, encoding=encoding, overwrite=overwrite
+    )
+
+
+@mcp.tool()
+async def list_files(
+    folder: str = ".",
+    pattern: str = "*",
+    recursive: bool = False,
+    limit: int = 200,
+) -> str:
+    """Browse the vault filesystem (`ls`-style), including non-markdown files.
+    Peer to `list_notes`, which lists indexed markdown only; `list_files` reads
+    the filesystem directly and reports sizes so you can gauge a binary before
+    `read_file`.
+
+    By default lists the immediate children of `folder` — subdirectories and
+    files, each file with size and modification time. `pattern` is a glob that
+    filters file entries (e.g. "*.pdf"); `recursive=True` descends into
+    subfolders and returns matching files. Dot-directories (`.obsidian`,
+    `.git`, `.trash`, …) are hidden, and a dot-directory `folder` is rejected.
+
+    At most `limit` entries are returned (default 200, hard cap 1000); the
+    response indicates when the listing was truncated.
+
+    Args:
+        folder: Vault-relative folder (default "." = vault root).
+        pattern: Glob applied to file names (default "*").
+        recursive: If True, descend into subfolders. Off by default.
+        limit: Maximum entries to return (default 200, hard cap 1000).
+    """
+    return await list_files_impl(
+        folder, pattern=pattern, recursive=recursive, limit=limit
+    )

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -1,5 +1,8 @@
+import base64
+import binascii
 import inspect
 import logging
+import mimetypes
 import os
 import re
 import shutil
@@ -8,16 +11,25 @@ from datetime import datetime, timezone
 from functools import wraps
 from pathlib import Path, PurePosixPath
 
+from mcp.server.fastmcp import Image
 from sqlalchemy import text
 
 from src.auth.session import current_user_id
+from src.config import settings
 from src.database import async_session
 from src.mcp_server.auth import current_api_key_id, current_oauth_token_id, current_permission
 from src.models.db import UsageLog
 from src.services.embeddings import semantic_search
 from src.services.filters import apply_note_filters
 from src.services.search import full_text_search
-from src.services.vault import read_file, write_file
+from src.services.vault import (
+    classify_bytes,
+    list_dir,
+    read_bytes,
+    read_file,
+    write_bytes,
+    write_file,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1086,3 +1098,151 @@ async def set_frontmatter_impl(
     if not summary:
         summary.append("no key changes (whitespace-only)")
     return f"Updated frontmatter in {path} ({'; '.join(summary)})"
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# Raw file-access tools: read_file / write_file / list_files
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def _base64_payload(path: str, data: bytes, mime: str) -> str:
+    """Format raw bytes as a labeled base64 block.
+
+    The header makes the encoding explicit and warns that the body is opaque
+    (a skill/client decodes it; the model cannot read it). The base64 string
+    is the final block, separated by a blank line.
+    """
+    b64 = base64.b64encode(data).decode("ascii")
+    return (
+        "encoding: base64\n"
+        f"mime: {mime}\n"
+        f"bytes: {len(data)}\n"
+        f"path: {path}\n"
+        "(opaque bytes — not human-readable; pass to a skill/client to decode)\n\n"
+        f"{b64}"
+    )
+
+
+@_tracked("read_file", ["path", "encoding"])
+async def read_file_impl(path: str, encoding: str = "auto"):
+    """Read any vault file: text, inline image block, or base64 bytes."""
+    if encoding not in ("auto", "text", "base64"):
+        return f"Invalid encoding '{encoding}'. Use 'auto', 'text', or 'base64'."
+
+    uid = current_user_id.get()
+    try:
+        data = read_bytes(path, user_id=uid, max_bytes=settings.max_file_read_bytes)
+    except FileNotFoundError:
+        return f"File not found: {path}"
+    except ValueError as e:
+        return str(e)
+
+    if encoding == "text":
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError:
+            return (
+                f"Cannot decode {path} as UTF-8 text (not valid UTF-8). "
+                'Use encoding="base64" for binary files.'
+            )
+
+    if encoding == "base64":
+        mime = mimetypes.guess_type(path)[0] or "application/octet-stream"
+        return _base64_payload(path, data, mime)
+
+    # encoding == "auto"
+    kind, mime = classify_bytes(data, path)
+    if kind == "text":
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError:
+            return _base64_payload(path, data, mime)
+    if kind == "image":
+        # FastMCP wraps this into an MCP image content block. `format` becomes
+        # the `image/<format>` MIME (e.g. "png", "jpeg", "gif", "webp").
+        return Image(data=data, format=mime.split("/", 1)[1])
+    return _base64_payload(path, data, mime)
+
+
+@_tracked("write_file", ["path", "encoding", "overwrite"])
+async def write_file_impl(
+    path: str,
+    content: str,
+    encoding: str = "base64",
+    overwrite: bool = False,
+) -> str:
+    """Write a file into the vault from base64 or text content."""
+    if err := _require_write():
+        return err
+    if encoding not in ("base64", "text"):
+        return f"Invalid encoding '{encoding}'. Use 'base64' or 'text'."
+
+    if encoding == "base64":
+        try:
+            data = base64.b64decode(content, validate=True)
+        except (binascii.Error, ValueError):
+            return "Invalid base64 content: could not decode. No file was written."
+    else:
+        data = content.encode("utf-8")
+
+    if len(data) > settings.max_file_write_bytes:
+        return (
+            f"Content too large ({len(data):,} bytes, "
+            f"max {settings.max_file_write_bytes:,}). No file was written."
+        )
+
+    uid = current_user_id.get()
+    try:
+        write_bytes(path, data, overwrite=overwrite, user_id=uid)
+    except FileExistsError:
+        return f"File already exists: {path}. Pass overwrite=True to replace it."
+    except ValueError as e:
+        return str(e)
+    return f"Wrote {len(data):,} bytes to {path}"
+
+
+@_tracked("list_files", ["folder", "pattern", "recursive", "limit"])
+async def list_files_impl(
+    folder: str = ".",
+    pattern: str = "*",
+    recursive: bool = False,
+    limit: int = 200,
+) -> str:
+    """Browse vault files and subdirectories (`ls`-style)."""
+    uid = current_user_id.get()
+    limit = max(1, min(limit, 1000))
+    try:
+        entries, truncated = list_dir(
+            folder, pattern=pattern, recursive=recursive, limit=limit, user_id=uid
+        )
+    except NotADirectoryError as e:
+        return str(e)
+    except ValueError as e:
+        return str(e)
+
+    where = folder or "."
+    if not entries:
+        return f"No entries in '{where}' matching '{pattern}'"
+
+    header = f"{len(entries)} " + ("entry" if len(entries) == 1 else "entries")
+    header += f" in '{where}'"
+    if pattern != "*":
+        header += f" matching '{pattern}'"
+    if recursive:
+        header += " (recursive)"
+    if truncated:
+        header += ", truncated"
+    lines = [header + ":\n"]
+    for e in entries:
+        if e["is_dir"]:
+            lines.append(f"- 📁 `{e['path']}/`")
+        else:
+            mod = datetime.fromtimestamp(e["mtime"], timezone.utc).strftime(
+                "%Y-%m-%d %H:%M"
+            )
+            lines.append(f"- `{e['path']}` ({e['size']:,}B, modified {mod})")
+    if truncated:
+        lines.append(
+            f"\n… more than {limit} entries; narrow with `pattern` or a subfolder."
+        )
+    return "\n".join(lines)

--- a/src/mcp_server/vault_guide_primer.md
+++ b/src/mcp_server/vault_guide_primer.md
@@ -210,6 +210,26 @@ Treat these as **literal text** when reading or editing notes. Do not
 try to evaluate them, rewrite their syntax, or remove them unless the
 user explicitly asks for that.
 
+## Raw file access (non-markdown)
+
+The vault holds plenty of non-markdown files — PDFs, scans and images,
+skill HTML/JS, data files. Three tools work on arbitrary files alongside
+the markdown-only note tools:
+
+- `list_files(folder, pattern, recursive, limit)` — `ls`-style browse of
+  files and subdirectories with sizes and modification times. Use it to
+  discover non-markdown files and to check a file's size before reading.
+- `read_file(path, encoding="auto")` — read any file. `auto` returns
+  text-like files as text, images as an inline image block, and other
+  binaries (e.g. PDFs) as an opaque base64 string for a client-side skill
+  to decode. The server does not extract or parse PDFs.
+- `write_file(path, content, encoding="base64", overwrite=False)` — save a
+  file (e.g. a generated PDF) into the vault; base64 for binary, text mode
+  for text. No-clobber by default.
+
+Dot-directories (`.obsidian`, `.git`, `.trash`, …) are out of reach for
+all three. Base64 reads are token-heavy — prefer `list_files` first.
+
 ## Summary for agents
 
 - Wikilinks (`[[Note]]`) and embeds (`![[Note]]`) are the primary

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -1,4 +1,5 @@
 import logging
+import mimetypes
 import os
 import re
 import shutil
@@ -101,6 +102,31 @@ def validate_path(relative_path: str, user_id: int | None = None) -> Path:
     return resolved
 
 
+def is_hidden_path(rel: "str | Path") -> bool:
+    """True if any component of a vault-relative path starts with a dot.
+
+    Mirrors the indexer's visibility rule
+    (`any(part.startswith(".") for part in rel.parts)`) so the file-access
+    tools keep `.obsidian`, `.git`, `.trash`, `.smart-env`, … out of reach.
+    """
+    return any(part.startswith(".") for part in Path(rel).parts)
+
+
+def validate_visible_path(relative_path: str, user_id: int | None = None) -> Path:
+    """`validate_path` plus the dot-dir visibility guard.
+
+    Rejects path traversal (via `validate_path`) and any path that resolves
+    into a dot-directory. Used by the raw file-access tools so they expose
+    exactly the files the indexer would consider.
+    """
+    resolved = validate_path(relative_path, user_id=user_id)
+    vault = _vault_root(user_id).resolve()
+    rel = resolved.relative_to(vault)
+    if is_hidden_path(rel):
+        raise ValueError(f"Hidden path denied: {relative_path}")
+    return resolved
+
+
 def read_file(relative_path: str, user_id: int | None = None) -> dict:
     """Read a note, returning frontmatter + content."""
     path = validate_path(relative_path, user_id=user_id)
@@ -121,28 +147,32 @@ def read_file(relative_path: str, user_id: int | None = None) -> dict:
     }
 
 
-def write_file(relative_path: str, content: str, user_id: int | None = None) -> Path:
-    """Write content to a note atomically (tmp file in same dir + os.replace).
+def _atomic_write(path: Path, *, text: str | None = None, data: bytes | None = None) -> Path:
+    """Write `text` (UTF-8) or `data` (raw bytes) to `path` atomically.
 
-    A crash between the tmp-file write and the rename leaves the destination
-    untouched. `os.replace` is atomic on POSIX same-FS renames; if the vault
-    ever spans filesystems (EXDEV), fall back to a non-atomic copy+remove and
-    log a warning.
+    Shared core for `write_file` (notes) and `write_bytes` (raw files): writes
+    a tmp file in the same directory then `os.replace`s it into place. A crash
+    between the tmp-file write and the rename leaves the destination untouched.
+    `os.replace` is atomic on POSIX same-FS renames; if the vault ever spans
+    filesystems (EXDEV), fall back to a non-atomic `shutil.move` and log a
+    warning. Creates missing parent directories.
     """
-    path = validate_path(relative_path, user_id=user_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp = path.with_name(
         f".tmp-{path.name}-{os.getpid()}-{uuid.uuid4().hex[:8]}"
     )
     try:
-        tmp.write_text(content, encoding="utf-8")
+        if data is not None:
+            tmp.write_bytes(data)
+        else:
+            tmp.write_text(text or "", encoding="utf-8")
         try:
             os.replace(tmp, path)
         except OSError as e:
             if getattr(e, "errno", None) == 18:  # EXDEV
                 logger.warning(
                     "Cross-FS rename for %s; falling back to shutil.move (non-atomic)",
-                    relative_path,
+                    path.name,
                 )
                 shutil.move(str(tmp), str(path))
             else:
@@ -155,6 +185,182 @@ def write_file(relative_path: str, content: str, user_id: int | None = None) -> 
             pass
         raise
     return path
+
+
+def write_file(relative_path: str, content: str, user_id: int | None = None) -> Path:
+    """Write content to a note atomically (tmp file in same dir + os.replace)."""
+    path = validate_path(relative_path, user_id=user_id)
+    return _atomic_write(path, text=content)
+
+
+def read_bytes(
+    relative_path: str,
+    user_id: int | None = None,
+    max_bytes: int | None = None,
+) -> bytes:
+    """Read raw bytes of an arbitrary vault file (dot-dirs rejected).
+
+    Validates path + visibility, then stat-checks the on-disk size against
+    `max_bytes` (when given) before reading so an over-cap file is refused
+    without loading it into memory. Raises `FileNotFoundError` for a missing
+    file and `ValueError` for traversal, a hidden path, or an over-cap size
+    (the message reports the actual size and path).
+    """
+    path = validate_visible_path(relative_path, user_id=user_id)
+    if not path.is_file():
+        raise FileNotFoundError(f"File not found: {relative_path}")
+    size = path.stat().st_size
+    if max_bytes is not None and size > max_bytes:
+        raise ValueError(
+            f"File too large: {relative_path} is {size:,} bytes "
+            f"(max {max_bytes:,})"
+        )
+    return path.read_bytes()
+
+
+def write_bytes(
+    relative_path: str,
+    data: bytes,
+    overwrite: bool = False,
+    user_id: int | None = None,
+) -> Path:
+    """Write raw bytes to an arbitrary vault file atomically (dot-dirs rejected).
+
+    Validates path + visibility, enforces no-clobber unless `overwrite`,
+    creates any missing parent directories, and routes through the shared
+    atomic temp-file + `os.replace` write. Raises `FileExistsError` when the
+    target exists and `overwrite` is False, leaving the existing file
+    untouched.
+    """
+    path = validate_visible_path(relative_path, user_id=user_id)
+    if path.exists() and not overwrite:
+        raise FileExistsError(f"File already exists: {relative_path}")
+    return _atomic_write(path, data=data)
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# File-access helpers: MIME classification + directory listing
+# ────────────────────────────────────────────────────────────────────────────
+
+
+def _sniff_image_mime(head: bytes) -> str | None:
+    """Return an image MIME type if `head` carries a known image signature.
+
+    Covers the common web image formats (PNG, JPEG, GIF, WebP). Used to
+    confirm — and to catch mislabeled — images independent of the file
+    extension. Returns None when no signature matches.
+    """
+    if head.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "image/png"
+    if head.startswith(b"\xff\xd8\xff"):
+        return "image/jpeg"
+    if head[:6] in (b"GIF87a", b"GIF89a"):
+        return "image/gif"
+    if head[:4] == b"RIFF" and head[8:12] == b"WEBP":
+        return "image/webp"
+    return None
+
+
+def _is_text_like_mime(mime: str | None) -> bool:
+    """Whether a MIME type is safe to return as decoded text.
+
+    `text/*` plus the common structured-text application types
+    (JSON, JavaScript, XML, and any `*+xml`/`*+json` suffix).
+    """
+    if not mime:
+        return False
+    if mime.startswith("text/"):
+        return True
+    if mime in {
+        "application/json",
+        "application/javascript",
+        "application/xml",
+        "application/x-yaml",
+        "application/yaml",
+    }:
+        return True
+    return mime.endswith("+xml") or mime.endswith("+json")
+
+
+def classify_bytes(data: bytes, name: str) -> tuple[str, str]:
+    """Classify a file as ``"text"`` / ``"image"`` / ``"other"`` plus its MIME.
+
+    Detection uses a magic-byte sniff (authoritative for images, so a
+    mislabeled image still renders and a non-image with an image extension
+    does not) and falls back to stdlib `mimetypes` for the text/binary split.
+    """
+    img_mime = _sniff_image_mime(data[:16])
+    if img_mime is not None:
+        return "image", img_mime
+    mime, _ = mimetypes.guess_type(name)
+    if _is_text_like_mime(mime):
+        return "text", mime  # type: ignore[return-value]
+    return "other", mime or "application/octet-stream"
+
+
+def list_dir(
+    folder: str = ".",
+    pattern: str = "*",
+    recursive: bool = False,
+    limit: int = 200,
+    user_id: int | None = None,
+) -> tuple[list[dict], bool]:
+    """Browse the vault filesystem, excluding dot-directories.
+
+    Returns ``(entries, truncated)``. Each entry is a dict with
+    ``path`` (vault-relative POSIX), ``is_dir``, ``size`` (bytes), and
+    ``mtime`` (epoch float). Dot-directories — and a dot-directory `folder` —
+    are rejected/omitted via `validate_visible_path`.
+
+    Non-recursive (default): immediate children only — subdirectories (always)
+    and files whose name matches `pattern`. Recursive: files matching `pattern`
+    beneath `folder`, pruning dot-directories. At most `limit` entries are
+    returned; `truncated` is True when more matched.
+    """
+    import fnmatch
+
+    base = validate_visible_path(folder or ".", user_id=user_id)
+    if not base.is_dir():
+        raise NotADirectoryError(f"Not a directory: {folder}")
+    vault = _vault_root(user_id).resolve()
+
+    def _entry(p: Path, is_dir: bool) -> dict:
+        st = p.stat()
+        return {
+            "path": p.resolve().relative_to(vault).as_posix(),
+            "is_dir": is_dir,
+            "size": st.st_size,
+            "mtime": st.st_mtime,
+        }
+
+    entries: list[dict] = []
+    truncated = False
+
+    if recursive:
+        for root, dirnames, filenames in os.walk(base):
+            # Prune dot-directories in place so os.walk never descends them.
+            dirnames[:] = sorted(d for d in dirnames if not d.startswith("."))
+            for fname in sorted(filenames):
+                if fname.startswith(".") or not fnmatch.fnmatch(fname, pattern):
+                    continue
+                if len(entries) >= limit:
+                    truncated = True
+                    return entries, truncated
+                entries.append(_entry(Path(root) / fname, False))
+    else:
+        children = sorted(base.iterdir(), key=lambda p: (not p.is_dir(), p.name.lower()))
+        for child in children:
+            if child.name.startswith("."):
+                continue
+            is_dir = child.is_dir()
+            if not is_dir and not fnmatch.fnmatch(child.name, pattern):
+                continue
+            if len(entries) >= limit:
+                truncated = True
+                break
+            entries.append(_entry(child, is_dir))
+
+    return entries, truncated
 
 
 def parse_frontmatter(raw: str) -> tuple[dict, str]:

--- a/tests/test_file_access_tools.py
+++ b/tests/test_file_access_tools.py
@@ -1,0 +1,291 @@
+"""Tests for the raw file-access tools (read_file / write_file / list_files).
+
+Covers the `add-nonmarkdown-file-access` change: encoding resolution, binary
+round-trips, size caps, no-clobber, glob/recursive listing, truncation, and
+the dot-dir / path-traversal safety rules. Fully offline — usage logging is
+stubbed and the vault is a per-test tmp dir.
+
+`src.mcp_server.tools` imports `src.config`, whose module-level `Settings()`
+reads `./.env`. Provide minimal defaults and chdir to a dir without a `.env`
+BEFORE importing, matching the other tool tests.
+"""
+
+import base64
+import os
+import tempfile
+import time
+from pathlib import Path
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+import pytest  # noqa: E402
+from mcp.server.fastmcp import Image  # noqa: E402
+
+import src.mcp_server.tools as tools  # noqa: E402
+from src.mcp_server.auth import current_permission  # noqa: E402
+
+PNG_SIG = b"\x89PNG\r\n\x1a\n"
+
+
+@pytest.fixture(autouse=True)
+def _no_usage_log(monkeypatch):
+    """Stub the DB-backed usage logger so tools run fully offline."""
+
+    async def _noop(*a, **k):
+        return None
+
+    monkeypatch.setattr(tools, "_log_usage", _noop)
+
+
+@pytest.fixture
+def vault(monkeypatch, tmp_path):
+    """Point the (single-user) vault root at a fresh tmp dir."""
+    monkeypatch.setattr(tools.settings, "vault_path", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def readwrite():
+    """Grant write permission for the duration of a test."""
+    token = current_permission.set("readwrite")
+    try:
+        yield
+    finally:
+        current_permission.reset(token)
+
+
+def _b64_body(result: str) -> bytes:
+    """Extract and decode the base64 block from a read_file base64 payload."""
+    assert "encoding: base64" in result
+    return base64.b64decode(result.split("\n\n", 1)[1])
+
+
+# ── 5.1 read_file ────────────────────────────────────────────────────────────
+
+
+async def test_read_auto_text(vault):
+    (vault / "note.html").write_text("<h1>hi</h1>", encoding="utf-8")
+    result = await tools.read_file_impl("note.html")
+    assert result == "<h1>hi</h1>"
+    assert "encoding: base64" not in result
+
+
+async def test_read_auto_image_returns_image_block(vault):
+    (vault / "pic.png").write_bytes(PNG_SIG + b"\x00" * 32)
+    result = await tools.read_file_impl("pic.png")
+    assert isinstance(result, Image)
+    assert result._mime_type == "image/png"
+    assert result.data == PNG_SIG + b"\x00" * 32
+
+
+async def test_read_auto_mislabeled_image_sniffed(vault):
+    # JPEG magic bytes under a .bin extension still render as an image.
+    (vault / "blob.bin").write_bytes(b"\xff\xd8\xff" + b"\x10" * 20)
+    result = await tools.read_file_impl("blob.bin")
+    assert isinstance(result, Image)
+    assert result._mime_type == "image/jpeg"
+
+
+async def test_read_auto_pdf_is_base64(vault):
+    raw = b"%PDF-1.4\n" + bytes(range(256))
+    (vault / "doc.pdf").write_bytes(raw)
+    result = await tools.read_file_impl("doc.pdf")
+    assert "mime: application/pdf" in result
+    assert _b64_body(result) == raw
+
+
+async def test_read_forced_base64_on_text(vault):
+    (vault / "a.txt").write_text("plain text", encoding="utf-8")
+    result = await tools.read_file_impl("a.txt", encoding="base64")
+    assert _b64_body(result) == b"plain text"
+
+
+async def test_read_missing_file(vault):
+    result = await tools.read_file_impl("nope.pdf")
+    assert "not found" in result.lower()
+    assert "nope.pdf" in result
+
+
+async def test_read_over_cap_reports_size_and_path(vault, monkeypatch):
+    monkeypatch.setattr(tools.settings, "max_file_read_bytes", 10)
+    (vault / "big.bin").write_bytes(b"x" * 50)
+    result = await tools.read_file_impl("big.bin")
+    assert isinstance(result, str)
+    assert "big.bin" in result
+    assert "50" in result  # actual size reported
+
+
+async def test_read_text_non_utf8_errors(vault):
+    (vault / "bad.txt").write_bytes(b"\xff\xfe\x00\x01")
+    result = await tools.read_file_impl("bad.txt", encoding="text")
+    assert "utf-8" in result.lower()
+
+
+async def test_read_invalid_encoding(vault):
+    result = await tools.read_file_impl("x", encoding="rot13")
+    assert "Invalid encoding" in result
+
+
+# ── 5.2 write_file ───────────────────────────────────────────────────────────
+
+
+async def test_write_binary_base64_roundtrip(vault, readwrite):
+    raw = bytes(range(256))
+    b64 = base64.b64encode(raw).decode()
+    result = await tools.write_file_impl("out/data.bin", b64)
+    assert "Wrote" in result
+    assert (vault / "out" / "data.bin").read_bytes() == raw
+
+
+async def test_write_text_mode(vault, readwrite):
+    await tools.write_file_impl("hello.txt", "hi there", encoding="text")
+    assert (vault / "hello.txt").read_text(encoding="utf-8") == "hi there"
+
+
+async def test_write_creates_parent_dirs(vault, readwrite):
+    await tools.write_file_impl("a/b/c/deep.txt", "x", encoding="text")
+    assert (vault / "a" / "b" / "c" / "deep.txt").is_file()
+
+
+async def test_write_no_clobber_leaves_file(vault, readwrite):
+    (vault / "keep.txt").write_text("original", encoding="utf-8")
+    result = await tools.write_file_impl("keep.txt", "new", encoding="text")
+    assert "already exists" in result.lower()
+    assert (vault / "keep.txt").read_text(encoding="utf-8") == "original"
+
+
+async def test_write_overwrite_replaces(vault, readwrite):
+    (vault / "keep.txt").write_text("original", encoding="utf-8")
+    await tools.write_file_impl("keep.txt", "new", encoding="text", overwrite=True)
+    assert (vault / "keep.txt").read_text(encoding="utf-8") == "new"
+
+
+async def test_write_invalid_base64_writes_nothing(vault, readwrite):
+    result = await tools.write_file_impl("bad.bin", "not!!base64!!")
+    assert "base64" in result.lower()
+    assert not (vault / "bad.bin").exists()
+
+
+async def test_write_over_cap_writes_nothing(vault, readwrite, monkeypatch):
+    monkeypatch.setattr(tools.settings, "max_file_write_bytes", 10)
+    b64 = base64.b64encode(b"x" * 50).decode()
+    result = await tools.write_file_impl("big.bin", b64)
+    assert "too large" in result.lower()
+    assert not (vault / "big.bin").exists()
+
+
+async def test_write_requires_readwrite(vault):
+    # No readwrite fixture → default "read" permission.
+    result = await tools.write_file_impl("x.txt", "y", encoding="text")
+    assert "read-only" in result.lower() or "permission denied" in result.lower()
+    assert not (vault / "x.txt").exists()
+
+
+# ── 5.3 list_files ───────────────────────────────────────────────────────────
+
+
+async def test_list_non_recursive_files_and_subdirs(vault):
+    (vault / "sub").mkdir()
+    (vault / "sub" / "nested.txt").write_text("n", encoding="utf-8")
+    (vault / "a.pdf").write_bytes(b"%PDF")
+    (vault / "b.txt").write_text("b", encoding="utf-8")
+    result = await tools.list_files_impl(".")
+    assert "`a.pdf`" in result
+    assert "`b.txt`" in result
+    assert "sub/`" in result  # directory entry
+    assert "nested.txt" not in result  # not recursive
+    assert "B, modified" in result  # size + mtime present
+
+
+async def test_list_glob_filters_files(vault):
+    (vault / "a.pdf").write_bytes(b"%PDF")
+    (vault / "b.txt").write_text("b", encoding="utf-8")
+    result = await tools.list_files_impl(".", pattern="*.pdf")
+    assert "a.pdf" in result
+    assert "b.txt" not in result
+
+
+async def test_list_recursive_descends(vault):
+    (vault / "sub").mkdir()
+    (vault / "sub" / "deep.pdf").write_bytes(b"%PDF")
+    result = await tools.list_files_impl(".", pattern="*.pdf", recursive=True)
+    assert "sub/deep.pdf" in result
+
+
+async def test_list_limit_truncates(vault):
+    for i in range(10):
+        (vault / f"f{i}.txt").write_text("x", encoding="utf-8")
+    result = await tools.list_files_impl(".", limit=3)
+    assert "truncated" in result.lower()
+    # 3 entries listed (lines starting with "- ")
+    assert sum(1 for ln in result.splitlines() if ln.startswith("- ")) == 3
+
+
+# ── 5.4 safety ───────────────────────────────────────────────────────────────
+
+
+async def test_read_traversal_rejected(vault):
+    result = await tools.read_file_impl("../secret.txt")
+    assert "traversal" in result.lower()
+
+
+async def test_write_traversal_rejected(vault, readwrite):
+    result = await tools.write_file_impl("../escape.txt", "x", encoding="text")
+    assert "traversal" in result.lower()
+
+
+async def test_list_traversal_rejected(vault):
+    result = await tools.list_files_impl("../..")
+    assert "traversal" in result.lower()
+
+
+async def test_read_dotdir_rejected(vault):
+    dot = vault / ".obsidian"
+    dot.mkdir()
+    (dot / "app.json").write_text("{}", encoding="utf-8")
+    result = await tools.read_file_impl(".obsidian/app.json")
+    assert "hidden" in result.lower()
+
+
+async def test_write_dotdir_rejected(vault, readwrite):
+    result = await tools.write_file_impl(".git/config", "x", encoding="text")
+    assert "hidden" in result.lower()
+    assert not (vault / ".git" / "config").exists()
+
+
+async def test_list_hides_dotdirs(vault):
+    (vault / ".obsidian").mkdir()
+    (vault / ".obsidian" / "x.json").write_text("{}", encoding="utf-8")
+    (vault / "visible.txt").write_text("v", encoding="utf-8")
+    result = await tools.list_files_impl(".")
+    assert ".obsidian" not in result
+    assert "visible.txt" in result
+
+
+async def test_list_dotdir_folder_rejected(vault):
+    (vault / ".obsidian").mkdir()
+    result = await tools.list_files_impl(".obsidian")
+    assert "hidden" in result.lower()
+
+
+# ── 5.5 guide ────────────────────────────────────────────────────────────────
+
+
+async def test_guide_mentions_file_tools(vault):
+    result = await tools.get_vault_guide_impl()
+    for name in ("read_file", "write_file", "list_files"):
+        assert name in result
+
+
+# ── extra: mtime sanity for list output ──────────────────────────────────────
+
+
+async def test_list_reports_recent_mtime(vault):
+    (vault / "fresh.txt").write_text("f", encoding="utf-8")
+    os.utime(vault / "fresh.txt", (time.time(), time.time()))
+    result = await tools.list_files_impl(".")
+    assert "fresh.txt" in result
+    assert Path(str(vault / "fresh.txt")).exists()


### PR DESCRIPTION
## Summary

Adds three **peer** MCP tools for working with non-markdown vault files (PDFs, images, skill assets, data files), bringing the server from 17 → 20 tools. The note tools stay markdown-only; these are distinct peers, matching the project's "distinct peer tools over fused primary tools" preference.

- **`read_file(path, encoding="auto")`** — `auto` returns text-like files as text, images as an inline MCP image block (renders in-client), and other binaries as a labeled base64 string. `text`/`base64` force the form. Capped by `MAX_FILE_READ_BYTES` (default 10 MB), checked against on-disk size before reading.
- **`write_file(path, content, encoding="base64", overwrite=False)`** — base64 → raw bytes, `text` → UTF-8. No-clobber by default, auto-creates parent dirs, atomic write. Capped by `MAX_FILE_WRITE_BYTES` (default 25 MB) on decoded length.
- **`list_files(folder=".", pattern="*", recursive=False, limit=200)`** — `ls`-style browse with size + mtime, glob filter, recursive descent, truncation note.

Pure byte transport — **no** server-side PDF/text extraction, **no** embedding or indexing of non-markdown files. All three reuse the path-traversal guard plus a shared dot-dir guard (`is_hidden_path`) that mirrors the indexer's visibility rule, keeping `.obsidian`/`.git`/`.trash`/`.smart-env` out of reach. `write_file` shares a new `_atomic_write` core with the existing note write path (temp file + `os.replace`).

## Config
Two new settings (defaults preserve existing behavior): `MAX_FILE_READ_BYTES` (10 MB), `MAX_FILE_WRITE_BYTES` (25 MB).

## Docs
`get_vault_guide` primer, `README.md` (tool list + count + config table + architecture diagram), `CLAUDE.md`, and `.env.example` updated. OpenSpec change archived; `file-access` and `vault-guide` specs synced.

## Testing
- 30 new unit tests in `tests/test_file_access_tools.py`, all passing.
- Independent OpenSpec verifier: 0 blocking gaps, 24/24 scenarios.
- `openspec validate --strict` + spec validation green.
- **Live smoke test** against the deployed server: listed folders, read a PNG (rendered inline) and a PDF (base64), wrote a PDF to a new folder and round-tripped it, confirmed no-clobber, `overwrite=True`, dot-dir block, and path-traversal block.

## Note
Includes a second commit bumping `python-multipart 0.0.27 → 0.0.30` (CVE-2026-53539) — required to pass the `trivy` deploy gate, which refuses to ship with a fixable HIGH. Unrelated to the feature but bundled since it blocked deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)