### PR TITLE
docs: adopt the standard engineering workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,34 @@ hostnames) must stay out of tracked files. The mechanism:
 - `make logs` — tail container logs
 - `make status` — check health
 
+## Engineering workflow
+
+The standard flow — supervisor main thread, **Opus** subagents, OpenSpec, the
+two Codex audit gates, `openspec-verifier`, and the `user-representative`
+browser pass — is defined once in `~/.claude/rules/engineering-workflow.md` and
+applies here. Read it; don't restate it. This section records only what is
+specific to this MCP server.
+
+**Local gates**
+
+| Gate | Command |
+| --- | --- |
+| Dependency audit | `make audit` (pip-audit) |
+| Migrations | `make db-migrate` (alembic) |
+| Deploy | `make deploy` (build, backup, migrate, deploy) |
+
+**Codex framing for this product.** The consumer here is an **agent**, not a
+person, and the vault is Max's single source of truth for every project. The
+expensive failures are **destructive writes** (an edit or append that clobbers
+a note — this has actually happened) and **silently wrong search results**,
+which an agent will act on without a human ever seeing the query. Treat any
+change to the write tools, section addressing, or the chunking/embedding path
+as a mandatory adversarial-pass trigger.
+
+**No `user-representative` pass** — there is no browser UI. Substitute an
+end-to-end exercise of the affected MCP tools against the live server, and say
+in the report which tools were actually called.
+
 ## Key Decisions
 - API keys use `omcp_` prefix, stored as SHA-256 hashes
 - Vault mounted read-write at /obsidian in container


### PR DESCRIPTION
Points this project at the shared workflow rule (`~/.claude/rules/engineering-workflow.md`), which is now the standard across all projects under `/home/max`: supervising main thread, Opus subagents doing the work, OpenSpec for non-trivial changes, Codex auditing the proposal *before* code and adversarially auditing the implementation after, then `openspec-verifier`, deploy, and a user-facing verification pass.

Only this project's deltas live here:

- **Gates** — `make audit` (pip-audit), `make db-migrate`, `make deploy`.
- **Codex framing** — the consumer here is an *agent*, not a person, and the vault is the single source of truth for every project. The expensive failures are destructive writes (an edit or append that clobbers a note — this has actually happened) and silently wrong search results, which an agent acts on without a human seeing the query. Changes to the write tools, section addressing, or the chunking/embedding path are mandatory adversarial-pass triggers.
- **No browser pass** — there is no UI. The substitute is an end-to-end exercise of the affected MCP tools against the live server, naming which tools were actually called.

Docs only; no code or behavior changes. Raised as a PR because `main` is protected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SweKBkw54oUGbpwAcUig5f
