### PR TITLE
fix: validate vault_path in bootstrap admin registration

### DIFF
--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -28,7 +28,7 @@ from src.csrf import generate_csrf_token, verify_csrf
 from src.database import get_session
 from src.limiter import limiter
 from src.models.db import APIKey, NoteMetadata, OAuthClient, OAuthCode, OAuthToken, UsageLog, User
-from src.services.vault import warm_user_vault_cache
+from src.services.vault import validate_vault_root_path, warm_user_vault_cache
 
 router = APIRouter(tags=["auth"], dependencies=[Depends(verify_csrf)])
 
@@ -228,6 +228,16 @@ async def register_submit(
             vault_path=vault_path,
             status_code=status.HTTP_400_BAD_REQUEST,
         )
+    normalized_vp, vp_err = validate_vault_root_path(vault_path)
+    if vp_err:
+        return _render_register(
+            request,
+            error=vp_err,
+            username=normalized,
+            vault_path=vault_path,
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+    vault_path = normalized_vp or vault_path
 
     # Critical section: take a transaction-scoped advisory lock so two
     # concurrent first-visits serialize. Inside the lock we re-check that

--- a/src/control_panel/users.py
+++ b/src/control_panel/users.py
@@ -41,7 +41,7 @@ from src.control_panel.routes import _panel_context, require_admin_panel
 from src.csrf import verify_csrf
 from src.database import get_session
 from src.models.db import APIKey, NoteMetadata, User
-from src.services.vault import clear_user_vault_cache
+from src.services.vault import clear_user_vault_cache, validate_vault_root_path
 
 router = APIRouter(prefix="/admin/users", tags=["users"])
 
@@ -61,33 +61,7 @@ router.dependencies.append(Depends(verify_csrf))
 # Allowed vault_path patterns: absolute paths under /vaults/, OR the
 # legacy single-user mount `settings.vault_path` (default /obsidian) for
 # max's existing setup post-flag-flip.
-def _validate_vault_path(p: str) -> tuple[str | None, str | None]:
-    """Return `(normalized_path, error)` — at most one of the two is set.
-
-    Empty or None → returns `(None, None)`: it's valid to clear a user's
-    vault_path (their vault tools just error until reassigned).
-    """
-    raw = (p or "").strip()
-    if not raw:
-        return None, None
-    # Canonicalize: forbid `..` traversal and trailing slashes.
-    if ".." in Path(raw).parts:
-        return None, "Vault path may not contain '..' traversal."
-    normalized = os.path.normpath(raw)
-    # `os.path.normpath` collapses double slashes and trailing slashes.
-    # We accept either the legacy mount or a strict /vaults/ subpath.
-    legacy = settings.vault_path.rstrip("/")
-    if normalized != legacy and not normalized.startswith("/vaults/"):
-        return None, (
-            f"Vault path must be either '{legacy}' (legacy mount) or a "
-            "subpath of '/vaults/'."
-        )
-    if not Path(normalized).is_dir():
-        return None, (
-            f"Vault path '{normalized}' does not exist as a directory "
-            "inside the container. Check the docker-compose volume mount."
-        )
-    return normalized, None
+_validate_vault_path = validate_vault_root_path
 
 
 async def _check_vault_path_unique(

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -91,6 +91,42 @@ def _vault_root(user_id: int | None = None) -> Path:
     return cached
 
 
+def validate_vault_root_path(p: str) -> tuple[str | None, str | None]:
+    """Validate an absolute container path as an acceptable vault root.
+
+    Returns ``(normalized_path, error)`` — at most one of the two is set.
+    Empty / None input → ``(None, None)``: callers that allow clearing a
+    vault_path assignment treat this as "no change".
+
+    Accepted values:
+    - ``settings.vault_path`` (the legacy single-user ``/obsidian`` mount)
+    - Any non-empty subpath of ``/vaults/``
+
+    The ``/vaults/`` restriction prevents an admin from accidentally (or
+    deliberately) pointing a user at ``/etc``, the host home dir, or another
+    container path that happens to be visible.  The directory-existence check
+    catches a docker-compose mount that was configured but not yet applied.
+    """
+    raw = (p or "").strip()
+    if not raw:
+        return None, None
+    if ".." in Path(raw).parts:
+        return None, "Vault path may not contain '..' traversal."
+    normalized = os.path.normpath(raw)
+    legacy = settings.vault_path.rstrip("/")
+    if normalized != legacy and not normalized.startswith("/vaults/"):
+        return None, (
+            f"Vault path must be either '{legacy}' (legacy mount) or a "
+            "subpath of '/vaults/'."
+        )
+    if not Path(normalized).is_dir():
+        return None, (
+            f"Vault path '{normalized}' does not exist as a directory "
+            "inside the container. Check the docker-compose volume mount."
+        )
+    return normalized, None
+
+
 def validate_path(relative_path: str, user_id: int | None = None) -> Path:
     """Resolve a relative path within the vault, preventing traversal."""
     vault = _vault_root(user_id)


### PR DESCRIPTION
## Problem

The bootstrap admin registration endpoint (`POST /admin/register`) accepts
an arbitrary string as `vault_path` and writes it to the database after
only a non-empty check. The user-management panel (`/admin/users/{id}/edit`)
applies much stricter validation to the same field:

- Rejects path-traversal (`..` components)
- Restricts to `settings.vault_path` (legacy mount) or a sub-path of `/vaults/`
- Verifies the path exists as a directory inside the container

A bootstrap registration with a malformed or non-existent path would
produce a silently broken first user (indexer fails on the next pass,
no vault content visible).

## Fix

Extract the shared logic from `control_panel/users.py` into a new public
function `validate_vault_root_path` in `src/services/vault.py`, then:

- Call it in `auth/routes.py:register_submit` (the actual fix)
- Replace the existing `_validate_vault_path` body in `users.py` with an
  alias to the shared function (no behavioural change, just deduplication)

```python
# src/auth/routes.py — after the non-empty check
normalized_vp, vp_err = validate_vault_root_path(vault_path)
if vp_err:
    return _render_register(request, error=vp_err, ...)
vault_path = normalized_vp or vault_path
```

This import is already available in `src/services/vault.py` (a dependency
of `auth/routes.py`) so there is no circular-import risk.

## Scope

- No schema or migration changes
- No behavioural change for valid input
- Existing unit tests unaffected
- The `validate_vault_root_path` function is a straight extraction of the
  29-line `_validate_vault_path` that was already in `users.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E7K5MS6u2MtEJGxPx47jBQ