### PR TITLE
Fix legacy edit_note append calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,8 @@ The server exposes 20 MCP tools across six concerns.
   replace (default), `append=True`, `find=…` (with optional
   `replace_all`), or `section=<heading>` (ATX headings, supports
   `Parent/Child` path-style disambiguation). `dry_run=True` returns a
-  unified diff without writing.
+  unified diff without writing. Legacy clients may use
+  `operation="append"`; `operation="replace"` explicitly selects full replace.
 - `move_note(from_path, to_path, rewrite_links=False)`, relocates and
   optionally rewrites incoming `[[Old]]`, `[[Old|alias]]`,
   `[[Old#anchor]]`, `![[Old]]`, and `[[folder/Old]]` references in

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -179,6 +179,7 @@ async def edit_note(
     path: str,
     content: str,
     append: bool = False,
+    operation: str | None = None,
     find: str | None = None,
     section: str | None = None,
     replace_all: bool = False,
@@ -199,6 +200,9 @@ async def edit_note(
        appears more than once. Setext (`====`/`----`) headings are not matched.
 
     Flags:
+    - `operation="append"`: legacy alias for `append=True`. This is accepted to
+      prevent older clients from silently falling through to full replacement.
+      `operation="replace"` explicitly selects full replacement.
     - `replace_all=True`: with `find`, replace every occurrence rather than failing on
       multiple matches. Ignored when `find` is unset.
     - `dry_run=True`: compute the would-be result and return a unified diff without
@@ -212,6 +216,7 @@ async def edit_note(
         path: Vault-relative path to the note.
         content: New full content, replacement text, text to append, or section body.
         append: If True, append content to the end of the note.
+        operation: Legacy mode selector; accepts "append" or "replace".
         find: Exact text to find and replace.
         section: ATX heading text identifying the section whose body to replace.
             Use `Parent/Child` to disambiguate repeated headings.
@@ -222,6 +227,7 @@ async def edit_note(
         path,
         content,
         append=append,
+        operation=operation,
         find=find,
         section=section,
         replace_all=replace_all,

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -663,12 +663,13 @@ async def find_orphans_impl(folder: str | None = None, limit: int = 50) -> str:
 
 @_tracked(
     "edit_note",
-    ["path", "append", "find", "section", "replace_all", "dry_run"],
+    ["path", "append", "operation", "find", "section", "replace_all", "dry_run"],
 )
 async def edit_note_impl(
     path: str,
     content: str,
     append: bool = False,
+    operation: str | None = None,
     find: str | None = None,
     section: str | None = None,
     replace_all: bool = False,
@@ -678,6 +679,16 @@ async def edit_note_impl(
     if err := _require_write():
         return err
 
+    if operation is not None:
+        operation = operation.lower()
+        if operation not in {"append", "replace"}:
+            return (
+                'edit_note: operation must be "append" or "replace" '
+                f'(got {operation!r}).'
+            )
+        if operation == "append":
+            append = True
+
     selected = []
     if append:
         selected.append("append=True")
@@ -685,6 +696,8 @@ async def edit_note_impl(
         selected.append("find=...")
     if section is not None:
         selected.append("section=...")
+    if operation == "replace" and selected:
+        selected.append('operation="replace"')
     if len(selected) > 1:
         return (
             "edit_note: choose at most one of append, find, section "

--- a/tests/test_edit_note_legacy_operation.py
+++ b/tests/test_edit_note_legacy_operation.py
@@ -1,0 +1,88 @@
+"""Regression tests for clients using the legacy ``operation`` selector.
+
+An older client sent ``operation="append"``. If that argument is discarded,
+``edit_note`` falls through to its default full-replace mode and destroys the
+existing note. Keep the alias explicit so that call shape is safe.
+"""
+
+import asyncio
+import os
+import tempfile
+
+_VAULT_DIR = tempfile.mkdtemp(prefix="edit-operation-vault-")
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ["VAULT_PATH"] = _VAULT_DIR
+os.chdir(tempfile.gettempdir())
+
+import src.mcp_server.tools as tools  # noqa: E402
+from src.config import settings  # noqa: E402
+from src.mcp_server.auth import current_permission  # noqa: E402
+
+settings.vault_path = _VAULT_DIR
+
+
+def _run_edit(path, **kwargs):
+    async def _noop_log(tool, params, duration_ms, response_size):
+        return None
+
+    original_log = tools._log_usage
+    original_vault_path = settings.vault_path
+    tools._log_usage = _noop_log
+    settings.vault_path = _VAULT_DIR
+    token = current_permission.set("readwrite")
+    try:
+        return asyncio.run(tools.edit_note_impl(path, **kwargs))
+    finally:
+        current_permission.reset(token)
+        settings.vault_path = original_vault_path
+        tools._log_usage = original_log
+
+
+def _fresh_note(name, content):
+    full = os.path.join(_VAULT_DIR, name)
+    with open(full, "w", encoding="utf-8") as fh:
+        fh.write(content)
+    return full
+
+
+def test_legacy_append_operation_preserves_frontmatter_and_body():
+    original = "---\nstatus: scratch\n---\n\n# Title\n\n## Log\n\n- original\n"
+    full = _fresh_note("legacy-append.md", original)
+
+    result = _run_edit(
+        "legacy-append.md", content="- appended", operation="append"
+    )
+
+    assert "Updated note" in result
+    with open(full, encoding="utf-8") as fh:
+        assert fh.read() == original + "\n- appended"
+
+
+def test_unknown_operation_is_rejected_without_writing():
+    original = "# Keep me\n"
+    full = _fresh_note("unknown-operation.md", original)
+
+    result = _run_edit(
+        "unknown-operation.md", content="replacement", operation="prepend"
+    )
+
+    assert "must be" in result
+    with open(full, encoding="utf-8") as fh:
+        assert fh.read() == original
+
+
+def test_replace_operation_cannot_be_combined_with_append():
+    original = "# Keep me\n"
+    full = _fresh_note("conflicting-operation.md", original)
+
+    result = _run_edit(
+        "conflicting-operation.md",
+        content="replacement",
+        append=True,
+        operation="replace",
+    )
+
+    assert "choose at most one" in result
+    with open(full, encoding="utf-8") as fh:
+        assert fh.read() == original


### PR DESCRIPTION
## Summary

- accept legacy `operation="append"` calls as a safe alias for `append=true`
- reject unknown and conflicting operation modes without writing
- document the compatibility behavior and add regression coverage

## Root cause

An older MCP client sent `operation: "append"`, while the server contract expected `append: true`. If that selector was discarded, `edit_note` fell through to its default full-replacement mode and could wipe the existing note.

## Validation

- 10 focused regression tests passed
- production deployment completed successfully
- container is healthy and `/health` returns `{"status":"ok"}`
- image scan found no fixable HIGH/CRITICAL CVEs

The broader local suite encountered one unrelated existing test that attempted to connect to PostgreSQL at localhost.
