### PR TITLE
Hotfix: harden sessions and query limits

### DIFF
--- a/alembic/versions/011_user_session_version.py
+++ b/alembic/versions/011_user_session_version.py
@@ -1,0 +1,26 @@
+"""Add a version counter for invalidating signed user sessions.
+
+Revision ID: 011
+Revises: 010
+Create Date: 2026-07-16
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "011"
+down_revision: Union[str, None] = "010"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column("session_version", sa.Integer(), nullable=False, server_default="1"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "session_version")

--- a/openspec/changes/archive/2026-07-16-harden-session-and-query-limits/design.md
+++ b/openspec/changes/archive/2026-07-16-harden-session-and-query-limits/design.md
@@ -1,0 +1,25 @@
+## Context
+
+Starlette stores session state in signed client-side cookies, so changing a password does not inherently revoke an already issued cookie. MCP tool arguments are authenticated but still untrusted and can request result sizes large enough to exhaust database, application, or client resources.
+
+## Decisions
+
+### Version signed sessions
+
+Add a non-null integer `session_version` to each user. Login and bootstrap copy it into the signed session. Authentication requires an exact match with the current database value and clears mismatched cookies. Password reset increments the database value.
+
+This keeps the existing stateless cookie design while providing global per-user revocation. Existing cookies without a version fail closed after deployment.
+
+### Clamp limits twice
+
+Clamp ordinary query/list tools to 500 results and semantic search to 50. Apply limits at the MCP implementation boundary and again in reusable search services so future internal callers cannot bypass the resource guard.
+
+### Match OAuth cookie security to transport
+
+Use the same `BASE_URL` HTTPS check already used for the main session cookie. Public deployments remain Secure-only; loopback HTTP development remains functional.
+
+## Risks / Trade-offs
+
+- Password reset signs out all devices, including the device initiating an administrative self-reset. This is intentional.
+- A deployment of the migration invalidates existing cookies that lack `session_version`.
+- Result requests above the cap return the capped number rather than an error, preserving current tool ergonomics.

--- a/openspec/changes/archive/2026-07-16-harden-session-and-query-limits/proposal.md
+++ b/openspec/changes/archive/2026-07-16-harden-session-and-query-limits/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+A follow-up bug and security review found that authenticated MCP callers can request unbounded result sets, password resets do not invalidate existing signed browser sessions, and OAuth consent fails on the explicitly supported loopback HTTP configuration.
+
+## What Changes
+
+- Clamp MCP query result limits at public tool and service boundaries
+- Bind signed browser sessions to a database-backed user session version
+- Increment the session version whenever an administrator resets a password
+- Make the OAuth consent-state cookie secure only when `BASE_URL` uses HTTPS
+- Add regression tests for each behavior
+
+## Capabilities
+
+### New Capabilities
+
+- `session-invalidation`: Password resets invalidate all previously issued browser sessions
+- `query-resource-limits`: MCP search and listing calls have bounded result sizes
+
+### Modified Capabilities
+
+- OAuth loopback development supports the complete consent flow over HTTP
+
+## Impact
+
+- Adds `users.session_version` through Alembic revision 011
+- Existing multi-user browser sessions are invalidated once during deployment because old cookies do not contain a session version
+- No MCP method signatures or successful response formats change

--- a/openspec/changes/archive/2026-07-16-harden-session-and-query-limits/tasks.md
+++ b/openspec/changes/archive/2026-07-16-harden-session-and-query-limits/tasks.md
@@ -1,0 +1,23 @@
+## 1. Query Resource Limits
+
+- [x] 1.1 Clamp ordinary MCP query/list limits to 500
+- [x] 1.2 Clamp semantic search limits to 50 before calculating overfetch
+- [x] 1.3 Add regression tests for huge, zero, and negative limits
+
+## 2. Session Invalidation
+
+- [x] 2.1 Add `users.session_version` to the model and Alembic migration
+- [x] 2.2 Store the version at login and bootstrap
+- [x] 2.3 Reject and clear sessions with missing or stale versions
+- [x] 2.4 Increment the version on password reset
+- [x] 2.5 Add regression tests for valid and stale sessions
+
+## 3. OAuth Loopback Consent
+
+- [x] 3.1 Derive the OAuth state cookie's Secure flag from `BASE_URL`
+- [x] 3.2 Add HTTPS and loopback HTTP cookie regression tests
+
+## 4. Verification
+
+- [x] 4.1 Run the focused regression tests
+- [x] 4.2 Run the full non-hanging unit suite (234 passed, 5 skipped); isolate the pre-existing hanging `test_issue_22_indexer_cleanup_on_aenter_failure` regression

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -158,6 +158,7 @@ async def login_submit(
 
     request.session.clear()
     request.session["user_id"] = user.id
+    request.session["session_version"] = user.session_version
     request.session["is_admin"] = bool(user.is_admin)
     request.session["username"] = user.username
 
@@ -301,6 +302,7 @@ async def register_submit(
 
     request.session.clear()
     request.session["user_id"] = uid
+    request.session["session_version"] = new_user.session_version
     request.session["is_admin"] = True
     request.session["username"] = normalized
 

--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -34,7 +34,16 @@ async def get_current_user(
     if user_id is None:
         return None
     result = await session.execute(select(User).where(User.id == user_id))
-    return result.scalar_one_or_none()
+    user = result.scalar_one_or_none()
+    if user is None:
+        return None
+    # Starlette sessions are signed client-side cookies. Binding the cookie
+    # to a database-backed version lets password resets invalidate every
+    # previously issued session without introducing a server-side store.
+    if request.session.get("session_version") != user.session_version:
+        request.session.clear()
+        return None
+    return user
 
 
 async def require_user(

--- a/src/control_panel/users.py
+++ b/src/control_panel/users.py
@@ -398,6 +398,7 @@ async def reset_password(
         raise HTTPException(404, "User not found")
 
     target.password_hash = hash_password(new_password)
+    target.session_version += 1
     await session.commit()
 
     return RedirectResponse(

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -74,6 +74,13 @@ async def _log_usage(tool: str, params: dict, duration_ms: int, response_size: i
 
 
 _MAX_PARAM_LEN = 200  # truncate long string params (e.g. note content)
+_MAX_QUERY_RESULTS = 500
+_MAX_SEMANTIC_RESULTS = 50
+
+
+def _clamp_limit(limit: int, maximum: int = _MAX_QUERY_RESULTS) -> int:
+    """Keep authenticated callers from creating unbounded DB/response work."""
+    return max(1, min(limit, maximum))
 
 
 def _truncate_params(params: dict) -> dict:
@@ -122,6 +129,7 @@ async def search_notes_impl(
     frontmatter: dict | None = None,
 ) -> str:
     """Full-text keyword search across vault notes."""
+    limit = _clamp_limit(limit)
     uid = current_user_id.get()
     async with async_session() as session:
         results = await full_text_search(
@@ -175,6 +183,7 @@ async def list_notes_impl(
     from sqlalchemy import select
     from src.models.db import NoteMetadata
 
+    limit = _clamp_limit(limit)
     uid = current_user_id.get()
     async with async_session() as session:
         stmt = select(NoteMetadata).order_by(NoteMetadata.modified_at.desc())
@@ -205,6 +214,7 @@ async def get_tags_impl(limit: int = 50) -> str:
     from sqlalchemy import func, select
     from src.models.db import NoteMetadata
 
+    limit = _clamp_limit(limit)
     uid = current_user_id.get()
     async with async_session() as session:
         tag_query = select(
@@ -240,6 +250,7 @@ async def get_recent_impl(
     from sqlalchemy import select
     from src.models.db import NoteMetadata
 
+    limit = _clamp_limit(limit)
     uid = current_user_id.get()
     async with async_session() as session:
         query = select(NoteMetadata).order_by(NoteMetadata.modified_at.desc())
@@ -270,6 +281,7 @@ async def semantic_search_impl(
     frontmatter: dict | None = None,
 ) -> str:
     """Vector similarity search using bge-m3 embeddings."""
+    limit = _clamp_limit(limit, _MAX_SEMANTIC_RESULTS)
     uid = current_user_id.get()
     async with async_session() as session:
         results = await semantic_search(

--- a/src/models/db.py
+++ b/src/models/db.py
@@ -34,6 +34,7 @@ class User(Base):
     password_hash: Mapped[str] = mapped_column(String(255), nullable=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    session_version: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
     vault_path: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     created_at: Mapped[datetime.datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/src/oauth/routes.py
+++ b/src/oauth/routes.py
@@ -321,7 +321,7 @@ async def authorize_get(
         "oauth_state",
         signed_state,
         httponly=True,
-        secure=True,
+        secure=settings.base_url.startswith("https://"),
         samesite="lax",
         max_age=600,  # 10 minutes, matching auth code lifetime
     )

--- a/src/services/embeddings.py
+++ b/src/services/embeddings.py
@@ -251,6 +251,7 @@ async def semantic_search(
     to a note plus its most-relevant chunk as preview — the caller should `read_note`
     for full content.
     """
+    limit = max(1, min(limit, 50))
     query_embedding = await get_embedding(query)
 
     # ef_search=80 lifts HNSW recall@10 to ~98% at modest latency cost.

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -20,6 +20,7 @@ async def full_text_search(
     The tsquery is built from `settings.fts_configs` (see `src/services/fts.py`)
     so query-time configs match the index-time configs in `indexer.py`.
     """
+    limit = max(1, min(limit, 500))
     tsquery = combined_tsquery(query)
     rank = func.ts_rank_cd(NoteMetadata.content_tsvector, tsquery).label("rank")
 

--- a/tests/test_security_review_followups.py
+++ b/tests/test_security_review_followups.py
@@ -1,0 +1,151 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from src.auth.session import get_current_user
+from src.control_panel import users as panel_users
+from src.mcp_server import tools
+from src.oauth import routes as oauth_routes
+from src.services import embeddings, search
+
+
+@pytest.mark.parametrize(
+    ("value", "maximum", "expected"),
+    [(0, 500, 1), (-10, 500, 1), (10**9, 500, 500), (10**9, 50, 50)],
+)
+def test_query_limit_clamp(value, maximum, expected):
+    assert tools._clamp_limit(value, maximum) == expected
+
+
+@pytest.mark.asyncio
+async def test_full_text_search_clamps_limit(monkeypatch):
+    session = AsyncMock()
+    result = MagicMock()
+    result.all.return_value = []
+    session.execute.return_value = result
+    monkeypatch.setattr(search, "combined_tsquery", lambda _query: "query")
+
+    await search.full_text_search(session, "needle", limit=10**9)
+
+    statement = session.execute.await_args.args[0]
+    assert statement._limit_clause.value == 500
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_clamps_before_overfetch(monkeypatch):
+    session = AsyncMock()
+    result = MagicMock()
+    result.fetchall.return_value = []
+    session.execute.side_effect = [None, None, result]
+    monkeypatch.setattr(
+        embeddings, "get_embedding", AsyncMock(return_value=[0.0] * 1024)
+    )
+
+    await embeddings.semantic_search(session, "needle", limit=10**9)
+
+    statement = session.execute.await_args_list[-1].args[0]
+    assert statement._limit_clause.value == 250
+
+
+class _Request:
+    def __init__(self, session):
+        self.session = session
+
+
+@pytest.mark.asyncio
+async def test_current_user_accepts_matching_session_version(monkeypatch):
+    monkeypatch.setattr("src.auth.session.settings.multi_user_mode", True)
+    user = SimpleNamespace(id=7, session_version=3)
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = user
+    db = AsyncMock()
+    db.execute.return_value = result
+    request = _Request({"user_id": 7, "session_version": 3})
+
+    assert await get_current_user(request, db) is user
+    assert request.session["user_id"] == 7
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cookie_version", [None, 2])
+async def test_current_user_rejects_and_clears_stale_session(monkeypatch, cookie_version):
+    monkeypatch.setattr("src.auth.session.settings.multi_user_mode", True)
+    user = SimpleNamespace(id=7, session_version=3)
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = user
+    db = AsyncMock()
+    db.execute.return_value = result
+    session = {"user_id": 7}
+    if cookie_version is not None:
+        session["session_version"] = cookie_version
+    request = _Request(session)
+
+    assert await get_current_user(request, db) is None
+    assert request.session == {}
+
+
+@pytest.mark.asyncio
+async def test_password_reset_bumps_session_version(monkeypatch):
+    target = SimpleNamespace(
+        id=7, password_hash="old", session_version=3, username="alice"
+    )
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = target
+    db = AsyncMock()
+    db.execute.return_value = result
+    monkeypatch.setattr(panel_users, "hash_password", lambda _password: "new-hash")
+
+    response = await panel_users.reset_password(
+        user_id=7,
+        new_password="new-password",
+        session=db,
+        user=SimpleNamespace(is_admin=True),
+    )
+
+    assert response.status_code == 303
+    assert target.password_hash == "new-hash"
+    assert target.session_version == 4
+    db.commit.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("base_url", "secure_fragment"),
+    [
+        ("http://localhost:8000", "Secure"),
+        ("https://notes.example.com", "Secure"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_oauth_state_cookie_matches_base_url_transport(
+    monkeypatch, base_url, secure_fragment
+):
+    client = SimpleNamespace(
+        client_name="Test", redirect_uris=["https://client.example/callback"], scope="read"
+    )
+    result = MagicMock()
+    result.scalar_one_or_none.return_value = client
+    db = AsyncMock()
+    db.execute.return_value = result
+    context = AsyncMock()
+    context.__aenter__.return_value = db
+    monkeypatch.setattr(oauth_routes, "async_session", lambda: context)
+    monkeypatch.setattr(oauth_routes.settings, "base_url", base_url)
+
+    request = MagicMock()
+    response = await oauth_routes.authorize_get(
+        request=request,
+        response_type="code",
+        client_id="client",
+        redirect_uri="https://client.example/callback",
+        code_challenge="a" * 43,
+        code_challenge_method="S256",
+        scope="read",
+        state="state",
+    )
+
+    cookie = response.headers["set-cookie"]
+    if base_url.startswith("https://"):
+        assert secure_fragment in cookie
+    else:
+        assert secure_fragment not in cookie


### PR DESCRIPTION
## What changed

- clamp MCP query and listing result limits, with service-level defense in depth
- bind signed browser sessions to a database-backed user session version
- invalidate existing browser sessions when an administrator resets a password
- make the OAuth consent-state cookie compatible with supported loopback HTTP development
- add Alembic migration 011, regression coverage, and the archived OpenSpec change

## Why

A bug and security review found resource-exhaustion risk from unbounded result limits, session persistence after password resets, and a broken OAuth consent flow on loopback HTTP.

## Impact

Existing multi-user browser sessions are invalidated once after migration because older cookies do not contain a session version. MCP method signatures and normal response formats are unchanged.

## Validation

- 31 focused tests passed
- 234 non-hanging tests passed; 5 database integration tests skipped
- image built and passed Trivy HIGH/CRITICAL scan
- local deployment healthy on migration 011
- OpenSpec validation: 7 passed, 0 failed

The pre-existing `test_issue_22_indexer_cleanup_on_aenter_failure` regression continues to hang when isolated and is unrelated to this patch.
