### PR TITLE
compose: second-user vault host path via env placeholder (refs #55)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,9 @@ services:
       # contains spaces. Admin assigns the container path on the user
       # record via /admin/users/<id>/edit.
 
-      # Oksana — assign vault_path=/vaults/oksana in the panel after she's created.
-      - "/storage/shared/Oksana Documents/Obsidian:/vaults/oksana"
+      # Second user — assign vault_path=/vaults/oksana in the panel after the
+      # user is created. The host path lives in .env (this file is public).
+      - "${OKSANA_VAULT_HOST_PATH:-./vaults/oksana}:/vaults/oksana"
 
       # Additional users — add an entry per user as you invite them.
       # Example: "/storage/vaults/alice:/vaults/alice"


### PR DESCRIPTION
Removes the last host-specific path from the tracked `docker-compose.yml` (CLAUDE.md public-repo rule). Both compose files (repo + deploy dir) now read `${OKSANA_VAULT_HOST_PATH:-./vaults/oksana}`; the real path is set in the deploy-dir `.env` (verified with `docker compose config` — the resolved mount is unchanged, so no container recreate is needed).

Refs #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FoJ7HhsYQqD9s14YujiaCy