### PR TITLE
deps: bump uvicorn 0.42.0 → 0.52.3 (standalone)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core
 fastapi==0.141.1
-uvicorn[standard]==0.42.0
+uvicorn[standard]==0.52.3
 # CVE-2026-53539 (fixable HIGH flagged by the Trivy deploy gate) was fixed in
 # 0.0.30 and remains fixed here.
 python-multipart==0.0.32


### PR DESCRIPTION
Standalone uvicorn bump per the dependency audit (kept separate from #49 so a proxy-header or startup-exit regression is unambiguously attributable). Stacked on `deps-refresh-2026-08`; retarget to `main` after #49 merges.

Verified:
- suite green (372 passed / 10 skipped) with uvicorn 0.52.3
- `ProxyHeadersMiddleware(app, trusted_hosts=…)` signature unchanged
- client-IP resolution identical to 0.42.0 for: trusted proxy + XFF, XFF comma list, duplicate XFF headers, untrusted client spoofing (this is what slowapi's rate limiter keys on)
- 0.50 changed the startup-failure exit code (1 → 3): nothing in the repo relies on the value; the dim-guard `sys.exit(1)` still stops the process and Docker's restart policy behaves the same

Post-deploy check (after merge): hit `/admin/auth/login` past 5/minute from one IP → 429; container starts healthy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoJ7HhsYQqD9s14YujiaCy