### PR TITLE
Upgrade MCP SDK to 1.28.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,9 @@ alembic==1.18.4
 pgvector==0.4.2
 
 # MCP
-mcp[cli]==1.26.0
+# 1.28.1 fixes CVE-2026-52869, CVE-2026-52870, and CVE-2026-59950
+# (fixable HIGH findings enforced by the Trivy deploy gate).
+mcp[cli]==1.28.1
 
 # Embeddings & search
 httpx==0.28.1


### PR DESCRIPTION
## Summary

- upgrade `mcp[cli]` from 1.26.0 to 1.28.1
- resolve three fixable HIGH findings enforced by the deployment vulnerability gate
- document the security rationale beside the dependency pin

## Security fixes

- CVE-2026-52869
- CVE-2026-52870
- CVE-2026-59950

## Verification

- installed and exercised MCP SDK 1.28.1 locally
- 266 tests passed and 5 skipped; the two remaining issue-22 failures are pre-existing fixture failures tracked separately
- suite excluding the known broken issue-22 fixture passed
- production image passed Trivy with zero fixable HIGH/CRITICAL findings
- deployed successfully; container is healthy and reports MCP SDK 1.28.1
- startup indexing and embedding passes completed successfully
