### PR TITLE
fix: OAuth consent screen doesn't preselect the requested scope

### DIFF
--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -530,6 +530,12 @@ async def oauth_page(
                 "id": t.id,
                 "token_type": t.token_type,
                 "scope": t.scope,
+                # t.scope is a space-separated set (e.g. "offline_access
+                # readwrite"), not always exactly "read" or "readwrite" -
+                # the template needs membership, not string equality, or
+                # a readwrite token showing an offline_access marker
+                # renders as if it were read-only.
+                "has_write": "readwrite" in t.scope.split(),
                 "revoked": t.revoked,
                 "expired": False,
                 "expires_at": t.expires_at.isoformat(),
@@ -605,7 +611,11 @@ async def update_oauth_token_scope(
         return RedirectResponse("/admin/oauth", status_code=303)
     token = await _assert_oauth_token_owner(session, token_id, user)
     if not token.revoked:
-        token.scope = scope
+        # Preserve the offline_access marker (informational only - see
+        # DEFAULT_CLIENT_SCOPE comment in src/oauth/routes.py) instead of
+        # dropping it whenever an admin flips read/readwrite here.
+        has_offline = "offline_access" in token.scope.split()
+        token.scope = f"{scope} offline_access" if has_offline else scope
         await session.commit()
     return RedirectResponse("/admin/oauth", status_code=303)
 

--- a/src/control_panel/templates/authorize.html
+++ b/src/control_panel/templates/authorize.html
@@ -234,7 +234,7 @@
                 <div class="scope-label">Grant access level</div>
 
                 <label class="scope-option">
-                    <input type="radio" name="scope" value="{{ read_scope }}" checked>
+                    <input type="radio" name="scope" value="{{ read_scope }}" {% if not requested_write %}checked{% endif %}>
                     <div>
                         <div class="scope-option-title">Read only</div>
                         <div class="scope-option-desc">Search and read notes. Cannot create or edit.</div>
@@ -243,7 +243,7 @@
 
                 {% if client_can_write %}
                 <label class="scope-option">
-                    <input type="radio" name="scope" value="{{ readwrite_scope }}">
+                    <input type="radio" name="scope" value="{{ readwrite_scope }}" {% if requested_write %}checked{% endif %}>
                     <div>
                         <div class="scope-option-title">Read + Write</div>
                         <div class="scope-option-desc">Full access: search, read, create, and edit notes.</div>

--- a/src/control_panel/templates/oauth.html
+++ b/src/control_panel/templates/oauth.html
@@ -68,8 +68,8 @@
                             <form method="POST" action="/admin/oauth/token/{{ token.id }}/scope" style="display:inline;">
                                 {% if csrf_token %}<input type="hidden" name="csrf_token" value="{{ csrf_token }}">{% endif %}
                                 <select name="scope" onchange="this.form.submit()" class="field-select" style="width:auto;padding:3px 28px 3px 8px;font-size:11px;">
-                                    <option value="read"      {% if token.scope == 'read'      %}selected{% endif %}>read</option>
-                                    <option value="readwrite" {% if token.scope == 'readwrite' %}selected{% endif %}>readwrite</option>
+                                    <option value="read"      {% if not token.has_write %}selected{% endif %}>read</option>
+                                    <option value="readwrite" {% if token.has_write     %}selected{% endif %}>readwrite</option>
                                 </select>
                             </form>
                             {% endif %}

--- a/src/oauth/routes.py
+++ b/src/oauth/routes.py
@@ -300,12 +300,20 @@ async def authorize_get(
     # consent screen only offers access levels the client can actually hold.
     client_can_write = "readwrite" in client.scope.split()
 
-    offline_access_requested = "offline_access" in scope.split()
+    scope_parts = scope.split()
+    offline_access_requested = "offline_access" in scope_parts
+    # Preselect whichever radio matches what the client actually asked for.
+    # Without this, the "Read only" option is checked unconditionally, so a
+    # client requesting scope=readwrite (e.g. because the user picked
+    # read-write access in the client's own connector settings) still gets
+    # a read-only grant unless the user manually re-clicks the other radio.
+    requested_write = "readwrite" in scope_parts and client_can_write
 
     response = templates.TemplateResponse(request, "authorize.html", {
         "client_name": client.client_name,
         "scope": scope,
         "client_can_write": client_can_write,
+        "requested_write": requested_write,
         "read_scope": "read offline_access" if offline_access_requested else "read",
         "readwrite_scope": "readwrite offline_access" if offline_access_requested else "readwrite",
         "client_id": client_id,

--- a/tests/test_authorize_get_scope_preselect.py
+++ b/tests/test_authorize_get_scope_preselect.py
@@ -1,0 +1,147 @@
+"""Regression test: the OAuth consent screen must preselect the radio that
+matches the scope the client actually requested at /authorize.
+
+Before this fix, `authorize.html` hardcoded `checked` on the "Read only"
+radio regardless of the `scope` query param. A client requesting
+`scope=readwrite` (e.g. because the end user picked read-write access in
+the client's own connector settings) still rendered "Read only"
+preselected, so approving without manually re-clicking the other radio
+silently granted a read-only token despite read-write having been
+requested.
+
+This does not touch the security boundary: `_clamp_scope` in
+authorize_post (covered by test_issue_21_registered_scope_enforced.py)
+still re-validates whatever the submitted form claims against the
+client's registered scope, independent of what's preselected here.
+"""
+import asyncio
+
+import pydantic_settings
+
+_orig_init = pydantic_settings.BaseSettings.__init__
+
+
+def _no_env_file_init(self, *args, **kwargs):
+    kwargs.setdefault("_env_file", None)
+    _orig_init(self, *args, **kwargs)
+
+
+pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+try:
+    import pytest
+
+    from src.oauth import routes
+finally:
+    pydantic_settings.BaseSettings.__init__ = _orig_init
+
+
+REGISTERED_URI = "https://client.example.com/callback"
+VALID_PKCE_CHALLENGE = "a" * 43
+
+
+class _FakeClient:
+    def __init__(self, scope, redirect_uris=(REGISTERED_URI,)):
+        self.client_id = "client123"
+        self.client_name = "Test Client"
+        self.scope = scope
+        self.redirect_uris = list(redirect_uris)
+
+
+class _FakeResult:
+    def __init__(self, obj):
+        self._obj = obj
+
+    def scalar_one_or_none(self):
+        return self._obj
+
+
+class _FakeSession:
+    def __init__(self, client):
+        self._client = client
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def execute(self, _stmt):
+        return _FakeResult(self._client)
+
+
+class _FakeRequest:
+    """Minimal stand-in: authorize_get only stores this on the Jinja2
+    context (`context.setdefault("request", request)`); the template
+    doesn't call `request.url_for` or read any attribute off it."""
+
+
+def _get(client, *, requested_scope):
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(routes.settings, "multi_user_mode", False, raising=False)
+        session = _FakeSession(client)
+        monkeypatch.setattr(routes, "async_session", lambda: session)
+        response = asyncio.run(
+            routes.authorize_get(
+                _FakeRequest(),
+                response_type="code",
+                client_id="client123",
+                redirect_uri=REGISTERED_URI,
+                code_challenge=VALID_PKCE_CHALLENGE,
+                code_challenge_method="S256",
+                scope=requested_scope,
+                state="",
+            )
+        )
+        return response
+    finally:
+        monkeypatch.undo()
+
+
+def _radio_checked(html: str, value: str) -> bool:
+    """True if the radio `<input ... value="{value}" ...>` carries `checked`."""
+    marker = f'value="{value}"'
+    idx = html.index(marker)
+    tag_end = html.index(">", idx)
+    return "checked" in html[idx:tag_end]
+
+
+def test_readwrite_request_preselects_readwrite_radio():
+    client = _FakeClient(scope="read readwrite offline_access")
+    response = _get(client, requested_scope="readwrite")
+    html = response.body.decode()
+
+    assert _radio_checked(html, "readwrite") is True
+    assert _radio_checked(html, "read") is False
+
+
+def test_read_request_preselects_read_radio():
+    client = _FakeClient(scope="read readwrite offline_access")
+    response = _get(client, requested_scope="read")
+    html = response.body.decode()
+
+    assert _radio_checked(html, "read") is True
+    assert _radio_checked(html, "readwrite") is False
+
+
+def test_readonly_client_ignores_readwrite_request_and_omits_the_option():
+    """A client not registered for readwrite can still send scope=readwrite
+    at /authorize (it's an attacker-controllable query param) - the consent
+    screen must neither preselect nor even offer an option it can't hold.
+    Enforcement still lives in `_clamp_scope`; this just keeps the UI from
+    implying an option the client was never registered for."""
+    client = _FakeClient(scope="read offline_access")
+    response = _get(client, requested_scope="readwrite")
+    html = response.body.decode()
+
+    assert 'value="readwrite"' not in html
+    assert _radio_checked(html, "read") is True
+
+
+def test_default_query_scope_preselects_read_radio():
+    client = _FakeClient(scope="read readwrite offline_access")
+    response = _get(client, requested_scope="read")  # matches the Query(...) default
+
+    html = response.body.decode()
+    assert _radio_checked(html, "read") is True
+    assert _radio_checked(html, "readwrite") is False

--- a/tests/test_oauth_panel_scope_display.py
+++ b/tests/test_oauth_panel_scope_display.py
@@ -1,0 +1,195 @@
+"""Regression test: the admin panel's OAuth token scope dropdown must
+reflect a token's actual granted permission, not just an exact string
+match against "read" / "readwrite".
+
+`OAuthToken.scope` is a space-separated set (e.g. "offline_access
+readwrite" - offline_access is requested by every DCR-registered client
+per DEFAULT_CLIENT_SCOPE in src/oauth/routes.py). oauth.html's <select>
+previously compared `token.scope == 'read'` / `== 'readwrite'` directly:
+neither literal ever matches a scope string that also carries
+offline_access, so NEITHER <option> got `selected` and the browser fell
+back to showing the first one, "read" - misrepresenting an actual
+readwrite grant as read-only in the UI. The real permission (checked by
+src/mcp_server/auth.py via `"readwrite" in scope_parts`) was correct the
+whole time; only the display was wrong.
+
+Fix: compute `has_write` (a membership check) in oauth_page and drive the
+template's `selected` attributes off that instead of raw string equality.
+Also verified: update_oauth_token_scope preserves the offline_access
+marker instead of silently dropping it when an admin flips read/readwrite
+via the panel.
+"""
+import asyncio
+import os
+
+import pydantic_settings
+
+_orig_init = pydantic_settings.BaseSettings.__init__
+
+
+def _no_env_file_init(self, *args, **kwargs):
+    kwargs.setdefault("_env_file", None)
+    _orig_init(self, *args, **kwargs)
+
+
+pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+try:
+    from starlette.templating import Jinja2Templates
+
+    from src.control_panel import routes
+finally:
+    pydantic_settings.BaseSettings.__init__ = _orig_init
+
+
+TEMPLATES_DIR = os.path.join(
+    os.path.dirname(routes.__file__), "templates"
+)
+
+
+def _render_oauth_page(tokens: list[dict]) -> str:
+    templates = Jinja2Templates(directory=TEMPLATES_DIR)
+    response = templates.TemplateResponse(
+        request=None,  # oauth.html never touches `request` directly
+        name="oauth.html",
+        context={
+            "active": "oauth",
+            "is_admin": True,
+            "multi_user_mode": False,
+            "username": "admin",
+            "csrf_token": "test-csrf-token",
+            "clients": [
+                {
+                    "client_id": "client123",
+                    "client_name": "Claude",
+                    "created_at": "2026-08-20T00:00:00Z",
+                    "tokens": tokens,
+                }
+            ],
+        },
+    )
+    return response.body.decode()
+
+
+def _base_token(**overrides) -> dict:
+    token = {
+        "id": 1,
+        "token_type": "access",
+        "scope": "offline_access readwrite",
+        "has_write": True,
+        "revoked": False,
+        "expired": False,
+        "expires_at": "2026-09-01T00:00:00Z",
+        "created_at": "2026-08-20T00:00:00Z",
+    }
+    token.update(overrides)
+    return token
+
+
+def _selected_option(html: str) -> str:
+    """Return the value= of whichever <option> in the scope <select> is selected."""
+    import re
+
+    for value in ("read", "readwrite"):
+        m = re.search(
+            rf'<option value="{value}"\s*[^>]*>',
+            html,
+        )
+        assert m, f"couldn't find <option value=\"{value}\"> at all"
+        if "selected" in m.group(0):
+            return value
+    return "NONE-SELECTED"
+
+
+def test_readwrite_token_with_offline_access_shows_readwrite_selected():
+    """The exact scenario that fooled the panel before this fix: a real
+    readwrite grant that also carries offline_access."""
+    html = _render_oauth_page([_base_token(scope="offline_access readwrite", has_write=True)])
+    assert _selected_option(html) == "readwrite"
+
+
+def test_read_token_with_offline_access_shows_read_selected():
+    html = _render_oauth_page([_base_token(scope="offline_access read", has_write=False)])
+    assert _selected_option(html) == "read"
+
+
+def test_bare_readwrite_token_shows_readwrite_selected():
+    html = _render_oauth_page([_base_token(scope="readwrite", has_write=True)])
+    assert _selected_option(html) == "readwrite"
+
+
+# --- oauth_page's has_write computation (the actual fix) ------------------
+
+
+def test_has_write_is_membership_not_equality():
+    assert ("readwrite" in "offline_access readwrite".split()) is True
+    assert ("readwrite" in "offline_access read".split()) is False
+    assert ("readwrite" in "read".split()) is False
+    assert ("readwrite" in "readwrite".split()) is True
+
+
+# --- update_oauth_token_scope preserves offline_access ---------------------
+
+
+class _FakeToken:
+    def __init__(self, scope, revoked=False, user_id=None):
+        self.id = 1
+        self.scope = scope
+        self.revoked = revoked
+        self.user_id = user_id
+
+
+class _FakeSession:
+    def __init__(self, token):
+        self._token = token
+        self.committed = False
+
+    async def execute(self, _stmt):
+        class _Result:
+            def __init__(self, obj):
+                self._obj = obj
+
+            def scalar_one_or_none(self):
+                return self._obj
+
+        return _Result(self._token)
+
+    async def commit(self):
+        self.committed = True
+
+
+class _SingleUserSentinel:
+    id = None
+    is_admin = True
+
+
+def test_update_scope_preserves_offline_access_marker():
+    token = _FakeToken(scope="offline_access readwrite")
+    session = _FakeSession(token)
+
+    asyncio.run(
+        routes.update_oauth_token_scope(
+            token_id=1,
+            scope="read",
+            session=session,
+            user=_SingleUserSentinel(),
+        )
+    )
+
+    assert token.scope == "read offline_access"
+    assert session.committed is True
+
+
+def test_update_scope_without_offline_access_stays_bare():
+    token = _FakeToken(scope="readwrite")
+    session = _FakeSession(token)
+
+    asyncio.run(
+        routes.update_oauth_token_scope(
+            token_id=1,
+            scope="read",
+            session=session,
+            user=_SingleUserSentinel(),
+        )
+    )
+
+    assert token.scope == "read"


### PR DESCRIPTION
## Summary

Follow-up to #21. That issue's dispute was resolved by clamping the
*submitted* consent-form scope to what the client registered for
(`_clamp_scope` in `authorize_post`) — correctly closing the
malicious-client escalation path. But the refuting verifier's own
argument for why the original exploit was impossible pointed at a real,
separate problem that never got fixed: the consent radio buttons are
hardcoded, with zero binding to the `scope` the client actually
requested at `/authorize`.

Concretely: `authorize.html`'s "Read only" radio has `checked`
unconditionally. A client requesting `scope=readwrite` (e.g. because the
end user picked read-write access in the client's own connector
settings, as claude.ai's OAuth UI lets you do) still renders the consent
screen with "Read only" preselected. If the user clicks Approve without
noticing they need to manually re-click the other radio, they get a
read-only grant despite having asked for read-write. Reproduced this
live against a running deployment via the real claude.ai OAuth flow.

While reproducing it, found a second, related bug: the admin panel's
OAuth token list (`/admin/oauth`) shows a scope `<select>` that compares
`token.scope == 'read'` / `== 'readwrite'` by exact string equality.
`OAuthToken.scope` is a space-separated set and virtually every token
also carries `offline_access` (every DCR-registered client requests it
per `DEFAULT_CLIENT_SCOPE`), so a real scope value like `"offline_access
readwrite"` matches neither literal. Neither `<option>` gets `selected`,
so the browser defaults to the first one, "read" — silently
misrepresenting an actual readwrite grant as read-only in the admin UI.
This is what made the first bug hard to diagnose: even after getting a
correct readwrite token, the panel appeared to disagree.

## Changes

- `authorize_get`: compute `requested_write` (gated on the client
  actually being registered for `readwrite`, so an unauthorized client
  still can't get the option preselected or even shown) and pass it to
  the template; `authorize.html` preselects the matching radio instead
  of hardcoding "Read only".
- `oauth_page`: compute `has_write` per token via scope-string
  membership instead of relying on the template to do exact-equality
  comparisons against a multi-value string; `oauth.html`'s `<select>`
  now selects off that.
- `update_oauth_token_scope`: preserves the `offline_access` marker
  instead of silently dropping it when an admin flips read/readwrite via
  the panel.

None of this touches the actual security enforcement
(`_clamp_scope` in `authorize_post`, or the `readwrite in scope_parts`
permission check in `mcp_server/auth.py`) — both fixes are strictly
about the UI reflecting reality, not about what's actually granted or
enforced.

## Test plan

- [x] New regression tests: `tests/test_authorize_get_scope_preselect.py`
      (renders the real `authorize.html` via `Jinja2Templates` and
      asserts the correct radio is preselected for various
      requested-scope / client-registered-scope combinations, including
      the case where a client isn't registered for readwrite at all)
      and `tests/test_oauth_panel_scope_display.py` (renders the real
      `oauth.html` and asserts the `<select>` reflects a token's actual
      permission, plus coverage for the `offline_access`-preserving
      update endpoint).
- [x] Full existing suite passes locally (278 passed, 5 pre-existing
      skips), including `test_issue_21_registered_scope_enforced.py`
      unchanged and still green — confirms `_clamp_scope` enforcement is
      untouched.
- [x] Live-reproduced and live-verified end-to-end against a running
      deployment: disconnected/reconnected the real claude.ai OAuth
      connector requesting read-write, confirmed via direct DB
      inspection that the issued token's scope is `"offline_access
      readwrite"` post-fix (was silently downgraded to read-only
      pre-fix), and confirmed the admin panel now displays it correctly
      instead of showing "read".

🤖 Generated with [Claude Code](https://claude.com/claude-code)