### PR TITLE
Panel fixes: vault error, self-edit lock, key liveness, indexer heartbeat (#70 #69 #76 #78)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,18 @@ nothing about the migration body.
   It logs and swallows ordinary failures (the indexer's `consecutive_failures`
   must not react to it) but **re-raises `CancelledError`** so lifespan shutdown
   still stops the loop.
+- **The dashboard's "Last run" is an in-process heartbeat, not
+  `max(notes_metadata.indexed_at)`.** `indexer.last_index_run_at` /
+  `last_index_run_ok` are stamped at the end of the startup pass and of every
+  periodic tick (`False` in the `except Exception` branch; `CancelledError` is
+  a `BaseException` so shutdown is not recorded as a failure). `indexed_at`
+  only moves for notes a pass actually upserted or moved, so a pass over an
+  unchanged vault writes it nowhere and a healthy indexer looked stalled for
+  days on an idle vault — an invitation to reach for the Danger zone and
+  re-embed the whole vault for nothing (#78). `max(indexed_at)` is still shown,
+  under its own label "Last change detected". No migration and no per-tick
+  write: it answers "is *this process's* loop alive", which is a property of
+  the process, and it resets to `None` on restart until the startup pass lands.
 - **Because the pre-warm holds `index_pass_lock`, the panel's destructive
   actions take it too.** `reset_embeddings` and `trigger_reembed` set
   `indexer_paused`, then `await session.close()` on the request's own session
@@ -344,6 +356,14 @@ plan there, so it is recorded, not asserted).
 no embedding call). A single whole-call `duration_ms` could not separate the
 two independent cold paths — provider eviction and HNSW page cache — so the
 last regression had to be diagnosed with hand-run probes against the live DB.
+
+**`usage_logs.tool` must hold the name the tool is registered under.**
+`_tracked`'s first argument is that name, and FastMCP takes it from the
+function name in `server.py` — so `search_notes_impl` is logged as
+`keyword_search`, not `search_notes`, which named a tool no client is ever
+offered and made `WHERE tool = 'keyword_search'` return nothing (#78). Rows
+written before that fix keep the old spelling, which is why `_usage_detail` in
+`src/control_panel/routes.py` still lists it alongside the current one.
 
 The holder is a `ContextVar` in `src/services/timing.py`, **owned by
 `_tracked`**: fresh dict at call start, cleared in `finally`. The ContextVar

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,6 +250,17 @@ nothing about the migration body.
   also NULLs `notes_metadata.embedded_content_hash` in the same transaction as
   the `DELETE`: `embed_vault` selects on hash mismatch, so deleting vectors
   alone meant the reindex it spawns re-embedded nothing.
+- **Every panel handler that can change `users.is_admin` / `users.is_active`
+  takes `_lock_admin_guard(session)` before counting the remaining admins**
+  (`src/control_panel/users.py` — `edit_user_submit` and `delete_user`, one
+  shared `pg_advisory_xact_lock` key). The last-admin guard is a count
+  followed by a write; without the lock two admins demoting each other
+  concurrently both read "one other admin remains", both pass, and the panel
+  is left with zero admins and no way back in through the UI. The lock is
+  transaction-scoped, so **never commit between taking it and writing the
+  flags** — that is what makes the check-then-act atomic. A new handler that
+  flips either flag must take it too, and use the *same* constant: two keys
+  do not exclude each other.
 - Wikilink graph extracted from note bodies into `note_links`; resolved at index time with same-folder-first preference
 - `MCP_SANDBOX_MODE=true` is a registry-eval-only switch: lifespan skips `_check_embedding_dim` and the indexer, and `APIKeyMiddleware` bypasses auth on `/mcp/*`. Lets Glama's sandbox build the image and validate MCP introspection without external deps. Never enable in production — tools register but cannot run.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,7 +260,13 @@ nothing about the migration body.
   transaction-scoped, so **never commit between taking it and writing the
   flags** — that is what makes the check-then-act atomic. A new handler that
   flips either flag must take it too, and use the *same* constant: two keys
-  do not exclude each other.
+  do not exclude each other. **Immediately after the lock, both handlers
+  re-read the acting admin's own `is_admin`/`is_active`
+  (`_actor_still_privileged`) and refuse unless both are exactly True** —
+  `require_admin_panel` authorised the request before the lock was requested,
+  and the wait for that lock is precisely the window in which another admin's
+  demotion of *this* actor commits; serializing the writes is no use if the
+  loser of the race then performs the mutation anyway.
 - Wikilink graph extracted from note bodies into `note_links`; resolved at index time with same-folder-first preference
 - `MCP_SANDBOX_MODE=true` is a registry-eval-only switch: lifespan skips `_check_embedding_dim` and the indexer, and `APIKeyMiddleware` bypasses auth on `/mcp/*`. Lets Glama's sandbox build the image and validate MCP introspection without external deps. Never enable in production — tools register but cannot run.
 

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -321,6 +321,8 @@ async def dashboard(
     def _usage_detail(tool: str, params: dict | None) -> str | None:
         if not params:
             return None
+        # "search_notes" is the legacy spelling `keyword_search` was logged
+        # under before #78; historical rows keep it, so it stays here.
         if tool in ("search_notes", "keyword_search", "semantic_search"):
             return params.get("query")
         if tool in ("read_note", "create_note", "edit_note"):
@@ -338,7 +340,19 @@ async def dashboard(
     ]
 
     graph = await _graph_stats(session, uid)
+    # Imported at call time so the values are read fresh each request (module
+    # attributes, not a snapshot taken at import).
+    from src.services import indexer as _indexer
     from src.services.indexer import link_backfill_in_progress
+
+    # "Last run" is the indexer's own heartbeat, not `max(indexed_at)`.
+    # `notes_metadata.indexed_at` only moves for notes a pass actually
+    # upserted or moved, so on an idle vault a perfectly healthy indexer
+    # looked stalled for days (#78). It is process-wide (the loop is), so it
+    # is not scoped by `uid` the way the note aggregates are — that is a fact
+    # about the server, and every panel user sees the same one.
+    last_run_at = _indexer.last_index_run_at
+    last_run_ok = _indexer.last_index_run_ok
 
     return templates.TemplateResponse(request, "dashboard.html", _panel_context(request, user, {
         "active": "dashboard",
@@ -353,6 +367,9 @@ async def dashboard(
         "reindexed_24h": reindexed_24h,
         "last_indexed_iso": last_indexed_at.isoformat() if last_indexed_at else None,
         "last_indexed_rel": _humanize_delta(last_indexed_at),
+        "last_run_iso": last_run_at.isoformat() if last_run_at else None,
+        "last_run_rel": _humanize_delta(last_run_at),
+        "last_run_ok": last_run_ok,
         "index_interval": settings.index_interval_seconds,
         "graph": graph,
         "graph_backfill_running": link_backfill_in_progress,

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -369,18 +369,38 @@ async def keys_page(
     user=Depends(require_user_panel),
 ):
     uid = _scope_user_id(user)
-    q = select(APIKey).order_by(APIKey.created_at.desc())
+    # Join the owner. A key's *effective* liveness is what `APIKeyMiddleware`
+    # enforces, and that is stricter than `api_keys.is_active` alone:
+    # `src/mcp_server/auth.py` also selects `User.is_active` for the key's
+    # `user_id` and 401s (reason=inactive_user) unless it is exactly True.
+    # Deactivating a user leaves their keys' own `is_active` untouched, so
+    # without this join the panel badged dead credentials green (#76). The
+    # outer join keeps single-user keys (`user_id IS NULL`), which the
+    # middleware exempts from the owner check entirely.
+    q = (
+        select(APIKey, User.username, User.is_active)
+        .select_from(APIKey)
+        .outerjoin(User, User.id == APIKey.user_id)
+        .order_by(APIKey.created_at.desc())
+    )
     if uid is not None:
         q = q.where(APIKey.user_id == uid)
     result = await session.execute(q)
     keys = []
-    for k in result.scalars().all():
+    for k, owner_username, owner_is_active in result.all():
+        # A key whose `user_id` has no row (owner_is_active is None) is dead
+        # too — the middleware's `is True` test fails for it just the same,
+        # so it must not read as live here.
+        owner_ok = k.user_id is None or owner_is_active is True
         keys.append({
             "id": k.id,
             "name": k.name,
             "key_prefix": k.key_prefix,
             "permission": k.permission,
             "is_active": k.is_active,
+            "owner_is_active": owner_ok,
+            "effective_active": bool(k.is_active) and owner_ok,
+            "owner_username": owner_username,
             "created_at": k.created_at.isoformat(),
             "last_used_at": k.last_used_at.isoformat() if k.last_used_at else None,
             "user_id": k.user_id,

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -403,12 +403,23 @@ async def keys_page(
     if uid is not None:
         q = q.where(APIKey.user_id == uid)
     result = await session.execute(q)
+    # One `now` for the whole page: rows compared against different instants
+    # could render two keys with the same `expires_at` differently.
+    now = datetime.now(timezone.utc)
     keys = []
     for k, owner_username, owner_is_active in result.all():
         # A key whose `user_id` has no row (owner_is_active is None) is dead
         # too — the middleware's `is True` test fails for it just the same,
         # so it must not read as live here.
         owner_ok = k.user_id is None or owner_is_active is True
+        # Expiry, phrased exactly as `APIKeyMiddleware` phrases it:
+        # `if api_key.expires_at and api_key.expires_at < now: 401`. So a key
+        # is *not* expired at exactly `expires_at` — the boundary instant is
+        # still live — and this comparison must keep matching that one rather
+        # than a plausible-looking `>=` of its own. Nothing in the codebase
+        # sets `expires_at` today, but the panel must not be the surface that
+        # goes stale the day something does.
+        expired = k.expires_at is not None and k.expires_at < now
         keys.append({
             "id": k.id,
             "name": k.name,
@@ -416,7 +427,9 @@ async def keys_page(
             "permission": k.permission,
             "is_active": k.is_active,
             "owner_is_active": owner_ok,
-            "effective_active": bool(k.is_active) and owner_ok,
+            "is_expired": expired,
+            "expires_at": k.expires_at.isoformat() if k.expires_at else None,
+            "effective_active": bool(k.is_active) and owner_ok and not expired,
             "owner_username": owner_username,
             "created_at": k.created_at.isoformat(),
             "last_used_at": k.last_used_at.isoformat() if k.last_used_at else None,

--- a/src/control_panel/templates/dashboard.html
+++ b/src/control_panel/templates/dashboard.html
@@ -6,8 +6,10 @@
     <div>
         <h1 class="page-title">Dashboard</h1>
         <div style="font-size:13px;color:var(--text-3);margin-top:8px;">
-            Last indexed
-            <span style="color:var(--text-2);font-weight:500;">{{ last_indexed_rel }}</span>
+            Indexer last ran
+            <span style="color:var(--text-2);font-weight:500;">{{ last_run_rel }}</span>
+            {% if last_run_ok is false %}<span class="badge badge-yellow" style="margin-left:6px;">last pass failed</span>{% endif %}
+            <span style="opacity:0.75;">· last change detected {{ last_indexed_rel }}</span>
         </div>
     </div>
     <div class="page-actions">
@@ -100,7 +102,7 @@
         <div class="card anim-3">
             <div class="card-header">
                 <span class="card-title">Indexer</span>
-                <span class="mono" style="font-size:11px;color:var(--text-3);">{{ last_indexed_rel }}</span>
+                <span class="mono" style="font-size:11px;color:var(--text-3);">{{ last_run_rel }}</span>
             </div>
             <div class="card-body">
                 <div style="display:flex;align-items:flex-end;gap:12px;padding:4px 0 22px;flex-wrap:wrap;">
@@ -111,7 +113,14 @@
                     </div>
                 </div>
                 <div class="kv" style="padding:12px 0;border-top:1px solid var(--border);">
-                    <span class="kv-k">Last run</span>
+                    <span class="kv-k" title="When the indexer last completed a pass, whether or not anything had changed.">Last run</span>
+                    <span class="kv-v mono" style="font-size:12px;">
+                        {% if last_run_iso %}<time datetime="{{ last_run_iso }}" data-localize>{{ last_run_iso }}</time>{% else %}Never{% endif %}
+                        {% if last_run_ok is false %}<span class="badge badge-yellow" style="margin-left:6px;">failed</span>{% endif %}
+                    </span>
+                </div>
+                <div class="kv" style="padding:12px 0;border-top:1px solid var(--border);">
+                    <span class="kv-k" title="The newest indexed_at on any note — i.e. the last time a pass found a change to write. Older than 'Last run' just means the vault has been quiet.">Last change detected</span>
                     <span class="kv-v mono" style="font-size:12px;">
                         {% if last_indexed_iso %}<time datetime="{{ last_indexed_iso }}" data-localize>{{ last_indexed_iso }}</time>{% else %}Never{% endif %}
                     </span>

--- a/src/control_panel/templates/keys.html
+++ b/src/control_panel/templates/keys.html
@@ -70,10 +70,14 @@
                     <td>
                         {% if not key.is_active %}
                         <span class="badge badge-red">Revoked</span>
+                        {% elif not key.owner_is_active %}
+                        {# Owner before expiry: `auth.py` checks the owner's
+                           is_active first and 401s there, so a key that is
+                           both should name the reason the middleware would
+                           actually give. #}
+                        <span class="badge badge-yellow" title="The key itself is live, but its owner is deactivated — the MCP server rejects it with 401 inactive_user.">Owner inactive</span>
                         {% elif key.is_expired %}
                         <span class="badge badge-red" title="Past its expires_at — the MCP server rejects it with 401 key_expired.">Expired</span>
-                        {% elif not key.owner_is_active %}
-                        <span class="badge badge-yellow" title="The key itself is live, but its owner is deactivated — the MCP server rejects it with 401 inactive_user.">Owner inactive</span>
                         {% else %}
                         <span class="badge badge-green">Active</span>
                         {% endif %}

--- a/src/control_panel/templates/keys.html
+++ b/src/control_panel/templates/keys.html
@@ -70,6 +70,8 @@
                     <td>
                         {% if not key.is_active %}
                         <span class="badge badge-red">Revoked</span>
+                        {% elif key.is_expired %}
+                        <span class="badge badge-red" title="Past its expires_at — the MCP server rejects it with 401 key_expired.">Expired</span>
                         {% elif not key.owner_is_active %}
                         <span class="badge badge-yellow" title="The key itself is live, but its owner is deactivated — the MCP server rejects it with 401 inactive_user.">Owner inactive</span>
                         {% else %}

--- a/src/control_panel/templates/keys.html
+++ b/src/control_panel/templates/keys.html
@@ -41,6 +41,7 @@
             <thead>
                 <tr>
                     <th>Name</th>
+                    {% if multi_user_mode %}<th>Owner</th>{% endif %}
                     <th>Prefix</th>
                     <th>Permission</th>
                     <th>Status</th>
@@ -53,6 +54,11 @@
                 {% for key in keys %}
                 <tr>
                     <td style="color:var(--text);font-weight:500;">{{ key.name }}</td>
+                    {% if multi_user_mode %}
+                    <td style="font-size:12px;color:var(--text-2);">
+                        {% if key.owner_username %}{{ key.owner_username }}{% else %}<span style="color:var(--text-3);">—</span>{% endif %}
+                    </td>
+                    {% endif %}
                     <td class="mono" style="color:var(--text-2);">{{ key.key_prefix }}···</td>
                     <td>
                         {% if key.permission == 'readwrite' %}
@@ -62,10 +68,12 @@
                         {% endif %}
                     </td>
                     <td>
-                        {% if key.is_active %}
-                        <span class="badge badge-green">Active</span>
-                        {% else %}
+                        {% if not key.is_active %}
                         <span class="badge badge-red">Revoked</span>
+                        {% elif not key.owner_is_active %}
+                        <span class="badge badge-yellow" title="The key itself is live, but its owner is deactivated — the MCP server rejects it with 401 inactive_user.">Owner inactive</span>
+                        {% else %}
+                        <span class="badge badge-green">Active</span>
                         {% endif %}
                     </td>
                     <td class="mono" style="font-size:11px;color:var(--text-2);">
@@ -91,7 +99,7 @@
                 {% endfor %}
                 {% if not keys %}
                 <tr>
-                    <td colspan="7" style="text-align:center;padding:32px;color:var(--text-3);">No API keys yet.</td>
+                    <td colspan="{{ 8 if multi_user_mode else 7 }}" style="text-align:center;padding:32px;color:var(--text-3);">No API keys yet.</td>
                 </tr>
                 {% endif %}
             </tbody>

--- a/src/control_panel/templates/user_edit.html
+++ b/src/control_panel/templates/user_edit.html
@@ -49,6 +49,7 @@
                     </div>
                     <div class="field" style="display:flex;align-items:center;gap:10px;">
                         <input type="checkbox" name="is_admin" id="is_admin" {% if target.is_admin %}checked{% endif %}
+                               {% if is_self %}disabled{% endif %}
                                style="width:18px;height:18px;accent-color:var(--primary);">
                         <label for="is_admin" style="font-size:14px;color:var(--text);cursor:pointer;">
                             Admin
@@ -59,6 +60,7 @@
                     </div>
                     <div class="field" style="display:flex;align-items:center;gap:10px;">
                         <input type="checkbox" name="is_active" id="is_active" {% if target.is_active %}checked{% endif %}
+                               {% if is_self %}disabled{% endif %}
                                style="width:18px;height:18px;accent-color:var(--primary);">
                         <label for="is_active" style="font-size:14px;color:var(--text);cursor:pointer;">
                             Active
@@ -69,7 +71,10 @@
                     </div>
                     {% if is_self %}
                     <div class="alert alert-warning" style="margin-top:8px;font-size:12px;">
-                        This is your own account — you can't remove your own admin role or deactivate yourself here.
+                        This is your own account — you can't remove your own admin role or
+                        deactivate yourself here. Both toggles are locked, and the server
+                        refuses the change even if the form is bypassed. Another admin can
+                        do it from this page.
                     </div>
                     {% endif %}
                     <div style="display:flex;gap:10px;margin-top:18px;">

--- a/src/control_panel/templates/users.html
+++ b/src/control_panel/templates/users.html
@@ -60,7 +60,10 @@
                     <td class="mono" style="font-size:11px;color:var(--text-2);max-width:280px;overflow:hidden;text-overflow:ellipsis;">
                         {% if u.vault_path %}{{ u.vault_path }}{% else %}<span style="color:var(--warning);">(unassigned)</span>{% endif %}
                     </td>
-                    <td class="mono" style="font-size:11px;color:var(--text-2);">{{ u.api_keys }}</td>
+                    <td class="mono" style="font-size:11px;color:var(--text-2);"
+                        title="Revoked keys are kept for the audit trail; only active ones can authenticate.">
+                        {{ u.api_keys_active }} active / {{ u.api_keys_total }} total
+                    </td>
                     <td class="mono" style="font-size:11px;color:var(--text-2);">{{ u.notes }}</td>
                     <td class="mono" style="font-size:11px;color:var(--text-2);">
                         {% if u.last_login_at %}<time datetime="{{ u.last_login_at }}" data-localize>{{ u.last_login_at }}</time>{% else %}—{% endif %}

--- a/src/control_panel/templates/vault.html
+++ b/src/control_panel/templates/vault.html
@@ -17,6 +17,17 @@
 </div>
 
 <div class="page-body">
+
+    {% if vault_error %}
+    <div class="alert alert-warning anim-1">
+        <strong>No vault is assigned to your account.</strong>
+        This page is empty because of that, not because your vault is —
+        nothing below reflects any real folder. Note and search tools over
+        MCP fail for the same reason. Ask an admin to assign a vault path to
+        your account (Users → your account → Vault Path).
+    </div>
+    {% endif %}
+
     <div class="vault-grid">
 
         <!-- File tree -->

--- a/src/control_panel/users.py
+++ b/src/control_panel/users.py
@@ -134,6 +134,39 @@ async def _lock_admin_guard(session: AsyncSession) -> None:
     )
 
 
+async def _actor_still_privileged(
+    session: AsyncSession, user: User | _SingleUserSentinel
+) -> bool:
+    """Re-read the acting admin's own flags *inside* the critical section.
+
+    `require_admin_panel` authorised this request before the advisory lock
+    was even requested, and waiting for that lock is exactly the window in
+    which another admin's demotion or deactivation of *this* actor commits.
+    Trusting the `User` loaded by the dependency would let a just-demoted
+    account perform the privileged mutation it queued for — the guard would
+    serialize the writes correctly and still let the wrong one through.
+
+    Single-user mode has no `users` row to re-read (the sentinel's `id` is
+    None); there is also no second admin who could have demoted anyone, so
+    the sentinel is simply still privileged.
+    """
+    if not isinstance(user, User):
+        return True
+    row = (
+        await session.execute(
+            select(User.is_admin, User.is_active).where(User.id == user.id)
+        )
+    ).one_or_none()
+    # A deleted actor (row is None) is not privileged either.
+    return row is not None and row.is_admin is True and row.is_active is True
+
+
+_ACTOR_REVOKED_MSG = (
+    "Your account's admin access changed while that request was in flight — "
+    "nothing was saved. Sign in again."
+)
+
+
 # --- Routes ---------------------------------------------------------------
 
 
@@ -313,6 +346,9 @@ async def edit_user_submit(
     # decides on — including `target`'s own flags, which a concurrent edit
     # could otherwise change between this read and our write.
     await _lock_admin_guard(session)
+    if not await _actor_still_privileged(session, user):
+        await session.rollback()
+        return _back_to_list_with_error(_ACTOR_REVOKED_MSG)
     result = await session.execute(select(User).where(User.id == user_id))
     target = result.scalar_one_or_none()
     if target is None:
@@ -434,6 +470,9 @@ async def delete_user(
     # each remove the other's "remaining admin", so they must exclude each
     # other, not just their own kind.
     await _lock_admin_guard(session)
+    if not await _actor_still_privileged(session, user):
+        await session.rollback()
+        return _back_to_list_with_error(_ACTOR_REVOKED_MSG)
     result = await session.execute(select(User).where(User.id == user_id))
     target = result.scalar_one_or_none()
     if target is None:

--- a/src/control_panel/users.py
+++ b/src/control_panel/users.py
@@ -267,8 +267,42 @@ async def edit_user_submit(
     if target is None:
         raise HTTPException(404, "User not found")
 
-    new_admin = is_admin == "on" or is_admin == "true" or is_admin == "1"
-    new_active = is_active == "on" or is_active == "true" or is_active == "1"
+    def _checked(raw: str) -> bool:
+        return raw in ("on", "true", "1")
+
+    new_admin = _checked(is_admin)
+    new_active = _checked(is_active)
+
+    is_self = isinstance(user, User) and user.id == target.id
+
+    # A self-edit can never change your own role or active flag (#69).
+    # user_edit.html states that as an unconditional promise and renders
+    # both checkboxes `disabled`; the handler is what makes the promise
+    # true, and it must hold for a hand-crafted POST too — the previous
+    # rule ("unless you are the last active admin") let an admin with a
+    # colleague demote or deactivate themselves out of the panel in one
+    # click, with the alert actively encouraging the belief that the
+    # toggle was inert.
+    #
+    # A `disabled` checkbox is not submitted at all, so an *absent* field
+    # on a self-edit means "unchanged", never "unchecked" — reading it as
+    # unchecked would demote the operator on every save. A field that is
+    # present and asks to strip the role or the active flag is refused
+    # outright rather than silently ignored, so a scripted caller gets a
+    # reason instead of a no-op.
+    if is_self:
+        if is_admin != "" and target.is_admin and not new_admin:
+            return _back_with_error(
+                user_id,
+                "You can't remove your own admin role. Ask another admin to do it.",
+            )
+        if is_active != "" and target.is_active and not new_active:
+            return _back_with_error(
+                user_id,
+                "You can't deactivate your own account. Ask another admin to do it.",
+            )
+        new_admin = target.is_admin
+        new_active = target.is_active
 
     # Defense: never let the last active admin be demoted or deactivated.
     # This covers both "max demotes himself" and "max demotes bob" — the
@@ -284,7 +318,9 @@ async def edit_user_submit(
             )
         )).scalar() or 0
         if remaining_admins == 0:
-            if isinstance(user, User) and target.id == user.id:
+            # Unreachable for a self-edit since the block above pins your own
+            # flags; kept as a backstop if that guard is ever relaxed.
+            if is_self:
                 return _back_with_error(
                     user_id,
                     "Refusing to remove the last admin (yourself). Promote another user to admin first.",

--- a/src/control_panel/users.py
+++ b/src/control_panel/users.py
@@ -30,7 +30,7 @@ from typing import Any
 from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -103,6 +103,35 @@ def _list_available_vaults() -> list[str]:
 
 
 _USERNAME_RE = __import__("re").compile(r"^[a-z0-9_]{1,64}$")
+
+
+# Every handler that can change a `users.is_admin` / `users.is_active` flag
+# takes this one advisory lock before it counts the remaining active admins.
+# The count and the write are otherwise two statements in separate
+# transactions with nothing between them: two admins demoting each other at
+# the same moment both read "1 other active admin remains", both pass the
+# guard, and the panel ends up with zero admins and no way back in through
+# the UI. The lock is transaction-scoped (`pg_advisory_xact_lock`), so it is
+# released by the commit or the rollback — there is no unlock path to forget,
+# and a crashed backend cannot strand it.
+#
+# The value is arbitrary but must never change: it is the *name* of the
+# critical section, and two builds using different constants would not
+# exclude each other during a rolling restart.
+_ADMIN_GUARD_LOCK_KEY = 7_842_119_530_461_007
+
+
+async def _lock_admin_guard(session: AsyncSession) -> None:
+    """Enter the "who may be an admin" critical section.
+
+    Must be taken *before* reading the admin count and released only by the
+    same transaction that writes the flags — i.e. never commit between this
+    and the write.
+    """
+    await session.execute(
+        text("SELECT pg_advisory_xact_lock(:key)"),
+        {"key": _ADMIN_GUARD_LOCK_KEY},
+    )
 
 
 # --- Routes ---------------------------------------------------------------
@@ -267,8 +296,11 @@ async def edit_user_submit(
     user_id: int,
     vault_path: str = Form(""),
     vault_path_custom: str = Form(""),
-    is_admin: str = Form(""),
-    is_active: str = Form(""),
+    # `None` means the field was **absent** from the submission; "" means it
+    # was present and empty. A disabled checkbox sends nothing at all, so
+    # only `None` may be read as "unchanged" — see the self-edit block below.
+    is_admin: str | None = Form(None),
+    is_active: str | None = Form(None),
     session: AsyncSession = Depends(get_session),
     user: User | _SingleUserSentinel = Depends(require_admin_panel),
 ):
@@ -277,12 +309,16 @@ async def edit_user_submit(
     # the actual path in `vault_path_custom`. Reconcile here.
     if vault_path == "__custom__":
         vault_path = vault_path_custom
+    # Enter the admin critical section before reading anything the guard
+    # decides on — including `target`'s own flags, which a concurrent edit
+    # could otherwise change between this read and our write.
+    await _lock_admin_guard(session)
     result = await session.execute(select(User).where(User.id == user_id))
     target = result.scalar_one_or_none()
     if target is None:
         raise HTTPException(404, "User not found")
 
-    def _checked(raw: str) -> bool:
+    def _checked(raw: str | None) -> bool:
         return raw in ("on", "true", "1")
 
     new_admin = _checked(is_admin)
@@ -299,19 +335,21 @@ async def edit_user_submit(
     # click, with the alert actively encouraging the belief that the
     # toggle was inert.
     #
-    # A `disabled` checkbox is not submitted at all, so an *absent* field
-    # on a self-edit means "unchanged", never "unchecked" — reading it as
-    # unchecked would demote the operator on every save. A field that is
-    # present and asks to strip the role or the active flag is refused
-    # outright rather than silently ignored, so a scripted caller gets a
-    # reason instead of a no-op.
+    # A `disabled` checkbox is not submitted at all, so an **absent** field
+    # (`None`) on a self-edit means "unchanged", never "unchecked" — reading
+    # it as unchecked would demote the operator on every save. Anything the
+    # caller actually *sent* is an intent, and one that would strip the role
+    # or the active flag is refused outright rather than silently ignored:
+    # that includes a present-but-empty `is_admin=` (a hand-built POST, or a
+    # form that lost its value), which must not slip through the same door as
+    # a genuinely absent field.
     if is_self:
-        if is_admin != "" and target.is_admin and not new_admin:
+        if is_admin is not None and target.is_admin and not new_admin:
             return _back_with_error(
                 user_id,
                 "You can't remove your own admin role. Ask another admin to do it.",
             )
-        if is_active != "" and target.is_active and not new_active:
+        if is_active is not None and target.is_active and not new_active:
             return _back_with_error(
                 user_id,
                 "You can't deactivate your own account. Ask another admin to do it.",
@@ -392,6 +430,10 @@ async def delete_user(
     """
     permanent = request.query_params.get("permanent") == "true"
 
+    # Same critical section as `edit_user_submit` — a delete and an edit can
+    # each remove the other's "remaining admin", so they must exclude each
+    # other, not just their own kind.
+    await _lock_admin_guard(session)
     result = await session.execute(select(User).where(User.id == user_id))
     target = result.scalar_one_or_none()
     if target is None:

--- a/src/control_panel/users.py
+++ b/src/control_panel/users.py
@@ -115,11 +115,25 @@ async def list_users(
     user: User | _SingleUserSentinel = Depends(require_admin_panel),
 ):
     # Aggregate per-user counts (api_keys + notes) in one query each.
+    #
+    # Keys are counted twice: total, and the `is_active` subset. Revocation
+    # sets `is_active = False` without deleting the row (routes.py's
+    # `revoke_key`), and `src/mcp_server/auth.py` authenticates only active
+    # rows — so a bare `count(*)` told an auditing admin "bob — API Keys: 4"
+    # when all four were revoked, and the panel had no surface anywhere on
+    # which to discover that (#76). Rendering "N active / M total" states
+    # both numbers instead of picking one and leaving the ambiguity.
     key_counts = dict(
-        (row.user_id, int(row.cnt))
+        (row.user_id, (int(row.active), int(row.total)))
         for row in (
             await session.execute(
-                select(APIKey.user_id, func.count(APIKey.id).label("cnt"))
+                select(
+                    APIKey.user_id,
+                    func.count(APIKey.id).label("total"),
+                    func.count(APIKey.id)
+                    .filter(APIKey.is_active.is_(True))
+                    .label("active"),
+                )
                 .group_by(APIKey.user_id)
             )
         ).all()
@@ -145,7 +159,8 @@ async def list_users(
             "vault_path": u.vault_path,
             "last_login_at": u.last_login_at.isoformat() if u.last_login_at else None,
             "created_at": u.created_at.isoformat(),
-            "api_keys": key_counts.get(u.id, 0),
+            "api_keys_active": key_counts.get(u.id, (0, 0))[0],
+            "api_keys_total": key_counts.get(u.id, (0, 0))[1],
             "notes": note_counts.get(u.id, 0),
         })
 

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -157,7 +157,11 @@ def _tracked(tool_name: str, param_keys: list[str], transforms: dict | None = No
     return decorator
 
 
-@_tracked("search_notes", ["query", "folder", "limit", "tags", "frontmatter"])
+# The tool this impl backs is registered as `keyword_search` (server.py takes
+# the function name), so that is what `usage_logs.tool` must record — the old
+# "search_notes" named a tool no client was ever offered, which made the audit
+# trail unsearchable in both directions (#78).
+@_tracked("keyword_search", ["query", "folder", "limit", "tags", "frontmatter"])
 async def search_notes_impl(
     query: str,
     folder: str | None = None,

--- a/src/services/indexer.py
+++ b/src/services/indexer.py
@@ -933,16 +933,28 @@ async def prewarm_search_caches() -> None:
         )
 
 
-async def _index_pass_once(user_id: int | None) -> None:
-    """One full index + embed pass for a single user (or single-user mode)."""
+async def _index_pass_once(user_id: int | None) -> bool:
+    """One full index + embed pass for a single user (or single-user mode).
+
+    Returns True only if both stages completed. Failures are swallowed per
+    stage so one user's broken vault cannot stop every other user's pass, but
+    the caller has to *know* they happened: a tick that logged two failures
+    must not stamp the heartbeat as a healthy run (#78). Swallowing and
+    returning True is exactly the "reports fine, is not" defect the heartbeat
+    exists to remove.
+    """
+    ok = True
     try:
         await index_vault(user_id=user_id)
     except Exception as e:
+        ok = False
         logger.error(f"Index failed (user_id={user_id}): {e}")
     try:
         await embed_vault(user_id=user_id)
     except Exception as e:
+        ok = False
         logger.error(f"Embedding failed (user_id={user_id}): {e}")
+    return ok
 
 
 async def run_indexer_loop():
@@ -1020,12 +1032,16 @@ async def run_indexer_loop():
             # Hold `index_pass_lock` for the whole index/embed pass so a
             # concurrent panel-triggered `_reindex_background` cannot run a
             # second index_vault/embed_vault over the same scope.
+            tick_ok = True
             async with index_pass_lock:
                 if settings.multi_user_mode:
                     # Re-fetch the user list every cycle so newly-added or
                     # newly-deactivated users are picked up without a restart.
+                    # One user's failure does not abort the others, but it
+                    # does make the whole tick a failed run.
                     for uid in await _active_user_ids():
-                        await _index_pass_once(uid)
+                        if not await _index_pass_once(uid):
+                            tick_ok = False
                 else:
                     await index_vault()
                     await embed_vault()
@@ -1037,8 +1053,11 @@ async def run_indexer_loop():
             await cleanup_expired_tokens()
             consecutive_failures = 0
             # Heartbeat: the tick completed. Recorded whether or not the pass
-            # found anything to index — that is the whole point (#78).
-            _record_index_run(True)
+            # found anything to index — that is the whole point (#78) — but
+            # `tick_ok` is False if any per-user pass swallowed an exception,
+            # so a multi-user tick that failed for every user is not stamped
+            # healthy just because the loop itself survived.
+            _record_index_run(tick_ok)
         except Exception as e:
             consecutive_failures += 1
             # A tick that raised still *ran*; the dashboard says so and marks

--- a/src/services/indexer.py
+++ b/src/services/indexer.py
@@ -27,6 +27,28 @@ from src.services.vault import (
 # progress" while the one-shot backfill is running.
 link_backfill_in_progress: bool = False
 
+# In-process heartbeat for the indexer: when a pass last *finished*, and
+# whether it finished cleanly. The dashboard used to infer this from
+# `max(notes_metadata.indexed_at)`, but that column only moves for notes a
+# pass actually upserted or moved — a pass over an unchanged vault writes it
+# nowhere. So a healthy indexer on an idle vault reported a last run of days
+# ago, which is an invitation to reach for the Danger zone and re-embed the
+# whole vault for nothing (#78).
+#
+# Deliberately in-process, not a table: it answers "is this process's loop
+# alive", which is exactly a property of this process, and it costs no write
+# per tick. It resets to None on restart — the startup pass sets it moments
+# later, so the window where the dashboard reads "Never" is the window in
+# which the first pass has genuinely not finished yet.
+last_index_run_at: datetime | None = None
+last_index_run_ok: bool | None = None
+
+
+def _record_index_run(ok: bool) -> None:
+    global last_index_run_at, last_index_run_ok
+    last_index_run_at = datetime.now(timezone.utc)
+    last_index_run_ok = ok
+
 # Serializes full index/embed passes so the periodic loop and a
 # panel-triggered on-demand reindex can never run index_vault/embed_vault
 # concurrently for the same scope. Two overlapping passes share no DB lock and
@@ -932,6 +954,7 @@ async def run_indexer_loop():
     """
     # Hold `index_pass_lock` for the initial pass too, so a panel-triggered
     # `_reindex_background` fired during startup is serialized against it.
+    startup_ok = True
     async with index_pass_lock:
         if settings.multi_user_mode:
             # Initial pass per user.
@@ -940,6 +963,7 @@ async def run_indexer_loop():
                 try:
                     await index_vault(user_id=uid)
                 except Exception as e:
+                    startup_ok = False
                     logger.error(f"Initial index failed (user_id={uid}): {e}")
             try:
                 # Link backfill still uses the global "table empty" guard but
@@ -949,27 +973,37 @@ async def run_indexer_loop():
                 for uid in user_ids:
                     await link_backfill_pass(user_id=uid)
             except Exception as e:
+                startup_ok = False
                 logger.error(f"Link backfill failed: {e}")
             for uid in user_ids:
                 try:
                     await embed_vault(user_id=uid)
                 except Exception as e:
+                    startup_ok = False
                     logger.error(f"Initial embedding failed (user_id={uid}): {e}")
         else:
             try:
                 await index_vault()
             except Exception as e:
+                startup_ok = False
                 logger.error(f"Initial index failed: {e}")
 
             try:
                 await link_backfill_pass()
             except Exception as e:
+                startup_ok = False
                 logger.error(f"Link backfill failed: {e}")
 
             try:
                 await embed_vault()
             except Exception as e:
+                startup_ok = False
                 logger.error(f"Initial embedding failed: {e}")
+
+    # The startup pass counts as a run: it does the same work a tick does, and
+    # without it the dashboard would read "Never" for a whole interval after
+    # every restart.
+    _record_index_run(startup_ok)
 
     consecutive_failures = 0
     logger.info(
@@ -1002,8 +1036,16 @@ async def run_indexer_loop():
                 await prewarm_search_caches()
             await cleanup_expired_tokens()
             consecutive_failures = 0
+            # Heartbeat: the tick completed. Recorded whether or not the pass
+            # found anything to index — that is the whole point (#78).
+            _record_index_run(True)
         except Exception as e:
             consecutive_failures += 1
+            # A tick that raised still *ran*; the dashboard says so and marks
+            # it failed rather than showing a stale-looking success.
+            # `CancelledError` is a BaseException and does not land here, so
+            # lifespan shutdown is not recorded as a failed pass.
+            _record_index_run(False)
             logger.error(f"Periodic task failed ({consecutive_failures} consecutive): {e}")
             if consecutive_failures >= 5:
                 logger.critical("Indexer has failed 5+ consecutive times — manual intervention required")

--- a/tests/test_issue_69_self_edit_role_lock.py
+++ b/tests/test_issue_69_self_edit_role_lock.py
@@ -59,20 +59,32 @@ class _Result:
 
 
 class _FakeSession:
-    """Answers the handler's two queries: the target row, then the
-    remaining-active-admins count."""
+    """Answers the handler's queries: the advisory lock (which returns
+    nothing anyone reads), the target row, then the remaining-active-admins
+    count."""
 
     def __init__(self, target: User, remaining_admins: int = 1):
         self._target = target
         self._remaining_admins = remaining_admins
         self.committed = False
+        self.deleted = None
         self.queries = 0
+        self.statements: list[str] = []
+        self.lock_keys: list[object] = []
 
-    async def execute(self, _stmt):
+    async def execute(self, stmt, *_a, **_k):
+        self.statements.append(str(stmt))
+        if "pg_advisory_xact_lock" in str(stmt):
+            params = _a[0] if _a else _k.get("params", {})
+            self.lock_keys.append(params.get("key"))
+            return _Result(None)
         self.queries += 1
         if self.queries == 1:
             return _Result(self._target)
         return _Result(self._remaining_admins)
+
+    async def delete(self, obj):
+        self.deleted = obj
 
     async def commit(self):
         self.committed = True
@@ -92,8 +104,8 @@ def _user(**overrides) -> User:
     return u
 
 
-def _submit(actor: User, target: User, *, is_admin: str, is_active: str,
-            remaining_admins: int = 1):
+def _submit(actor: User, target: User, *, is_admin: str | None,
+            is_active: str | None, remaining_admins: int = 1):
     session = _FakeSession(target, remaining_admins=remaining_admins)
     response = asyncio.run(
         users_mod.edit_user_submit(
@@ -126,13 +138,13 @@ def test_self_demotion_is_refused_even_when_other_admins_exist():
     property under test; the save itself is allowed to succeed for the fields
     a self-edit may legitimately change (the vault path)."""
     me = _user()
-    _submit(me, me, is_admin="", is_active="on", remaining_admins=3)
+    _submit(me, me, is_admin=None, is_active="on", remaining_admins=3)
     assert me.is_admin is True, "self-demotion went through — the #69 bug"
 
 
 def test_self_deactivation_is_refused_even_when_other_admins_exist():
     me = _user()
-    _submit(me, me, is_admin="on", is_active="", remaining_admins=3)
+    _submit(me, me, is_admin="on", is_active=None, remaining_admins=3)
     assert me.is_active is True, "self-deactivation went through — the #69 bug"
 
 
@@ -161,6 +173,128 @@ def test_self_demotion_is_refused_for_a_scripted_post_too():
     assert session.committed is False
 
 
+def test_present_but_empty_field_is_refused_not_read_as_unchanged():
+    """`is_admin=` — present, empty — is a submission, not an omission. It
+    must not slip through the "absent means unchanged" door; only a truly
+    absent field (`None`) may."""
+    me = _user()
+    response, session = _submit(
+        me, me, is_admin="", is_active="on", remaining_admins=3
+    )
+    assert me.is_admin is True
+    assert _is_error_redirect(response)
+    assert session.committed is False
+
+
+def test_present_but_empty_active_field_is_refused_too():
+    me = _user()
+    response, session = _submit(
+        me, me, is_admin="on", is_active="", remaining_admins=3
+    )
+    assert me.is_active is True
+    assert _is_error_redirect(response)
+    assert session.committed is False
+
+
+# --- Concurrency: the guard and the write must be one critical section ----
+
+
+def _lock_index(statements: list[str]) -> int:
+    for i, s in enumerate(statements):
+        if "pg_advisory_xact_lock" in s:
+            return i
+    return -1
+
+
+def _count_index(statements: list[str]) -> int:
+    for i, s in enumerate(statements):
+        if "count(" in s.lower():
+            return i
+    return -1
+
+
+def test_edit_takes_the_admin_lock_before_counting_admins():
+    """Without it the count and the write are two statements with nothing
+    between them: two admins demoting each other concurrently both read "one
+    other admin remains", both pass, and the panel is left with zero."""
+    me = _user()
+    bob = _user(username="bob")
+    bob.id = 2
+    _, session = _submit(me, bob, is_admin=None, is_active="on", remaining_admins=1)
+
+    lock_at = _lock_index(session.statements)
+    count_at = _count_index(session.statements)
+    assert lock_at != -1, "no advisory lock taken"
+    assert count_at != -1, "the last-admin count did not run"
+    assert lock_at < count_at, "the lock must precede the count it protects"
+
+
+def test_edit_takes_the_lock_before_reading_the_target_row():
+    """The target's own flags are part of what the guard decides on, so the
+    read belongs inside the critical section too."""
+    me = _user()
+    _, session = _submit(me, me, is_admin=None, is_active=None)
+    assert "pg_advisory_xact_lock" in session.statements[0]
+
+
+def _delete(actor: User, target: User, *, permanent=False, remaining_admins=1):
+    session = _FakeSession(target, remaining_admins=remaining_admins)
+
+    class _Req:
+        query_params = {"permanent": "true"} if permanent else {}
+
+    response = asyncio.run(
+        users_mod.delete_user(
+            user_id=target.id,
+            request=_Req(),
+            session=session,
+            user=actor,
+        )
+    )
+    return response, session
+
+
+def test_delete_takes_the_admin_lock_before_counting_admins():
+    """A delete and an edit can each remove the other's "remaining admin", so
+    both must take the *same* lock — excluding only their own kind would not
+    close the race."""
+    me = _user()
+    bob = _user(username="bob")
+    bob.id = 2
+    _, session = _delete(me, bob, remaining_admins=1)
+
+    lock_at = _lock_index(session.statements)
+    count_at = _count_index(session.statements)
+    assert lock_at != -1, "no advisory lock taken"
+    assert count_at != -1
+    assert lock_at < count_at
+
+
+def test_delete_still_refuses_the_last_active_admin():
+    me = _user()
+    bob = _user(username="bob")
+    bob.id = 2
+    response, session = _delete(me, bob, remaining_admins=0)
+    assert bob.is_active is True
+    assert "error=" in response.headers["location"]
+    assert session.committed is False
+
+
+def test_delete_and_edit_share_one_lock_key():
+    """Two different constants would not exclude each other at all."""
+    me = _user()
+    bob = _user(username="bob")
+    bob.id = 2
+    _, edit_session = _submit(me, bob, is_admin=None, is_active="on")
+    _, delete_session = _delete(me, bob)
+    key = users_mod._ADMIN_GUARD_LOCK_KEY
+    assert edit_session.lock_keys == [key]
+    assert delete_session.lock_keys == [key]
+    # `pg_advisory_xact_lock(bigint)` — a key outside int64 is a runtime error
+    # on the first concurrent edit, i.e. exactly when it is needed.
+    assert -(2 ** 63) <= key < 2 ** 63
+
+
 # --- The trap the fix must not walk into ----------------------------------
 
 
@@ -169,7 +303,7 @@ def test_absent_checkboxes_on_a_self_edit_mean_unchanged_not_unchecked():
     your own account submits neither. That must save the vault path without
     demoting or deactivating you."""
     me = _user(vault_path=None)
-    response, session = _submit(me, me, is_admin="", is_active="")
+    response, session = _submit(me, me, is_admin=None, is_active=None)
     assert me.is_admin is True
     assert me.is_active is True
     assert session.committed is True
@@ -185,7 +319,7 @@ def test_demoting_another_admin_still_works_when_admins_remain():
     bob = _user(username="bob")
     bob.id = 2
     response, session = _submit(
-        me, bob, is_admin="", is_active="on", remaining_admins=1
+        me, bob, is_admin=None, is_active="on", remaining_admins=1
     )
     assert bob.is_admin is False
     assert session.committed is True
@@ -197,7 +331,7 @@ def test_demoting_the_last_active_admin_is_still_refused():
     bob = _user(username="bob")
     bob.id = 2
     response, session = _submit(
-        me, bob, is_admin="", is_active="on", remaining_admins=0
+        me, bob, is_admin=None, is_active="on", remaining_admins=0
     )
     assert bob.is_admin is True
     assert _is_error_redirect(response)

--- a/tests/test_issue_69_self_edit_role_lock.py
+++ b/tests/test_issue_69_self_edit_role_lock.py
@@ -1,0 +1,253 @@
+"""Regression test (#69): a self-edit can never demote or deactivate you.
+
+`user_edit.html` promises, unconditionally, "This is your own account — you
+can't remove your own admin role or deactivate yourself here." The handler
+only ever refused when the target was the **last active admin**, so with any
+second active admin present an admin who unchecked their own Admin (or Active)
+box and saved was demoted or deactivated on the spot — locking themselves out
+of a panel they may be the only operator of. Neither checkbox carried
+`disabled`, so nothing in the UI contradicted the promise.
+
+The fix makes both sides agree, the fail-closed way:
+
+- both checkboxes render `disabled` when `is_self`;
+- the handler refuses the change for a self-edit *regardless* of how many
+  other admins exist — including a hand-crafted POST that bypasses the form;
+- and, because a `disabled` checkbox is not POSTed at all, an absent field on
+  a self-edit means "unchanged", never "unchecked". Reading it as unchecked
+  would demote the operator on every single save, which is the trap the fix
+  must not walk into.
+"""
+import asyncio
+import os
+
+import pydantic_settings
+
+_orig_init = pydantic_settings.BaseSettings.__init__
+
+
+def _no_env_file_init(self, *args, **kwargs):
+    kwargs.setdefault("_env_file", None)
+    _orig_init(self, *args, **kwargs)
+
+
+pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+try:
+    from starlette.templating import Jinja2Templates
+
+    from src.control_panel import users as users_mod
+    from src.models.db import User
+finally:
+    pydantic_settings.BaseSettings.__init__ = _orig_init
+
+
+TEMPLATES_DIR = os.path.join(os.path.dirname(users_mod.__file__), "templates")
+
+
+# --- Fakes ----------------------------------------------------------------
+
+
+class _Result:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+    def scalar(self):
+        return self._value
+
+
+class _FakeSession:
+    """Answers the handler's two queries: the target row, then the
+    remaining-active-admins count."""
+
+    def __init__(self, target: User, remaining_admins: int = 1):
+        self._target = target
+        self._remaining_admins = remaining_admins
+        self.committed = False
+        self.queries = 0
+
+    async def execute(self, _stmt):
+        self.queries += 1
+        if self.queries == 1:
+            return _Result(self._target)
+        return _Result(self._remaining_admins)
+
+    async def commit(self):
+        self.committed = True
+
+
+def _user(**overrides) -> User:
+    u = User(
+        username="max",
+        password_hash="x",
+        is_admin=True,
+        is_active=True,
+        vault_path=None,
+    )
+    u.id = 1
+    for k, v in overrides.items():
+        setattr(u, k, v)
+    return u
+
+
+def _submit(actor: User, target: User, *, is_admin: str, is_active: str,
+            remaining_admins: int = 1):
+    session = _FakeSession(target, remaining_admins=remaining_admins)
+    response = asyncio.run(
+        users_mod.edit_user_submit(
+            user_id=target.id,
+            vault_path="",
+            vault_path_custom="",
+            is_admin=is_admin,
+            is_active=is_active,
+            session=session,
+            user=actor,
+        )
+    )
+    return response, session
+
+
+def _is_error_redirect(response) -> bool:
+    return "error=" in response.headers["location"]
+
+
+# --- The bug: self-demotion with a second admin present -------------------
+
+
+def test_self_demotion_is_refused_even_when_other_admins_exist():
+    """The exact #69 scenario: two active admins, one unchecks their own
+    Admin box and saves. Before the fix the demotion went through.
+
+    An unchecked *browser* checkbox submits nothing at all, which is
+    indistinguishable from the `disabled` field the fixed template renders —
+    so the handler reads it as "unchanged" and the role survives. That is the
+    property under test; the save itself is allowed to succeed for the fields
+    a self-edit may legitimately change (the vault path)."""
+    me = _user()
+    _submit(me, me, is_admin="", is_active="on", remaining_admins=3)
+    assert me.is_admin is True, "self-demotion went through — the #69 bug"
+
+
+def test_self_deactivation_is_refused_even_when_other_admins_exist():
+    me = _user()
+    _submit(me, me, is_admin="on", is_active="", remaining_admins=3)
+    assert me.is_active is True, "self-deactivation went through — the #69 bug"
+
+
+def test_self_deactivation_via_an_explicit_false_is_an_error():
+    """A submission that *states* the intent (rather than merely omitting the
+    field) gets a reason back instead of a silent no-op."""
+    me = _user()
+    response, session = _submit(
+        me, me, is_admin="on", is_active="false", remaining_admins=3
+    )
+    assert me.is_active is True
+    assert _is_error_redirect(response)
+    assert session.committed is False
+
+
+def test_self_demotion_is_refused_for_a_scripted_post_too():
+    """`disabled` only removes the field from the browser's submission; a
+    hand-crafted POST can still send `is_admin=off`. The handler is the
+    guard, not the template."""
+    me = _user()
+    response, session = _submit(
+        me, me, is_admin="off", is_active="on", remaining_admins=3
+    )
+    assert me.is_admin is True
+    assert _is_error_redirect(response)
+    assert session.committed is False
+
+
+# --- The trap the fix must not walk into ----------------------------------
+
+
+def test_absent_checkboxes_on_a_self_edit_mean_unchanged_not_unchecked():
+    """Both fields are `disabled` in the rendered form, so a *normal* save of
+    your own account submits neither. That must save the vault path without
+    demoting or deactivating you."""
+    me = _user(vault_path=None)
+    response, session = _submit(me, me, is_admin="", is_active="")
+    assert me.is_admin is True
+    assert me.is_active is True
+    assert session.committed is True
+    assert "error=" not in response.headers["location"]
+    assert "flash=" in response.headers["location"]
+
+
+# --- Editing somebody else is unchanged -----------------------------------
+
+
+def test_demoting_another_admin_still_works_when_admins_remain():
+    me = _user()
+    bob = _user(username="bob")
+    bob.id = 2
+    response, session = _submit(
+        me, bob, is_admin="", is_active="on", remaining_admins=1
+    )
+    assert bob.is_admin is False
+    assert session.committed is True
+    assert "error=" not in response.headers["location"]
+
+
+def test_demoting_the_last_active_admin_is_still_refused():
+    me = _user()
+    bob = _user(username="bob")
+    bob.id = 2
+    response, session = _submit(
+        me, bob, is_admin="", is_active="on", remaining_admins=0
+    )
+    assert bob.is_admin is True
+    assert _is_error_redirect(response)
+    assert session.committed is False
+
+
+# --- The template side ----------------------------------------------------
+
+
+def _render_user_edit(is_self: bool) -> str:
+    templates = Jinja2Templates(directory=TEMPLATES_DIR)
+    response = templates.TemplateResponse(
+        request=None,  # user_edit.html never touches `request` directly
+        name="user_edit.html",
+        context={
+            "active": "users",
+            "is_admin": True,
+            "multi_user_mode": True,
+            "username": "max",
+            "csrf_token": "test-csrf-token",
+            "target": {
+                "id": 1,
+                "username": "max",
+                "is_admin": True,
+                "is_active": True,
+                "vault_path": "",
+            },
+            "available_vaults": ["/vaults/max"],
+            "is_self": is_self,
+            "error": None,
+            "flash": None,
+        },
+    )
+    return response.body.decode()
+
+
+def _input_tag(html: str, name: str) -> str:
+    idx = html.find(f'name="{name}"')
+    assert idx != -1, f"no input named {name}"
+    start = html.rfind("<input", 0, idx)
+    return html[start : html.find(">", idx) + 1]
+
+
+def test_self_edit_renders_both_checkboxes_disabled():
+    html = _render_user_edit(is_self=True)
+    assert "disabled" in _input_tag(html, "is_admin")
+    assert "disabled" in _input_tag(html, "is_active")
+
+
+def test_editing_another_user_leaves_the_checkboxes_live():
+    html = _render_user_edit(is_self=False)
+    assert "disabled" not in _input_tag(html, "is_admin")
+    assert "disabled" not in _input_tag(html, "is_active")

--- a/tests/test_issue_69_self_edit_role_lock.py
+++ b/tests/test_issue_69_self_edit_role_lock.py
@@ -54,8 +54,19 @@ class _Result:
     def scalar_one_or_none(self):
         return self._value
 
+    def one_or_none(self):
+        return self._value
+
     def scalar(self):
         return self._value
+
+
+class _ActorRow:
+    """What `select(User.is_admin, User.is_active)` yields."""
+
+    def __init__(self, is_admin, is_active):
+        self.is_admin = is_admin
+        self.is_active = is_active
 
 
 class _FakeSession:
@@ -63,28 +74,47 @@ class _FakeSession:
     nothing anyone reads), the target row, then the remaining-active-admins
     count."""
 
-    def __init__(self, target: User, remaining_admins: int = 1):
+    def __init__(self, target: User, remaining_admins: int = 1,
+                 actor_after_lock=None):
         self._target = target
         self._remaining_admins = remaining_admins
+        # What the actor's row looks like *once the lock has been taken* —
+        # i.e. after any concurrent demotion has committed. `None` means
+        # "unchanged: still an active admin".
+        self._actor_after_lock = actor_after_lock
         self.committed = False
+        self.rolled_back = False
         self.deleted = None
         self.queries = 0
         self.statements: list[str] = []
         self.lock_keys: list[object] = []
 
     async def execute(self, stmt, *_a, **_k):
-        self.statements.append(str(stmt))
-        if "pg_advisory_xact_lock" in str(stmt):
+        sql = str(stmt)
+        self.statements.append(sql)
+        if "pg_advisory_xact_lock" in sql:
             params = _a[0] if _a else _k.get("params", {})
             self.lock_keys.append(params.get("key"))
             return _Result(None)
-        self.queries += 1
-        if self.queries == 1:
-            return _Result(self._target)
-        return _Result(self._remaining_admins)
+        # Must be a *prefix* test: `select(User)` names every column, so
+        # "users.is_admin, users.is_active" appears in the target query too.
+        if sql.startswith("SELECT users.is_admin, users.is_active"):
+            if self._actor_after_lock is False:  # the actor's row is gone
+                return _Result(None)
+            return _Result(
+                self._actor_after_lock
+                if self._actor_after_lock is not None
+                else _ActorRow(True, True)
+            )
+        if "count(" in sql.lower():
+            return _Result(self._remaining_admins)
+        return _Result(self._target)
 
     async def delete(self, obj):
         self.deleted = obj
+
+    async def rollback(self):
+        self.rolled_back = True
 
     async def commit(self):
         self.committed = True
@@ -105,8 +135,12 @@ def _user(**overrides) -> User:
 
 
 def _submit(actor: User, target: User, *, is_admin: str | None,
-            is_active: str | None, remaining_admins: int = 1):
-    session = _FakeSession(target, remaining_admins=remaining_admins)
+            is_active: str | None, remaining_admins: int = 1,
+            actor_after_lock=None):
+    session = _FakeSession(
+        target, remaining_admins=remaining_admins,
+        actor_after_lock=actor_after_lock,
+    )
     response = asyncio.run(
         users_mod.edit_user_submit(
             user_id=target.id,
@@ -237,8 +271,12 @@ def test_edit_takes_the_lock_before_reading_the_target_row():
     assert "pg_advisory_xact_lock" in session.statements[0]
 
 
-def _delete(actor: User, target: User, *, permanent=False, remaining_admins=1):
-    session = _FakeSession(target, remaining_admins=remaining_admins)
+def _delete(actor: User, target: User, *, permanent=False, remaining_admins=1,
+            actor_after_lock=None):
+    session = _FakeSession(
+        target, remaining_admins=remaining_admins,
+        actor_after_lock=actor_after_lock,
+    )
 
     class _Req:
         query_params = {"permanent": "true"} if permanent else {}
@@ -278,6 +316,116 @@ def test_delete_still_refuses_the_last_active_admin():
     assert bob.is_active is True
     assert "error=" in response.headers["location"]
     assert session.committed is False
+
+
+def test_edit_refuses_when_the_actor_was_demoted_while_waiting():
+    """`require_admin_panel` authorised this request before the lock was even
+    requested, and the wait for that lock is exactly when another admin's
+    demotion of *this* actor commits. Serializing the writes is not enough if
+    the loser then performs the mutation anyway."""
+    me = _user()
+    bob = _user(username="bob")
+    bob.id = 2
+    response, session = _submit(
+        me, bob, is_admin=None, is_active="on", remaining_admins=1,
+        actor_after_lock=_ActorRow(is_admin=False, is_active=True),
+    )
+    assert bob.is_admin is True, "a demoted actor still performed the mutation"
+    assert session.committed is False
+    assert session.rolled_back is True, "the advisory lock must be released"
+    assert "error=" in response.headers["location"]
+
+
+def test_edit_refuses_when_the_actor_was_deactivated_while_waiting():
+    me = _user()
+    bob = _user(username="bob")
+    bob.id = 2
+    response, session = _submit(
+        me, bob, is_admin=None, is_active="on", remaining_admins=1,
+        actor_after_lock=_ActorRow(is_admin=True, is_active=False),
+    )
+    assert bob.is_admin is True
+    assert session.committed is False
+    assert "error=" in response.headers["location"]
+
+
+def test_edit_refuses_when_the_actor_row_is_gone():
+    """A permanently deleted actor has no row at all — not privileged
+    either."""
+    me = _user()
+    bob = _user(username="bob")
+    bob.id = 2
+    response, session = _submit(
+        me, bob, is_admin=None, is_active="on", remaining_admins=1,
+        actor_after_lock=False,  # sentinel: `one_or_none()` finds nothing
+    )
+    assert bob.is_admin is True
+    assert session.committed is False
+    assert "error=" in response.headers["location"]
+
+
+def test_edit_actor_recheck_happens_after_the_lock():
+    """Re-reading before the lock would read the same stale row the
+    dependency did."""
+    me = _user()
+    bob = _user(username="bob")
+    bob.id = 2
+    _, session = _submit(me, bob, is_admin=None, is_active="on")
+    lock_at = _lock_index(session.statements)
+    actor_at = next(
+        i for i, sql in enumerate(session.statements)
+        if sql.startswith("SELECT users.is_admin, users.is_active")
+    )
+    assert lock_at < actor_at
+
+
+def test_delete_refuses_when_the_actor_was_demoted_while_waiting():
+    me = _user()
+    bob = _user(username="bob")
+    bob.id = 2
+    response, session = _delete(
+        me, bob, remaining_admins=1,
+        actor_after_lock=_ActorRow(is_admin=False, is_active=True),
+    )
+    assert bob.is_active is True, "a demoted actor still deleted a user"
+    assert session.committed is False
+    assert session.rolled_back is True
+    assert "error=" in response.headers["location"]
+
+
+def test_delete_actor_recheck_happens_after_the_lock():
+    me = _user()
+    bob = _user(username="bob")
+    bob.id = 2
+    _, session = _delete(me, bob)
+    lock_at = _lock_index(session.statements)
+    actor_at = next(
+        i for i, sql in enumerate(session.statements)
+        if sql.startswith("SELECT users.is_admin, users.is_active")
+    )
+    assert lock_at < actor_at
+
+
+def test_single_user_sentinel_is_not_re_read():
+    """The sentinel has no `users` row (its `id` is None), and there is no
+    second admin who could have demoted it."""
+    class _Sentinel:
+        id = None
+        username = "admin"
+        is_admin = True
+        is_active = True
+
+    bob = _user(username="bob")
+    bob.id = 2
+    response, session = _submit(
+        _Sentinel(), bob, is_admin=None, is_active="on", remaining_admins=1
+    )
+    assert session.committed is True
+    assert "error=" not in response.headers["location"]
+    assert not any(
+        sql.startswith("SELECT users.is_admin, users.is_active")
+        for sql in session.statements
+    )
 
 
 def test_delete_and_edit_share_one_lock_key():

--- a/tests/test_issue_70_vault_error_render.py
+++ b/tests/test_issue_70_vault_error_render.py
@@ -1,0 +1,123 @@
+"""Regression test (#70): `vault.html` must render `vault_error`.
+
+`vault_page` catches the "no vault_path assigned" RuntimeError from
+`_vault_root` and deliberately hands the template a `vault_error` key so the
+page can explain itself "as a friendly empty state rather than a 500". The
+template never referenced that key, so the message was computed and thrown
+away and an *unassigned* vault rendered as an ordinary, successful, **empty**
+one — "Notes (0)", no error — while every note tool the same user called over
+MCP failed.
+
+The fix is an `{% if vault_error %}` alert at the top of the page body,
+rendered for admins and non-admins alike (a non-admin has no other vault
+surface in the panel, and the admin-only users list is where the
+"(unassigned)" warning lives).
+"""
+import os
+
+import pydantic_settings
+
+_orig_init = pydantic_settings.BaseSettings.__init__
+
+
+def _no_env_file_init(self, *args, **kwargs):
+    kwargs.setdefault("_env_file", None)
+    _orig_init(self, *args, **kwargs)
+
+
+pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+try:
+    from starlette.templating import Jinja2Templates
+
+    from src.control_panel import routes
+finally:
+    pydantic_settings.BaseSettings.__init__ = _orig_init
+
+
+TEMPLATES_DIR = os.path.join(os.path.dirname(routes.__file__), "templates")
+
+
+def _render_vault_page(**overrides) -> str:
+    """Render vault.html with the exact context `vault_page` builds for the
+    RuntimeError branch (src/control_panel/routes.py)."""
+    context = {
+        "active": "vault",
+        "is_admin": True,
+        "multi_user_mode": True,
+        "username": "bob",
+        "csrf_token": "test-csrf-token",
+        "current_folder": "",
+        "breadcrumbs": [],
+        "folders": [],
+        "notes": [],
+        "selected_note": None,
+        "note_content": None,
+        "note_title": None,
+        "note_tags": [],
+    }
+    context.update(overrides)
+    templates = Jinja2Templates(directory=TEMPLATES_DIR)
+    response = templates.TemplateResponse(
+        request=None,  # vault.html never touches `request` directly
+        name="vault.html",
+        context=context,
+    )
+    return response.body.decode()
+
+
+def _alert_block(html: str) -> str | None:
+    """The rendered `alert alert-warning` block, if any."""
+    marker = 'class="alert alert-warning'
+    idx = html.find(marker)
+    if idx == -1:
+        return None
+    end = html.find("</div>", idx)
+    return html[idx:end]
+
+
+def test_unassigned_vault_renders_a_warning_alert():
+    html = _render_vault_page(vault_error="Vault path for user_id=7 is not in cache.")
+    block = _alert_block(html)
+    assert block is not None, "vault_error produced no alert — the bug in #70"
+    assert "vault" in block.lower()
+    # It must tell the reader what to do about it.
+    assert "admin" in block.lower()
+
+
+def test_alert_is_absent_on_a_healthy_vault():
+    html = _render_vault_page(
+        notes=[{"name": "Inbox", "path": "Inbox.md"}],
+    )
+    assert _alert_block(html) is None
+    assert "Inbox" in html
+
+
+def test_alert_is_absent_when_a_healthy_vault_is_genuinely_empty():
+    """The distinction the page could not previously make: zero notes and no
+    assignment problem must NOT show the alert."""
+    html = _render_vault_page()
+    assert _alert_block(html) is None
+    assert "Notes" in html
+
+
+def test_alert_renders_for_a_non_admin_too():
+    """#70 explicitly requires this — pointing a non-admin at the admin-only
+    users list would be useless, so the alert may not be admin-gated."""
+    html = _render_vault_page(
+        is_admin=False, vault_error="Vault path for user_id=7 is not in cache."
+    )
+    block = _alert_block(html)
+    assert block is not None
+    assert "admin" in block.lower()
+
+
+def test_vault_page_still_passes_vault_error_to_the_template():
+    """Guard the other half of the contract: the handler's RuntimeError branch
+    is what supplies the key the template now reads."""
+    import inspect
+
+    source = inspect.getsource(routes.vault_page)
+    assert '"vault_error"' in source
+
+    with open(os.path.join(TEMPLATES_DIR, "vault.html")) as fh:
+        assert "vault_error" in fh.read()

--- a/tests/test_issue_76_key_liveness_surfaces.py
+++ b/tests/test_issue_76_key_liveness_surfaces.py
@@ -245,6 +245,30 @@ def test_expired_key_renders_its_own_badge():
     assert 'class="badge badge-green"' not in html
 
 
+def test_owner_inactive_beats_expired_in_the_badge():
+    """A key that is both expired and owner-inactive: `auth.py` checks the
+    owner's `is_active` first and 401s there, so the badge must name the
+    reason the middleware would actually give."""
+    html = _render_keys_page([
+        _key_ctx(owner_is_active=False, is_expired=True, effective_active=False)
+    ])
+    assert _status_badge(html) == "Owner inactive"
+    assert 'class="badge badge-green"' not in html
+
+
+def test_middleware_checks_the_owner_before_expiry():
+    """The ordering this badge mirrors. If auth.py ever checks expiry first,
+    this fails and the template should follow it."""
+    import inspect
+
+    from src.mcp_server import auth
+
+    src = inspect.getsource(auth)
+    owner_at = src.index('"reason": "inactive_user"')
+    expiry_at = src.index("api_key.expires_at < datetime.now(timezone.utc)")
+    assert owner_at < expiry_at
+
+
 def test_revoked_beats_expired_in_the_badge():
     html = _render_keys_page(
         [_key_ctx(is_active=False, is_expired=True, effective_active=False)]

--- a/tests/test_issue_76_key_liveness_surfaces.py
+++ b/tests/test_issue_76_key_liveness_surfaces.py
@@ -1,0 +1,405 @@
+"""Regression test (#76): the panel's key surfaces must apply the same
+liveness predicate `APIKeyMiddleware` does.
+
+Two defects, one cause — the panel used a weaker predicate than auth:
+
+1. `keys.html` badged Status from `api_keys.is_active` alone. `auth.py`
+   additionally selects `User.is_active` for the key's `user_id` and 401s
+   (reason=inactive_user) unless it is exactly True, and `delete_user` sets
+   `is_active=False` *without touching that user's keys* — so after
+   deactivating a user the panel showed their dead keys green/"Active".
+   There was also no owner column at all, so the finding would have been
+   unattributable even once badged.
+
+2. The users list counted `count(APIKey.id)` with no `is_active` filter, so
+   revoking every one of a user's keys left the number unchanged — and no
+   panel surface anywhere would have shown otherwise.
+
+Both bite only in multi_user_mode; single-user keys carry `user_id=NULL`,
+which the middleware exempts from the owner check (and the outer join here
+keeps).
+"""
+import asyncio
+import os
+
+import pydantic_settings
+
+_orig_init = pydantic_settings.BaseSettings.__init__
+
+
+def _no_env_file_init(self, *args, **kwargs):
+    kwargs.setdefault("_env_file", None)
+    _orig_init(self, *args, **kwargs)
+
+
+pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+try:
+    from starlette.templating import Jinja2Templates
+
+    from src.control_panel import routes
+    from src.control_panel import users as users_mod
+finally:
+    pydantic_settings.BaseSettings.__init__ = _orig_init
+
+
+TEMPLATES_DIR = os.path.join(os.path.dirname(routes.__file__), "templates")
+
+
+# --- keys_page: effective status is a join, not a column ------------------
+
+
+class _KeyRow:
+    """Stand-in for an APIKey ORM row."""
+
+    def __init__(self, id, user_id, is_active=True, name="k", permission="read"):
+        self.id = id
+        self.name = name
+        self.key_prefix = "omcp_abcdef"
+        self.permission = permission
+        self.is_active = is_active
+        self.user_id = user_id
+        self.created_at = _FixedTime()
+        self.last_used_at = None
+
+
+class _FixedTime:
+    def isoformat(self):
+        return "2026-08-20T00:00:00+00:00"
+
+
+class _KeysResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _KeysSession:
+    def __init__(self, rows):
+        self._rows = rows
+        self.statements = []
+
+    async def execute(self, stmt):
+        self.statements.append(stmt)
+        return _KeysResult(self._rows)
+
+
+class _Request:
+    """Minimal stand-in: keys_page only pops a flash off `request.session`,
+    and `_panel_context` needs it for the CSRF token."""
+
+    def __init__(self):
+        self.session = {}
+        self.scope = {}
+
+
+class _AdminUser:
+    id = 1
+    username = "max"
+    is_admin = True
+    is_active = True
+
+
+def _keys_context(rows, monkeypatch):
+    captured = {}
+
+    def _fake_response(request, name, context):
+        captured["name"] = name
+        captured["context"] = context
+        return None
+
+    monkeypatch.setattr(routes.templates, "TemplateResponse", _fake_response)
+    monkeypatch.setattr(routes, "generate_csrf_token", lambda _r: "csrf")
+    session = _KeysSession(rows)
+    asyncio.run(routes.keys_page(request=_Request(), session=session, user=_AdminUser()))
+    return captured["context"], session
+
+
+def test_key_of_a_deactivated_owner_is_not_effectively_active(monkeypatch):
+    rows = [(_KeyRow(id=1, user_id=2), "bob", False)]
+    ctx, _ = _keys_context(rows, monkeypatch)
+    key = ctx["keys"][0]
+    assert key["is_active"] is True, "the key's own column is untouched by deactivation"
+    assert key["owner_is_active"] is False
+    assert key["effective_active"] is False
+    assert key["owner_username"] == "bob"
+
+
+def test_key_of_an_active_owner_is_effectively_active(monkeypatch):
+    rows = [(_KeyRow(id=1, user_id=2), "bob", True)]
+    ctx, _ = _keys_context(rows, monkeypatch)
+    key = ctx["keys"][0]
+    assert key["effective_active"] is True
+    assert key["owner_is_active"] is True
+
+
+def test_single_user_key_with_null_owner_stays_active(monkeypatch):
+    """`user_id IS NULL` is single-user mode; auth.py skips the owner check
+    entirely there, so the panel must not invent an owner problem."""
+    rows = [(_KeyRow(id=1, user_id=None), None, None)]
+    ctx, _ = _keys_context(rows, monkeypatch)
+    key = ctx["keys"][0]
+    assert key["owner_is_active"] is True
+    assert key["effective_active"] is True
+    assert key["owner_username"] is None
+
+
+def test_key_whose_owner_row_is_missing_is_not_active(monkeypatch):
+    """An outer join yields NULLs for a key pointing at a row that isn't
+    there. The middleware's `is True` test fails for it, so this must not
+    read as live."""
+    rows = [(_KeyRow(id=1, user_id=99), None, None)]
+    ctx, _ = _keys_context(rows, monkeypatch)
+    key = ctx["keys"][0]
+    assert key["owner_is_active"] is False
+    assert key["effective_active"] is False
+
+
+def test_revoked_key_is_never_effectively_active(monkeypatch):
+    rows = [(_KeyRow(id=1, user_id=2, is_active=False), "bob", True)]
+    ctx, _ = _keys_context(rows, monkeypatch)
+    assert ctx["keys"][0]["effective_active"] is False
+
+
+def test_keys_query_outer_joins_the_owner(monkeypatch):
+    """The join must be an OUTER join — an inner one would drop every
+    single-user key (`user_id IS NULL`) off the page entirely."""
+    rows = [(_KeyRow(id=1, user_id=2), "bob", True)]
+    _, session = _keys_context(rows, monkeypatch)
+    sql = str(session.statements[0].compile()).upper()
+    assert "LEFT OUTER JOIN USERS" in sql
+
+
+# --- keys.html: the badge and the owner column ----------------------------
+
+
+def _render_keys_page(keys, multi_user_mode=True) -> str:
+    templates = Jinja2Templates(directory=TEMPLATES_DIR)
+    response = templates.TemplateResponse(
+        request=None,  # keys.html never touches `request` directly
+        name="keys.html",
+        context={
+            "active": "keys",
+            "is_admin": True,
+            "multi_user_mode": multi_user_mode,
+            "username": "max",
+            "csrf_token": "csrf",
+            "keys": keys,
+            "new_key": None,
+        },
+    )
+    return response.body.decode()
+
+
+def _key_ctx(**overrides) -> dict:
+    key = {
+        "id": 1,
+        "name": "laptop",
+        "key_prefix": "omcp_abcdef",
+        "permission": "read",
+        "is_active": True,
+        "owner_is_active": True,
+        "effective_active": True,
+        "owner_username": "bob",
+        "created_at": "2026-08-20T00:00:00+00:00",
+        "last_used_at": None,
+    }
+    key.update(overrides)
+    return key
+
+
+def _status_badge(html: str) -> str:
+    for label in ("Active", "Revoked", "Owner inactive"):
+        if f">{label}<" in html:
+            return label
+    return "NONE"
+
+
+def test_deactivated_owner_does_not_render_a_green_active_badge():
+    html = _render_keys_page(
+        [_key_ctx(owner_is_active=False, effective_active=False)]
+    )
+    assert 'class="badge badge-green"' not in html  # the stylesheet defines it
+    assert _status_badge(html) == "Owner inactive"
+
+
+def test_live_key_still_renders_active():
+    html = _render_keys_page([_key_ctx()])
+    assert _status_badge(html) == "Active"
+    assert "badge-green" in html
+
+
+def test_revoked_key_still_renders_revoked():
+    html = _render_keys_page(
+        [_key_ctx(is_active=False, effective_active=False)]
+    )
+    assert _status_badge(html) == "Revoked"
+
+
+def test_owner_column_is_rendered_in_multi_user_mode():
+    html = _render_keys_page([_key_ctx(owner_username="bob")])
+    assert "<th>Owner</th>" in html
+    assert "bob" in html
+
+
+def test_owner_column_is_hidden_in_single_user_mode():
+    html = _render_keys_page(
+        [_key_ctx(owner_username=None)], multi_user_mode=False
+    )
+    assert "<th>Owner</th>" not in html
+
+
+def test_revoke_action_still_offered_for_an_owner_inactive_key():
+    """The key's own `is_active` is what revoke/delete key off — an
+    owner-inactive key is still revocable, and must not be offered the
+    permanent-delete action reserved for already-revoked keys."""
+    html = _render_keys_page(
+        [_key_ctx(owner_is_active=False, effective_active=False)]
+    )
+    assert "/revoke" in html
+    assert "/delete" not in html
+
+
+# --- users list: "N active / M total" -------------------------------------
+
+
+class _CountRow:
+    def __init__(self, user_id, total, active):
+        self.user_id = user_id
+        self.total = total
+        self.active = active
+
+
+class _ListResult:
+    def __init__(self, rows=None, scalars=None):
+        self._rows = rows or []
+        self._scalars = scalars or []
+
+    def all(self):
+        return self._rows
+
+    def scalars(self):
+        outer = self
+
+        class _S:
+            def all(self_inner):
+                return outer._scalars
+
+        return _S()
+
+
+class _ListSession:
+    """Answers list_users' three queries: key counts, note counts, users."""
+
+    def __init__(self, key_rows, users):
+        self._key_rows = key_rows
+        self._users = users
+        self.statements = []
+
+    async def execute(self, stmt):
+        self.statements.append(stmt)
+        n = len(self.statements)
+        if n == 1:
+            return _ListResult(rows=self._key_rows)
+        if n == 2:
+            return _ListResult(rows=[])
+        return _ListResult(scalars=self._users)
+
+
+class _UserRow:
+    def __init__(self, id, username):
+        self.id = id
+        self.username = username
+        self.is_admin = False
+        self.is_active = True
+        self.vault_path = "/vaults/bob"
+        self.last_login_at = None
+        self.created_at = _FixedTime()
+
+
+def _list_users_context(key_rows, users, monkeypatch):
+    captured = {}
+
+    def _fake_response(request, name, context):
+        captured["context"] = context
+        return None
+
+    monkeypatch.setattr(users_mod.templates, "TemplateResponse", _fake_response)
+    monkeypatch.setattr(routes, "generate_csrf_token", lambda _r: "csrf")
+    session = _ListSession(key_rows, users)
+
+    class _Req:
+        query_params: dict = {}
+        scope: dict = {}
+
+    asyncio.run(
+        users_mod.list_users(request=_Req(), session=session, user=_AdminUser())
+    )
+    return captured["context"], session
+
+
+def test_users_list_reports_active_and_total_separately(monkeypatch):
+    """bob holds four keys, all revoked. The old column said "4"."""
+    ctx, _ = _list_users_context(
+        [_CountRow(user_id=2, total=4, active=0)],
+        [_UserRow(2, "bob")],
+        monkeypatch,
+    )
+    row = ctx["users"][0]
+    assert row["api_keys_total"] == 4
+    assert row["api_keys_active"] == 0
+
+
+def test_users_list_counts_default_to_zero_for_a_user_with_no_keys(monkeypatch):
+    ctx, _ = _list_users_context([], [_UserRow(2, "bob")], monkeypatch)
+    row = ctx["users"][0]
+    assert row["api_keys_total"] == 0
+    assert row["api_keys_active"] == 0
+
+
+def test_users_list_key_query_filters_the_active_count(monkeypatch):
+    """Pin the SQL: the active count must be a filtered aggregate, not the
+    same bare count under a different label."""
+    _, session = _list_users_context([], [_UserRow(2, "bob")], monkeypatch)
+    sql = str(session.statements[0].compile()).upper()
+    assert "FILTER (WHERE" in sql
+    assert "IS_ACTIVE IS TRUE" in sql
+
+
+def _render_users_page(users) -> str:
+    templates = Jinja2Templates(directory=TEMPLATES_DIR)
+    response = templates.TemplateResponse(
+        request=None,  # users.html never touches `request` directly
+        name="users.html",
+        context={
+            "active": "users",
+            "is_admin": True,
+            "multi_user_mode": True,
+            "username": "max",
+            "csrf_token": "csrf",
+            "users": users,
+            "flash": None,
+            "flash_kind": "ok",
+            "error": None,
+        },
+    )
+    return response.body.decode()
+
+
+def test_users_html_renders_active_over_total():
+    html = _render_users_page([
+        {
+            "id": 2,
+            "username": "bob",
+            "is_admin": False,
+            "is_active": True,
+            "vault_path": "/vaults/bob",
+            "last_login_at": None,
+            "created_at": "2026-08-20T00:00:00+00:00",
+            "api_keys_active": 1,
+            "api_keys_total": 4,
+            "notes": 12,
+        }
+    ])
+    assert "1 active / 4 total" in html

--- a/tests/test_issue_76_key_liveness_surfaces.py
+++ b/tests/test_issue_76_key_liveness_surfaces.py
@@ -21,6 +21,7 @@ keeps).
 """
 import asyncio
 import os
+from datetime import datetime, timedelta, timezone
 
 import pydantic_settings
 
@@ -51,7 +52,8 @@ TEMPLATES_DIR = os.path.join(os.path.dirname(routes.__file__), "templates")
 class _KeyRow:
     """Stand-in for an APIKey ORM row."""
 
-    def __init__(self, id, user_id, is_active=True, name="k", permission="read"):
+    def __init__(self, id, user_id, is_active=True, name="k", permission="read",
+                 expires_at=None):
         self.id = id
         self.name = name
         self.key_prefix = "omcp_abcdef"
@@ -60,6 +62,7 @@ class _KeyRow:
         self.user_id = user_id
         self.created_at = _FixedTime()
         self.last_used_at = None
+        self.expires_at = expires_at
 
 
 class _FixedTime:
@@ -162,6 +165,93 @@ def test_revoked_key_is_never_effectively_active(monkeypatch):
     assert ctx["keys"][0]["effective_active"] is False
 
 
+# --- expiry: the third half of the middleware's predicate ------------------
+
+
+def test_expired_key_is_not_effectively_active(monkeypatch):
+    """`auth.py` 401s (reason=key_expired) on `expires_at < now`. The panel
+    must apply that too, or it badges a dead key green the day anything
+    starts setting the column."""
+    past = datetime.now(timezone.utc) - timedelta(hours=1)
+    rows = [(_KeyRow(id=1, user_id=2, expires_at=past), "bob", True)]
+    ctx, _ = _keys_context(rows, monkeypatch)
+    key = ctx["keys"][0]
+    assert key["is_active"] is True
+    assert key["owner_is_active"] is True
+    assert key["is_expired"] is True
+    assert key["effective_active"] is False
+
+
+def test_unexpired_key_stays_active(monkeypatch):
+    future = datetime.now(timezone.utc) + timedelta(days=30)
+    rows = [(_KeyRow(id=1, user_id=2, expires_at=future), "bob", True)]
+    ctx, _ = _keys_context(rows, monkeypatch)
+    assert ctx["keys"][0]["is_expired"] is False
+    assert ctx["keys"][0]["effective_active"] is True
+
+
+def test_null_expires_at_never_expires(monkeypatch):
+    rows = [(_KeyRow(id=1, user_id=2, expires_at=None), "bob", True)]
+    ctx, _ = _keys_context(rows, monkeypatch)
+    assert ctx["keys"][0]["is_expired"] is False
+    assert ctx["keys"][0]["effective_active"] is True
+
+
+def test_the_boundary_instant_matches_the_middleware(monkeypatch):
+    """The middleware rejects on `expires_at < now`, so a key whose
+    `expires_at` is exactly now is still accepted. The panel must draw the
+    boundary on the same side rather than inventing a `>=` of its own."""
+    fixed = datetime(2026, 8, 20, 12, 0, 0, tzinfo=timezone.utc)
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed
+
+    monkeypatch.setattr(routes, "datetime", _FrozenDatetime)
+    rows = [(_KeyRow(id=1, user_id=2, expires_at=fixed), "bob", True)]
+    ctx, _ = _keys_context(rows, monkeypatch)
+    assert ctx["keys"][0]["is_expired"] is False, (
+        "at exactly expires_at the middleware still authenticates the key"
+    )
+    assert ctx["keys"][0]["effective_active"] is True
+
+    # One microsecond later it is expired on both sides.
+    rows = [(
+        _KeyRow(id=1, user_id=2, expires_at=fixed - timedelta(microseconds=1)),
+        "bob",
+        True,
+    )]
+    ctx, _ = _keys_context(rows, monkeypatch)
+    assert ctx["keys"][0]["is_expired"] is True
+
+
+def test_middleware_still_uses_the_comparison_this_mirrors():
+    """If auth.py's boundary ever moves, this pairing must be revisited —
+    fail here rather than let the two surfaces drift apart silently."""
+    import inspect
+
+    from src.mcp_server import auth
+
+    src = inspect.getsource(auth)
+    assert "api_key.expires_at < datetime.now(timezone.utc)" in src
+
+
+def test_expired_key_renders_its_own_badge():
+    html = _render_keys_page(
+        [_key_ctx(is_expired=True, effective_active=False)]
+    )
+    assert _status_badge(html) == "Expired"
+    assert 'class="badge badge-green"' not in html
+
+
+def test_revoked_beats_expired_in_the_badge():
+    html = _render_keys_page(
+        [_key_ctx(is_active=False, is_expired=True, effective_active=False)]
+    )
+    assert _status_badge(html) == "Revoked"
+
+
 def test_keys_query_outer_joins_the_owner(monkeypatch):
     """The join must be an OUTER join — an inner one would drop every
     single-user key (`user_id IS NULL`) off the page entirely."""
@@ -200,6 +290,8 @@ def _key_ctx(**overrides) -> dict:
         "permission": "read",
         "is_active": True,
         "owner_is_active": True,
+        "is_expired": False,
+        "expires_at": None,
         "effective_active": True,
         "owner_username": "bob",
         "created_at": "2026-08-20T00:00:00+00:00",
@@ -210,7 +302,7 @@ def _key_ctx(**overrides) -> dict:
 
 
 def _status_badge(html: str) -> str:
-    for label in ("Active", "Revoked", "Owner inactive"):
+    for label in ("Active", "Revoked", "Expired", "Owner inactive"):
         if f">{label}<" in html:
             return label
     return "NONE"

--- a/tests/test_issue_78_panel_labels.py
+++ b/tests/test_issue_78_panel_labels.py
@@ -1,0 +1,381 @@
+"""Regression tests (#78): two panel labels that named the wrong thing.
+
+1. The dashboard's "Last run" was `max(notes_metadata.indexed_at)` — a column
+   only written for notes a pass actually upserted or moved. A pass that finds
+   no changed hashes writes it nowhere, so on an idle vault a perfectly
+   healthy 5-minute indexer reported a last run of hours or days ago. The
+   operator's move from there is Settings → Danger zone: a full re-embed that
+   costs time and, on the OpenAI provider, money, to fix nothing.
+
+   The fix records the pass itself — an in-process heartbeat set at the end of
+   each tick, success and failure distinctly — and keeps `max(indexed_at)` as
+   a separately labelled "Last change detected".
+
+2. `usage_logs.tool` recorded "search_notes" for a tool registered as
+   `keyword_search` (FastMCP takes the function name), so `/admin/usage`
+   named a tool no client is ever offered and `WHERE tool = 'keyword_search'`
+   returned nothing. The tell was `_usage_detail` already special-casing both
+   spellings.
+"""
+import asyncio
+import inspect
+import os
+from datetime import datetime, timedelta, timezone
+
+import pydantic_settings
+
+_orig_init = pydantic_settings.BaseSettings.__init__
+
+
+def _no_env_file_init(self, *args, **kwargs):
+    kwargs.setdefault("_env_file", None)
+    _orig_init(self, *args, **kwargs)
+
+
+pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+try:
+    from starlette.templating import Jinja2Templates
+
+    from src.control_panel import routes
+    from src.mcp_server import tools
+    from src.services import indexer
+finally:
+    pydantic_settings.BaseSettings.__init__ = _orig_init
+
+
+TEMPLATES_DIR = os.path.join(os.path.dirname(routes.__file__), "templates")
+
+
+# --- 1a. the heartbeat itself ---------------------------------------------
+
+
+def test_indexer_exposes_a_run_heartbeat():
+    assert hasattr(indexer, "last_index_run_at")
+    assert hasattr(indexer, "last_index_run_ok")
+
+
+def test_record_index_run_stamps_utc_and_outcome(monkeypatch):
+    monkeypatch.setattr(indexer, "last_index_run_at", None)
+    monkeypatch.setattr(indexer, "last_index_run_ok", None)
+
+    indexer._record_index_run(True)
+    first = indexer.last_index_run_at
+    assert first is not None and first.tzinfo is not None
+    assert indexer.last_index_run_ok is True
+
+    indexer._record_index_run(False)
+    assert indexer.last_index_run_ok is False
+    assert indexer.last_index_run_at >= first
+
+
+def test_the_periodic_tick_records_a_run_even_when_nothing_changed(monkeypatch):
+    """The scenario the label got wrong: a pass over an untouched vault. It
+    writes no `indexed_at` anywhere, and must still count as a run."""
+    monkeypatch.setattr(indexer, "last_index_run_at", None)
+    monkeypatch.setattr(indexer, "last_index_run_ok", None)
+    monkeypatch.setattr(indexer.settings, "multi_user_mode", False)
+    monkeypatch.setattr(indexer.settings, "index_interval_seconds", 0)
+    monkeypatch.setattr(indexer, "_is_paused", lambda: False)
+
+    calls = {"n": 0}
+
+    async def _noop_index(*_a, **_k):
+        # An idle pass: finds nothing to do, writes no indexed_at.
+        return None
+
+    async def _noop(*_a, **_k):
+        return None
+
+    async def _tick_counter(*_a, **_k):
+        calls["n"] += 1
+        if calls["n"] >= 2:
+            raise asyncio.CancelledError
+        return None
+
+    monkeypatch.setattr(indexer, "index_vault", _noop_index)
+    monkeypatch.setattr(indexer, "embed_vault", _noop)
+    monkeypatch.setattr(indexer, "link_backfill_pass", _noop)
+    monkeypatch.setattr(indexer, "prewarm_search_caches", _noop)
+    # Ends the loop after one full tick.
+    monkeypatch.setattr(indexer, "cleanup_expired_tokens", _tick_counter)
+
+    with_cancel = indexer.run_indexer_loop()
+    try:
+        asyncio.run(with_cancel)
+    except asyncio.CancelledError:
+        pass
+
+    assert indexer.last_index_run_at is not None
+    assert indexer.last_index_run_ok is True
+
+
+def test_a_failing_tick_is_recorded_as_a_failed_run(monkeypatch):
+    monkeypatch.setattr(indexer, "last_index_run_at", None)
+    monkeypatch.setattr(indexer, "last_index_run_ok", None)
+    monkeypatch.setattr(indexer.settings, "multi_user_mode", False)
+    monkeypatch.setattr(indexer.settings, "index_interval_seconds", 0)
+    monkeypatch.setattr(indexer, "_is_paused", lambda: False)
+
+    state = {"ticks": 0}
+
+    async def _noop(*_a, **_k):
+        return None
+
+    async def _boom(*_a, **_k):
+        state["ticks"] += 1
+        if state["ticks"] == 1:
+            # Let the startup pass through, then fail the first real tick.
+            return None
+        if state["ticks"] > 2:
+            raise asyncio.CancelledError
+        raise RuntimeError("database is down")
+
+    monkeypatch.setattr(indexer, "index_vault", _boom)
+    monkeypatch.setattr(indexer, "embed_vault", _noop)
+    monkeypatch.setattr(indexer, "link_backfill_pass", _noop)
+    monkeypatch.setattr(indexer, "prewarm_search_caches", _noop)
+    monkeypatch.setattr(indexer, "cleanup_expired_tokens", _noop)
+
+    try:
+        asyncio.run(indexer.run_indexer_loop())
+    except asyncio.CancelledError:
+        pass
+
+    assert indexer.last_index_run_at is not None
+    assert indexer.last_index_run_ok is False
+
+
+def test_startup_pass_records_a_run(monkeypatch):
+    """Otherwise the dashboard reads "Never" for a whole interval after every
+    restart — the same false alarm from the other direction."""
+    monkeypatch.setattr(indexer, "last_index_run_at", None)
+    monkeypatch.setattr(indexer, "last_index_run_ok", None)
+    monkeypatch.setattr(indexer.settings, "multi_user_mode", False)
+    monkeypatch.setattr(indexer, "_is_paused", lambda: False)
+
+    async def _noop(*_a, **_k):
+        return None
+
+    async def _stop(*_a, **_k):
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(indexer, "index_vault", _noop)
+    monkeypatch.setattr(indexer, "embed_vault", _noop)
+    monkeypatch.setattr(indexer, "link_backfill_pass", _noop)
+    # Cancel while the loop is asleep, i.e. before any tick can record.
+    monkeypatch.setattr(indexer.asyncio, "sleep", _stop)
+
+    try:
+        asyncio.run(indexer.run_indexer_loop())
+    except asyncio.CancelledError:
+        pass
+
+    assert indexer.last_index_run_at is not None
+    assert indexer.last_index_run_ok is True
+
+
+# --- 1b. the dashboard reads the heartbeat, not max(indexed_at) -----------
+
+
+class _Scalar:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar(self):
+        return self._value
+
+    def scalars(self):
+        outer = self
+
+        class _S:
+            def all(self_inner):
+                return outer._value if isinstance(outer._value, list) else []
+
+        return _S()
+
+    def fetchall(self):
+        return []
+
+
+class _DashboardSession:
+    """Feeds `dashboard` scalars; `max(indexed_at)` is the one that matters."""
+
+    def __init__(self, last_indexed):
+        self._last_indexed = last_indexed
+        self.n = 0
+
+    async def execute(self, stmt, *_a, **_k):
+        self.n += 1
+        text = str(stmt).lower()
+        if "max(" in text:
+            return _Scalar(self._last_indexed)
+        if "select" in text and "usage_logs" in text and "count" not in text:
+            return _Scalar([])
+        return _Scalar(0)
+
+
+class _Request:
+    def __init__(self):
+        self.session = {}
+        self.scope = {}
+        self.query_params = {}
+
+
+class _AdminUser:
+    id = 1
+    username = "max"
+    is_admin = True
+    is_active = True
+
+
+def _dashboard_context(monkeypatch, last_indexed, last_run, last_run_ok=True):
+    captured = {}
+
+    def _fake_response(request, name, context):
+        captured["context"] = context
+        return None
+
+    monkeypatch.setattr(routes.templates, "TemplateResponse", _fake_response)
+    monkeypatch.setattr(routes, "generate_csrf_token", lambda _r: "csrf")
+    monkeypatch.setattr(indexer, "last_index_run_at", last_run)
+    monkeypatch.setattr(indexer, "last_index_run_ok", last_run_ok)
+
+    async def _graph(*_a, **_k):
+        return {}
+
+    monkeypatch.setattr(routes, "_graph_stats", _graph)
+    asyncio.run(
+        routes.dashboard(
+            request=_Request(),
+            session=_DashboardSession(last_indexed),
+            user=_AdminUser(),
+        )
+    )
+    return captured["context"]
+
+
+def test_dashboard_last_run_is_the_heartbeat_not_the_newest_note(monkeypatch):
+    """The weekend scenario: nothing has changed since Friday, the indexer ran
+    a minute ago. "Last run" must say a minute ago."""
+    now = datetime.now(timezone.utc)
+    ctx = _dashboard_context(
+        monkeypatch,
+        last_indexed=now - timedelta(days=3),
+        last_run=now - timedelta(seconds=30),
+    )
+    assert ctx["last_run_rel"] == "just now"
+    assert "day" in ctx["last_indexed_rel"], "the note-change stat is still reported"
+    assert ctx["last_run_iso"] != ctx["last_indexed_iso"]
+    assert ctx["last_run_ok"] is True
+
+
+def test_dashboard_reports_a_failed_last_pass(monkeypatch):
+    ctx = _dashboard_context(
+        monkeypatch,
+        last_indexed=None,
+        last_run=datetime.now(timezone.utc),
+        last_run_ok=False,
+    )
+    assert ctx["last_run_ok"] is False
+
+
+def test_dashboard_before_the_first_pass_says_never(monkeypatch):
+    ctx = _dashboard_context(monkeypatch, last_indexed=None, last_run=None)
+    assert ctx["last_run_iso"] is None
+    assert ctx["last_run_rel"] == "never"
+
+
+# --- 1c. the template labels -----------------------------------------------
+
+
+def _render_dashboard(**overrides) -> str:
+    context = {
+        "active": "dashboard",
+        "is_admin": True,
+        "multi_user_mode": False,
+        "username": "max",
+        "csrf_token": "csrf",
+        "stats": {
+            "notes_indexed": 10,
+            "notes_with_embeddings": 10,
+            "embedding_pct": 100,
+            "active_keys": 1,
+            "requests_today": 3,
+        },
+        "recent_usage": [],
+        "reindexed_24h": 0,
+        "last_indexed_iso": "2026-08-17T00:00:00+00:00",
+        "last_indexed_rel": "3 days ago",
+        "last_run_iso": "2026-08-20T12:00:00+00:00",
+        "last_run_rel": "just now",
+        "last_run_ok": True,
+        "index_interval": 300,
+        "graph": {},
+        "graph_backfill_running": False,
+    }
+    context.update(overrides)
+    templates = Jinja2Templates(directory=TEMPLATES_DIR)
+    response = templates.TemplateResponse(
+        request=None,  # dashboard.html never touches `request` directly
+        name="dashboard.html",
+        context=context,
+    )
+    return response.body.decode()
+
+
+def test_last_run_row_renders_the_heartbeat_timestamp():
+    html = _render_dashboard()
+    idx = html.find(">Last run<")
+    assert idx != -1
+    window = html[idx : idx + 400]
+    assert "2026-08-20T12:00:00+00:00" in window
+    assert "2026-08-17T00:00:00+00:00" not in window
+
+
+def test_last_change_detected_row_exists_and_carries_max_indexed_at():
+    html = _render_dashboard()
+    idx = html.find(">Last change detected<")
+    assert idx != -1, "max(indexed_at) lost its own label"
+    window = html[idx : idx + 400]
+    assert "2026-08-17T00:00:00+00:00" in window
+
+
+def test_a_failed_pass_is_visible_on_the_card():
+    ok = _render_dashboard()
+    failed = _render_dashboard(last_run_ok=False)
+    assert "failed" in failed.lower()
+    assert failed.lower().count("failed") > ok.lower().count("failed")
+
+
+# --- 2. the usage log records a tool that exists --------------------------
+
+
+def test_keyword_search_is_logged_under_its_registered_name():
+    from src.mcp_server import server
+
+    registered = server.keyword_search.__name__
+    assert registered == "keyword_search"
+
+    src = inspect.getsource(tools)
+    assert '@_tracked("keyword_search"' in src
+    assert '@_tracked("search_notes"' not in src
+
+
+def test_usage_detail_still_renders_historical_search_notes_rows():
+    """Rows written before the rename keep the old string; the panel must
+    still show their query."""
+    src = inspect.getsource(routes.dashboard)
+    assert '"search_notes"' in src
+
+    # And the behaviour, not just the source: pull `_usage_detail` out of the
+    # handler's own code object so the tuple under test is the live one.
+    detail = None
+    for const in routes.dashboard.__code__.co_consts:
+        if getattr(const, "co_name", None) == "_usage_detail":
+            detail = const
+            break
+    assert detail is not None
+    tool_tuples = [c for c in detail.co_consts if isinstance(c, tuple)]
+    search_tuple = next(t for t in tool_tuples if "semantic_search" in t)
+    assert "search_notes" in search_tuple, "historical rows lost their detail"
+    assert "keyword_search" in search_tuple

--- a/tests/test_issue_78_panel_labels.py
+++ b/tests/test_issue_78_panel_labels.py
@@ -145,6 +145,84 @@ def test_a_failing_tick_is_recorded_as_a_failed_run(monkeypatch):
     assert indexer.last_index_run_ok is False
 
 
+def test_multi_user_tick_with_a_failing_user_is_not_a_healthy_run(monkeypatch):
+    """`_index_pass_once` swallows per-user exceptions so one broken vault
+    cannot stop the others — but the tick must not then be stamped `ok=True`.
+    Swallow-and-report-healthy is the same "reports fine, is not" defect the
+    heartbeat exists to remove."""
+    monkeypatch.setattr(indexer, "last_index_run_at", None)
+    monkeypatch.setattr(indexer, "last_index_run_ok", None)
+    monkeypatch.setattr(indexer.settings, "multi_user_mode", True)
+    monkeypatch.setattr(indexer.settings, "index_interval_seconds", 0)
+    monkeypatch.setattr(indexer, "_is_paused", lambda: False)
+
+    seen = []
+    phase = {"startup": True}
+
+    async def _users(*_a, **_k):
+        return [1, 2, 3]
+
+    async def _index(user_id=None, **_k):
+        if phase["startup"]:
+            return None
+        seen.append(user_id)
+        if user_id == 2:
+            raise RuntimeError("user 2's vault is gone")
+        return None
+
+    async def _noop(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(indexer, "_active_user_ids", _users)
+    monkeypatch.setattr(indexer, "index_vault", _index)
+    monkeypatch.setattr(indexer, "embed_vault", _noop)
+    monkeypatch.setattr(indexer, "link_backfill_pass", _noop)
+    monkeypatch.setattr(indexer, "prewarm_search_caches", _noop)
+    monkeypatch.setattr(indexer, "cleanup_expired_tokens", _noop)
+
+    sleeps = {"n": 0}
+
+    async def _sleep(*_a, **_k):
+        # First sleep starts the first periodic tick; the second means that
+        # tick finished — and, crucially, that it has already recorded its
+        # heartbeat, which is what this test reads.
+        sleeps["n"] += 1
+        phase["startup"] = False
+        if sleeps["n"] >= 2:
+            raise asyncio.CancelledError
+
+    monkeypatch.setattr(indexer.asyncio, "sleep", _sleep)
+
+    try:
+        asyncio.run(indexer.run_indexer_loop())
+    except asyncio.CancelledError:
+        pass
+
+    assert seen == [1, 2, 3], "one user's failure must not abort the others"
+    assert indexer.last_index_run_ok is False, (
+        "a tick that swallowed a per-user failure was stamped healthy"
+    )
+
+
+def test_index_pass_once_reports_each_stage(monkeypatch):
+    async def _ok(*_a, **_k):
+        return None
+
+    async def _fail(*_a, **_k):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(indexer, "index_vault", _ok)
+    monkeypatch.setattr(indexer, "embed_vault", _ok)
+    assert asyncio.run(indexer._index_pass_once(1)) is True
+
+    monkeypatch.setattr(indexer, "index_vault", _fail)
+    assert asyncio.run(indexer._index_pass_once(1)) is False
+
+    monkeypatch.setattr(indexer, "index_vault", _ok)
+    monkeypatch.setattr(indexer, "embed_vault", _fail)
+    assert asyncio.run(indexer._index_pass_once(1)) is False
+
+
 def test_startup_pass_records_a_run(monkeypatch):
     """Otherwise the dashboard reads "Never" for a whole interval after every
     restart — the same false alarm from the other direction."""

--- a/tests/test_search_phase_timing.py
+++ b/tests/test_search_phase_timing.py
@@ -213,7 +213,7 @@ async def test_no_leakage_into_a_later_call_in_the_same_task(monkeypatch, captur
     await tools.search_notes_impl("needle")
 
     first = captured.params_for("semantic_search")
-    second = captured.params_for("search_notes")
+    second = captured.params_for("keyword_search")
     assert first["embed_ms"] >= 0
     assert "embed_ms" not in second
     assert "db_ms" not in second
@@ -242,7 +242,7 @@ async def test_holder_is_cleared_even_when_the_tool_raises(monkeypatch, captured
     monkeypatch.setattr(tools, "async_session", lambda: _FTSSession())
     monkeypatch.setattr("src.services.search.combined_tsquery", lambda _q: "tsq")
     await tools.search_notes_impl("needle")
-    assert "db_ms" not in captured.params_for("search_notes")
+    assert "db_ms" not in captured.params_for("keyword_search")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #70, closes #69, closes #78. Addresses the keys/users half of #76 (the OAuth half ships with the grant-families PR, which closes it).

- #70 `vault.html` renders the `vault_error` empty state (non-admins too).
- #69 self-edit cannot demote/deactivate the actor: checkboxes `disabled`, handler pins the flags; every admin/active-flag mutation is serialized with a transaction-scoped `pg_advisory_xact_lock` and re-validates the actor under the lock.
- #76 `keys_page` applies the middleware predicate (owner `is_active`, `expires_at`), Owner column in multi-user mode, users list renders "N active / M total".
- #78 indexer heartbeat (`last_index_run_at/ok`, failure-aware in multi-user) shown as "Last run"; `max(indexed_at)` relabelled "Last change detected"; `usage_logs.tool` now records `keyword_search`.

Gates: Codex adversarial 2 rounds (remaining findings belong to other branches); 1017 passed / 5 skipped on the rebased branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mSEspK9GFPSdxmK9XrrMQ