### PR TITLE
fix: always register SessionMiddleware and guard localhost in allowed_hosts

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -137,6 +137,11 @@ class Settings(BaseSettings):
                 self.allowed_origins = ["http://localhost:8000"]
             if self.allowed_hosts is None:
                 self.allowed_hosts = ["localhost"]
+        # Always ensure localhost is allowed so Docker health checks (which hit
+        # http://localhost:8000/health) are never blocked by TrustedHostMiddleware,
+        # even when ALLOWED_HOSTS is set explicitly in the environment.
+        if self.allowed_hosts and "localhost" not in self.allowed_hosts:
+            self.allowed_hosts = list(self.allowed_hosts) + ["localhost"]
         return self
 
     @model_validator(mode="after")

--- a/src/main.py
+++ b/src/main.py
@@ -156,18 +156,19 @@ app.add_middleware(TrustedHostMiddleware, allowed_hosts=settings.allowed_hosts)
 # GZip compression for responses >= 1000 bytes
 app.add_middleware(GZipMiddleware, minimum_size=1000)
 
-if settings.multi_user_mode:
-    from starlette.middleware.sessions import SessionMiddleware
-    # Browsers refuse Secure cookies on plain HTTP, so only localhost dev uses
-    # insecure cookies. BASE_URL is authoritative for proxy deployments.
-    app.add_middleware(
-        SessionMiddleware,
-        secret_key=settings.secret_key,
-        max_age=settings.session_max_age,
-        https_only=settings.base_url.startswith("https://"),
-        same_site="lax",
-        session_cookie=settings.session_cookie_name,
-    )
+from starlette.middleware.sessions import SessionMiddleware
+# Browsers refuse Secure cookies on plain HTTP, so only localhost dev uses
+# insecure cookies. BASE_URL is authoritative for proxy deployments.
+# SessionMiddleware is always required: verify_csrf runs on all /admin routes
+# regardless of multi_user_mode, and it depends on request.session.
+app.add_middleware(
+    SessionMiddleware,
+    secret_key=settings.secret_key,
+    max_age=settings.session_max_age,
+    https_only=settings.base_url.startswith("https://"),
+    same_site="lax",
+    session_cookie=settings.session_cookie_name,
+)
 
 # CORS
 app.add_middleware(


### PR DESCRIPTION
## Summary

Two related bugs that surface together in single-user deployments:

**1. CSRF validation always fails when `MULTI_USER_MODE=false`**

`SessionMiddleware` was only added to the app when `MULTI_USER_MODE=true`, but `verify_csrf` is a hard dependency on every `/admin` route regardless of that setting. Without the middleware, `request.session` raises `AssertionError`, which `validate_csrf_token` catches and returns `False` — meaning every form POST (create API key, delete key, trigger re-embed, etc.) fails with `403 CSRF validation failed`.

Fix: unconditionally register `SessionMiddleware`. CSRF protection is valid in single-user mode too, and the middleware has no meaningful cost when sessions aren't otherwise used.

**2. Docker health check returns 400 when `ALLOWED_HOSTS` is set explicitly**

`_derive_public_urls` auto-appends `"localhost"` to `allowed_hosts` when deriving from `MCP_HOSTNAME` — but only when `allowed_hosts` is `None`. If the operator sets `ALLOWED_HOSTS` explicitly in the environment, that guard is skipped, and `TrustedHostMiddleware` rejects the Docker health check (`curl -f http://localhost:8000/health`) with `400`, marking the container perpetually unhealthy.

Fix: always inject `"localhost"` into `allowed_hosts` after derivation if it isn't already present.

## Test plan

- [ ] With `MULTI_USER_MODE=false`: confirm API key creation succeeds (no `403 CSRF validation failed`)
- [ ] With `MULTI_USER_MODE=true`: confirm existing OAuth/session flow still works
- [ ] With `ALLOWED_HOSTS` explicitly set (e.g. `["myhost.example.com"]`): confirm `GET /health` returns `200` inside Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dn5kGz4igFYMtAsCnRmkoS