### PR TITLE
Vault unassignment revokes every MCP tool; request-scoped vault snapshot; ownerless credentials fail closed (#66)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -416,12 +416,23 @@ told the operator "vault tools error".
 - **`_vault_root` must stay a pure cache lookup.** What makes that correct is
   `APIKeyMiddleware` calling `warm_user_vault_cache(session, user_id)` on
   *every* authenticated MCP request. Do not add a DB query to the gate.
-- **The single-user form of that warm is authoritative — it evicts.** It used
-  to be a silent no-op for a NULL `vault_path`, so a previously cached root
-  survived; the panel's `clear_user_vault_cache` only clears the worker that
-  served the POST. Eviction is what makes a mid-session unassignment visible
-  from the next call in every process. The bulk form stays add-only (it would
-  otherwise drop a just-warmed entry for a user created after its query).
+- **The single-user form of that warm is authoritative — it evicts**, and it
+  returns the root it read. It used to be a silent no-op for a NULL
+  `vault_path`, so a previously cached root survived; the panel's
+  `clear_user_vault_cache` only clears the worker that served the POST.
+- **`_vault_root` prefers the request's own snapshot over the shared dict, and
+  that is the part that fails closed.** `_user_vault_cache` is process-global
+  and the indexer's bulk warm is add-only, so a bulk `SELECT` issued *before*
+  the admin cleared `vault_path` can land *after* the per-request warm evicted
+  the entry and put the revoked root back — mid-request, with a write tool in
+  flight. Eviction cannot order a query that was already running. So the
+  middleware binds `current_vault_root = (user_id, Path | None)` (a ContextVar
+  beside `current_user_id` in `src/auth/session.py`) and the gate reads that;
+  no other task can write this request's context. **Do not "simplify" the gate
+  back to the dict** — the bulk warm's add-only behaviour is safe only because
+  the snapshot outranks it. The snapshot is keyed by user id (another user's
+  snapshot falls through to the dict) and is never consulted for
+  `user_id is None`.
 - **A cold cache refuses too**, with the same message — it is not permission to
   serve stale rows — and the refusal is written to `usage_logs` with
   `params["error"] = "no_vault_assigned"` and no other new field.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -438,6 +438,25 @@ told the operator "vault tools error".
   `params["error"] = "no_vault_assigned"` and no other new field.
 - Single-user and sandbox mode are untouched: `current_user_id` is None there
   and `_vault_root(None)` answers from `settings.vault_path`.
+- **In multi-user mode, `user_id is None` is a refusal, not the global vault.**
+  An ownerless credential — `api_keys.user_id` / `oauth_tokens.user_id` NULL —
+  is the *single-user* shape, and it survives a configuration cycle: a key
+  minted while multi-user was off keeps its NULL, and the bootstrap backfill in
+  `src/auth/routes.py` only claims NULL rows while `users` is empty, so
+  flipping the flag after users exist never adopts it. Every layer then treated
+  that key as single-user and handed it `settings.vault_path` — an ownerless
+  *readwrite* key could edit the whole vault. `APIKeyMiddleware` now 401s such
+  a credential (`reason=ownerless_credential`, same body as any other rejected
+  key, on both the API-key and OAuth branches) and `_vault_root(None)` raises
+  when `settings.multi_user_mode`. Two layers on purpose: the middleware is the
+  gate, `_vault_root` is the one that cannot be bypassed by a future caller.
+- **The panel's vault browser uses what the warm returned, not a re-read of the
+  dict.** `vault_page` warmed the cache and then called `_vault_root(user.id)`,
+  which reopens the same window: a stale bulk warm landing in between served an
+  unassigned user's vault. It now takes the `Path | None` from
+  `warm_user_vault_cache` directly and renders the `vault_error` empty state on
+  None. Any new caller that warms-then-resolves has the same bug — use the
+  return value.
 
 ## Graph tools
 - `get_backlinks(path, limit)` — notes that link TO `path` (resolved links only).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -389,6 +389,45 @@ lives in a service module only to avoid an import cycle (`tools` imports
 return types are unchanged — a direct call outside a tracked tool finds no
 holder and records nothing. No migration: `params` is JSONB.
 
+## The vault assignment is the admission gate for every tool
+
+`_tracked` in `src/mcp_server/tools.py` resolves `_vault_root(current_user_id)`
+**once, before the tool body runs**, and fails the call with a tool error when
+it raises. That is the whole enforcement of "this user has no vault", and it
+lives in the shared decorator on purpose.
+
+Per-tool checks were the bug (#66). The tools that leaked — `semantic_search`,
+`keyword_search`, `list_notes`, `get_recent` and every graph tool — are exactly
+the ones with no reason to call `_vault_root`: they are served from
+`notes_metadata` / `note_embeddings` filtered by `user_id` alone. Unassigning
+`users.vault_path` stopped only the disk-touching tools, while the indexer's
+`_active_user_ids()` (which filters `vault_path IS NOT NULL`) meant the user's
+rows were never pruned either. An unchanged API key kept returning paths,
+titles, tags, frontmatter and chunk excerpts indefinitely, while the panel had
+told the operator "vault tools error".
+
+- **Nothing is exempt.** Every `_tracked` tool reads or writes vault content or
+  vault metadata — `get_vault_guide` returns the vault's own `CLAUDE.md`,
+  `check_upload` reports a published vault path and digest. Keep the exemption
+  list at zero; a new tool inherits the gate by being registered.
+- **The index rows are preserved.** Deleting `notes_metadata` on the NULL
+  transition was the weaker fix: it forces a full re-embed on reassignment and
+  leaves the credential itself unaddressed.
+- **`_vault_root` must stay a pure cache lookup.** What makes that correct is
+  `APIKeyMiddleware` calling `warm_user_vault_cache(session, user_id)` on
+  *every* authenticated MCP request. Do not add a DB query to the gate.
+- **The single-user form of that warm is authoritative — it evicts.** It used
+  to be a silent no-op for a NULL `vault_path`, so a previously cached root
+  survived; the panel's `clear_user_vault_cache` only clears the worker that
+  served the POST. Eviction is what makes a mid-session unassignment visible
+  from the next call in every process. The bulk form stays add-only (it would
+  otherwise drop a just-warmed entry for a user created after its query).
+- **A cold cache refuses too**, with the same message — it is not permission to
+  serve stale rows — and the refusal is written to `usage_logs` with
+  `params["error"] = "no_vault_assigned"` and no other new field.
+- Single-user and sandbox mode are untouched: `current_user_id` is None there
+  and `_vault_root(None)` answers from `settings.vault_path`.
+
 ## Graph tools
 - `get_backlinks(path, limit)` — notes that link TO `path` (resolved links only).
 - `get_links(path)` — outgoing links from `path`, both resolved and dangling.

--- a/openspec/changes/vault-unassignment-revokes-tools/design.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/design.md
@@ -144,3 +144,65 @@ time. An in-flight call that passed the gate microseconds before the admin
 saved the unassignment completes. That is the same optimistic level as every
 other revocation in this server except the transfer publish gate, which holds
 `FOR UPDATE` locks across the filesystem write precisely because it can.
+
+
+## Ownerless credentials: `user_id is None` means two different things
+
+`user_id IS NULL` on an `api_keys` / `oauth_tokens` row is the *single-user*
+shape, and single-user mode is where `_vault_root(None)` returning
+`settings.vault_path` is correct. The problem is that the NULL outlives the
+configuration it belonged to:
+
+- a key minted while `MULTI_USER_MODE=false` keeps `user_id = NULL`;
+- the bootstrap backfill in `src/auth/routes.py` adopts every NULL row for the
+  first administrator, but it only runs while `users` is **empty** — it is
+  guarded by `_users_table_empty(session)` under an advisory lock;
+- so flipping the flag *after* users exist leaves those NULLs unclaimed
+  forever.
+
+Such a key then authenticated (the middleware only checks activity and expiry),
+skipped the warm (`if api_key.user_id is not None`), left `current_user_id` at
+None, and got the global vault from `_vault_root(None)` — including for
+`readwrite`, i.e. `edit_note` over the whole vault with no owner.
+
+Both layers are fixed, deliberately:
+
+- **`APIKeyMiddleware` 401s it** (both branches, `reason=ownerless_credential`,
+  the same response body as any other rejected credential — which check failed
+  is not disclosed). This is the gate.
+- **`_vault_root(None)` raises when `settings.multi_user_mode`.** This is the
+  invariant. The middleware can be bypassed by a future caller that resolves a
+  root outside a request; the resolver cannot.
+
+The bootstrap flow is unaffected: it is a panel `POST /admin/auth/register`
+handled by FastAPI, never routed through `APIKeyMiddleware`, and it does not
+resolve a vault root before the admin row exists. Single-user mode is
+unaffected in both layers — the checks are conditioned on
+`settings.multi_user_mode`.
+
+## Warm-then-resolve is the same bug in a second place
+
+`vault_page` did:
+
+```python
+await warm_user_vault_cache(session, user.id)
+vault = _vault_root(user.id)      # <- re-reads the shared dict
+```
+
+which reopens exactly the window the tool gate closes: the stale bulk warm can
+land between the two statements. The fix is the same idea as the ContextVar —
+**use the value the warm returned** — expressed in the simplest form available
+to a handler that already has it in hand:
+
+```python
+vault = await warm_user_vault_cache(session, user.id)
+if vault is None:
+    vault_error = vault_unassigned_error(user.id)
+```
+
+The message comes from `vault_unassigned_error()` so the panel and the agent
+are told the same thing. `vault.html` is untouched — the `vault_error` empty
+state it already renders is the refusal.
+
+Any future caller that warms and then resolves has this bug. The rule is in
+CLAUDE.md: use the return value.

--- a/openspec/changes/vault-unassignment-revokes-tools/design.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/design.md
@@ -1,0 +1,92 @@
+# Design — vault unassignment revokes every tool
+
+## Where the gate goes, and why not in the tools
+
+Issue #66 offered two fixes. Deleting the user's `notes_metadata` rows on the
+NULL transition (embeddings and links cascade) revokes the data but destroys an
+index a reassignment would have to rebuild from scratch — for a 2,500-note
+vault that is a full re-embed. It also leaves the *authorisation* question
+unanswered: the key still authenticates, and the next tool that grows a
+DB-backed path is leaky again by default.
+
+The gate therefore lives in `_tracked`, the decorator every tool impl already
+wears, and the index is preserved.
+
+Putting it in the individual tools was rejected for the reason the bug exists:
+the leaky tools are exactly the ones that had no reason to call `_vault_root`,
+so a per-tool check is a list somebody must remember to extend. One gate in the
+shared decorator is enforced by construction — a new tool cannot be registered
+without it, because registration goes through `_tracked`.
+
+## Fail closed, with an empty exemption list
+
+The rule applied: *if the user has no vault, no tool that reads or writes vault
+content or metadata may run.* Every `_tracked` tool does one of those, so the
+exemption list is empty. The two candidates worth naming:
+
+- `get_vault_guide` — returns a static primer **plus the vault's own
+  `CLAUDE.md`**. It reads vault content. Gated.
+- `check_upload` — reports `path`, `size`, `sha256`, `mime` for a completed
+  upload into the vault. That is vault metadata for a vault the caller no
+  longer holds. Gated. (Its own identity scoping is unchanged; the gate runs
+  first.)
+
+The remaining transfer tools (`request_upload`, `request_download`,
+`import_from_url`, `delete_file`) all mint or exercise a capability over a
+vault root, so gating them is not a judgement call.
+
+`_tracked` decorates nothing but MCP tool impls, so the gate has no other
+blast radius.
+
+## Cost: the hot path stays a dict lookup
+
+`_vault_root(uid)` is a `dict.get`. It must stay one — a DB round trip per tool
+call would be a new query on the hottest path in the server. What makes a pure
+cache lookup *correct* is that `APIKeyMiddleware` already re-reads
+`users.vault_path` from the database on **every** authenticated MCP request
+(`warm_user_vault_cache(session, api_key.user_id)`, and the same on the OAuth
+branch). The gate is therefore reading a value at most one request old.
+
+## Why the warm had to become authoritative
+
+The warm was add-only: `if row is not None: cache[id] = …`. With a NULL
+`vault_path` it did nothing, so a previously cached root survived. The panel
+compensates by calling `clear_user_vault_cache(target.id)`, but that only
+clears the cache **in the worker process that handled the panel POST**, and it
+only happens on that one code path. Under more than one worker, the other
+processes would keep serving from a stale entry indefinitely.
+
+Making the single-user form of the warm evict when the row is absent closes
+that: the per-request warm is now the authoritative refresh, so a mid-session
+unassignment is visible from the next tool call in every process, whether or
+not `clear_user_vault_cache` was called.
+
+The bulk form (`warm_user_vault_cache(session)` with no user id, used by the
+indexer) is deliberately left add-only. Making it authoritative would mean
+dropping entries that a concurrent per-request warm had just written for a user
+created after the bulk query ran — a spurious refusal for a legitimate caller.
+It is not needed: every consumer of `_vault_root(user_id)` (MCP tools, the
+panel's vault browser, the auth routes) warms that user individually first.
+
+## Cold cache is a refusal, not a 500
+
+`_vault_root` raises the same `RuntimeError` for "no assignment" and "never
+warmed". Both refuse, with the same message. A cold cache is not permission to
+serve stale rows, and a fresh process must not 500 on it. The operator-facing
+distinction is a `logger.warning("tool_refused_no_vault", extra={"user_id": …})`.
+
+## What the refusal says and logs
+
+A fixed string: no path, no query echo, no note content — the point of the fix
+is that this caller learns nothing further about the vault. The usage log gets
+`params["error"] = "no_vault_assigned"` alongside the existing allow-listed
+params; both are already-known values (the tool name and user id are columns),
+so the refusal is not a new disclosure channel.
+
+## Residual, stated
+
+The refusal is per tool call and reads a value refreshed at authentication
+time. An in-flight call that passed the gate microseconds before the admin
+saved the unassignment completes. That is the same optimistic level as every
+other revocation in this server except the transfer publish gate, which holds
+`FOR UPDATE` locks across the filesystem write precisely because it can.

--- a/openspec/changes/vault-unassignment-revokes-tools/design.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/design.md
@@ -38,6 +38,57 @@ vault root, so gating them is not a judgement call.
 `_tracked` decorates nothing but MCP tool impls, so the gate has no other
 blast radius.
 
+## The shared dict is not enough — the request keeps its own answer
+
+An earlier draft of this change stopped at "make the per-request warm evict".
+Adversarial review found that admission was still not fail-closed under
+concurrency, and it is worth writing down exactly why, because the fix looks
+redundant otherwise.
+
+`_user_vault_cache` is process-global, and *two* writers touch it: the
+per-request warm in `APIKeyMiddleware` and the indexer's bulk warm, which is
+add-only. Ordered interleaving:
+
+1. the indexer's bulk `SELECT` is issued; its snapshot still shows user 42 at
+   `/vaults/a`;
+2. the admin commits `vault_path = NULL` for user 42;
+3. an MCP request authenticates: its warm reads NULL and **evicts** 42;
+4. the older bulk query finally returns and **re-inserts** `/vaults/a`;
+5. the request, still in flight, reaches `_tracked` — which reads the restored
+   root and admits the call. `edit_note` then writes into a vault the caller no
+   longer holds.
+
+Eviction cannot fix this on its own: the losing writer is a query that was
+already in flight, so there is no ordering the dict can enforce after the fact.
+
+So `APIKeyMiddleware` binds the root **it** read to the request —
+`current_vault_root = (user_id, Path | None)`, a ContextVar next to
+`current_user_id` in `src/auth/session.py` — and `_vault_root` prefers that
+snapshot whenever it is set for the user being resolved. A ContextVar bound in
+this request's context cannot be written by the indexer task, so step 4 is
+inert. The shared dict remains the fallback for non-request contexts (the
+indexer itself, panel routes, tests).
+
+Two constraints held:
+
+- **`user_id is None` never consults the snapshot.** Single-user and sandbox
+  mode answer from `settings.vault_path` before the snapshot is read at all.
+- **The snapshot is keyed by user id.** A context carrying another user's
+  snapshot falls through to the dict rather than answering for the wrong vault.
+
+The alternative Codex offered — a version counter with compare-and-set on the
+dict — would also close the race, but it makes every reader depend on a
+monotonic source the DB does not currently provide, and it still leaves the
+shared dict as the authority for a decision that is per-request. The snapshot
+is smaller and the failure mode of a bug in it is a spurious refusal.
+
+`test_stale_bulk_warm_really_does_repopulate_the_shared_dict` pins step 4 as a
+real effect (the negative control), and
+`test_stale_bulk_warm_cannot_readmit_a_revoked_user` plus
+`test_api_key_middleware_binds_the_snapshot_and_the_tool_refuses` pin the
+refusal — the latter through the real middleware, with the stale bulk warm
+landing mid-request.
+
 ## Cost: the hot path stays a dict lookup
 
 `_vault_root(uid)` is a `dict.get`. It must stay one — a DB round trip per tool
@@ -62,11 +113,14 @@ unassignment is visible from the next tool call in every process, whether or
 not `clear_user_vault_cache` was called.
 
 The bulk form (`warm_user_vault_cache(session)` with no user id, used by the
-indexer) is deliberately left add-only. Making it authoritative would mean
-dropping entries that a concurrent per-request warm had just written for a user
-created after the bulk query ran — a spurious refusal for a legitimate caller.
-It is not needed: every consumer of `_vault_root(user_id)` (MCP tools, the
-panel's vault browser, the auth routes) warms that user individually first.
+indexer) is deliberately left add-only — but **that is only safe because of the
+request-scoped snapshot above**, not on its own. Making it authoritative would
+mean dropping entries that a concurrent per-request warm had just written for a
+user created after the bulk query ran, and it would still not fix the ordered
+race, whose losing writer is a query already in flight. Eviction in the
+per-request warm is therefore defence in depth for non-request contexts (the
+indexer, panel routes, a process with no snapshot bound); the snapshot is what
+makes admission itself fail closed.
 
 ## Cold cache is a refusal, not a 500
 

--- a/openspec/changes/vault-unassignment-revokes-tools/proposal.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/proposal.md
@@ -35,9 +35,17 @@ happening. (Issue #66, severity high.)
   allow-listed params as a successful call. No new field carries user content.
 - **`warm_user_vault_cache(session, user_id)` becomes authoritative.** It was
   a silent no-op when the user had no usable row, leaving a previously cached
-  root in place; it now evicts. That warm runs on every authenticated MCP
-  request, so a mid-session unassignment is refused from the next call in
-  *every* worker process, not only the one that served the panel request.
+  root in place; it now evicts and returns what it read. That warm runs on
+  every authenticated MCP request, so a mid-session unassignment is refused
+  from the next call in *every* worker process, not only the one that served
+  the panel request.
+- **The authenticated request keeps its own answer.** `APIKeyMiddleware` binds
+  the root it read to `current_vault_root` (a ContextVar beside
+  `current_user_id`), and `_vault_root` prefers that snapshot. Without it,
+  admission is still not fail-closed under concurrency: the indexer's bulk warm
+  is add-only, so a bulk `SELECT` issued before the revocation can land after
+  the per-request warm evicted the entry and re-admit the caller mid-request,
+  with a write tool in flight. See design.md.
 - **Single-user mode is untouched.** `current_user_id` is None there and
   `_vault_root(None)` answers from `settings.vault_path` without consulting
   the cache.
@@ -55,10 +63,13 @@ happening. (Issue #66, severity high.)
 ## Impact
 
 - `src/mcp_server/tools.py` — `_tracked` gate, `_vault_admission_error()`,
-  `_NO_VAULT_MESSAGE`, `_NO_VAULT_MARKER`
-- `src/services/vault.py` — `warm_user_vault_cache` evicts; `_vault_root`
-  docstring records that it is now the admission gate and must stay a cache
-  lookup
+  `_NO_VAULT_MESSAGE`, `_NO_VAULT_MARKER`, `__tracked_tool__` marker
+- `src/services/vault.py` — `warm_user_vault_cache` evicts and returns the
+  root; `_vault_root` prefers the request snapshot and records that it is now
+  the admission gate and must stay a cache lookup
+- `src/auth/session.py` — `current_vault_root` ContextVar + `UNSET_VAULT_ROOT`
+- `src/mcp_server/auth.py` — binds and resets the snapshot on both the API-key
+  and OAuth branches
 - `src/control_panel/templates/user_edit.html` — option label
 - `tests/test_issue_66_vault_unassignment_revokes_tools.py` — new
 - No database schema changes, no new dependencies, no migration

--- a/openspec/changes/vault-unassignment-revokes-tools/proposal.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/proposal.md
@@ -1,0 +1,64 @@
+## Why
+
+The control panel offers `(unassigned — vault tools error)` for a user's vault
+path. Selecting it NULLs `users.vault_path`, clears the in-process vault cache
+and flashes success — but the promise only held for the disk-touching tools.
+
+Everything served from the database kept working. `semantic_search`,
+`keyword_search`, `list_notes`, `get_recent` and every graph tool
+(`get_backlinks`, `get_links`, `get_neighborhood`, `find_orphans`,
+`find_related`) query `notes_metadata` / `note_embeddings` filtered by
+`user_id` alone and never call `_vault_root`. Nothing prunes those rows either:
+the indexer's `_active_user_ids()` filters `User.vault_path.isnot(None)`, so
+`index_vault(user_id=…)` — the only thing that deletes stale `notes_metadata`
+rows — never runs for that user again. The rows are frozen in place
+permanently and this never self-heals.
+
+The user's API key still authenticates (`src/mcp_server/auth.py` checks only
+key/user activity and expiry — there is no vault requirement), so the result is
+an **indefinite, fully queryable mirror of the content the user last held** —
+file paths, titles, tags, frontmatter and 200-char chunk excerpts, up to 50
+hits per call, unbounded calls — reachable with an unchanged credential, while
+the operator was told "vault tools error". `read_note` on any returned path
+correctly errors, which is exactly what makes the leak look like it isn't
+happening. (Issue #66, severity high.)
+
+## What Changes
+
+- **One admission gate for every MCP tool.** `_tracked` in
+  `src/mcp_server/tools.py` — the decorator every tool impl shares — resolves
+  the caller's vault root once, *before* the tool body runs, and fails the
+  whole call with a tool error when it cannot be resolved. Nothing is exempt:
+  every `_tracked` tool reads or writes vault content or vault metadata.
+- **The refusal is logged** like any other tool error, with an
+  `error: "no_vault_assigned"` marker in `usage_logs.params` and the same
+  allow-listed params as a successful call. No new field carries user content.
+- **`warm_user_vault_cache(session, user_id)` becomes authoritative.** It was
+  a silent no-op when the user had no usable row, leaving a previously cached
+  root in place; it now evicts. That warm runs on every authenticated MCP
+  request, so a mid-session unassignment is refused from the next call in
+  *every* worker process, not only the one that served the panel request.
+- **Single-user mode is untouched.** `current_user_id` is None there and
+  `_vault_root(None)` answers from `settings.vault_path` without consulting
+  the cache.
+- **The index rows are preserved** — deliberately. A reassignment of the same
+  path must not have to re-embed the vault from scratch.
+- **The option label is corrected** to state what the code now does:
+  `(unassigned — every MCP tool refuses; index kept for reassignment)`.
+
+## Capabilities
+
+### Modified Capabilities
+- `mcp-request-routing`: an authenticated MCP tool call is admitted only while
+  the caller has a resolvable vault root.
+
+## Impact
+
+- `src/mcp_server/tools.py` — `_tracked` gate, `_vault_admission_error()`,
+  `_NO_VAULT_MESSAGE`, `_NO_VAULT_MARKER`
+- `src/services/vault.py` — `warm_user_vault_cache` evicts; `_vault_root`
+  docstring records that it is now the admission gate and must stay a cache
+  lookup
+- `src/control_panel/templates/user_edit.html` — option label
+- `tests/test_issue_66_vault_unassignment_revokes_tools.py` — new
+- No database schema changes, no new dependencies, no migration

--- a/openspec/changes/vault-unassignment-revokes-tools/proposal.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/proposal.md
@@ -54,6 +54,25 @@ happening. (Issue #66, severity high.)
 - **The option label is corrected** to state what the code now does:
   `(unassigned — every MCP tool refuses; index kept for reassignment)`.
 
+Two further holes, both found by adversarial review of this change:
+
+- **An ownerless credential in multi-user mode was treated as single-user.** A
+  key or token with `user_id IS NULL` is the single-user shape, and it survives
+  a configuration cycle — mint it with multi-user off, enable multi-user after
+  users already exist, and the bootstrap backfill (which only claims NULL rows
+  while `users` is empty) never adopts it. The middleware skipped the warm,
+  `current_user_id` stayed None, and `_vault_root(None)` returned the global
+  `settings.vault_path`: an ownerless *readwrite* key could edit the whole
+  vault. `APIKeyMiddleware` now 401s such a credential on both branches
+  (`reason=ownerless_credential`), and `_vault_root(None)` raises when
+  multi-user mode is on. The panel bootstrap is unaffected — it runs in a panel
+  POST, not through the MCP middleware.
+- **The panel's vault browser lost the same race as the tools.** `vault_page`
+  called `warm_user_vault_cache(...)` and then re-read the shared dict through
+  `_vault_root`, so a stale bulk warm landing in between served an unassigned
+  user's vault. It now uses the `Path | None` the warm returns and renders the
+  existing `vault_error` empty state on None.
+
 ## Capabilities
 
 ### Modified Capabilities
@@ -69,7 +88,11 @@ happening. (Issue #66, severity high.)
   the admission gate and must stay a cache lookup
 - `src/auth/session.py` — `current_vault_root` ContextVar + `UNSET_VAULT_ROOT`
 - `src/mcp_server/auth.py` — binds and resets the snapshot on both the API-key
-  and OAuth branches
+  and OAuth branches; rejects ownerless credentials in multi-user mode
+- `src/services/vault.py` — `_vault_root(None)` raises in multi-user mode;
+  `vault_unassigned_error()` shared with the panel
+- `src/control_panel/routes.py` — `vault_page` browses the root the warm
+  returned
 - `src/control_panel/templates/user_edit.html` — option label
 - `tests/test_issue_66_vault_unassignment_revokes_tools.py` — new
 - No database schema changes, no new dependencies, no migration

--- a/openspec/changes/vault-unassignment-revokes-tools/specs/mcp-request-routing/spec.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/specs/mcp-request-routing/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Tool calls are admitted only while the caller holds a vault assignment
+Every MCP tool call SHALL resolve the caller's vault root once, before the tool
+body runs, and SHALL fail the call with a tool error when the root cannot be
+resolved. The check MUST live in the shared tool decorator rather than in
+individual tools, so that a tool served entirely from the database is covered
+without opting in. Refusal MUST NOT depend on whether the process cache was
+previously warmed, and MUST NOT delete the caller's `notes_metadata`,
+`note_embeddings` or `note_links` rows.
+
+#### Scenario: Database-backed search after unassignment
+- **WHEN** an administrator clears a multi-user account's vault path and the
+  account's unchanged, still-active API key calls `semantic_search`,
+  `keyword_search`, `list_notes` or `get_recent`
+- **THEN** the call SHALL be refused with a tool error naming no note path,
+  title, tag, frontmatter value or chunk excerpt
+
+#### Scenario: Graph tools after unassignment
+- **WHEN** the same credential calls `get_backlinks`, `get_links`,
+  `get_neighborhood`, `find_orphans` or `find_related`
+- **THEN** the call SHALL be refused with the same tool error
+
+#### Scenario: No exemptions for vault content or vault metadata
+- **WHEN** the same credential calls any registered tool, including
+  `get_vault_guide` (which returns the vault's own `CLAUDE.md`) and
+  `check_upload` (which reports a published vault path, size and digest)
+- **THEN** the call SHALL be refused
+
+#### Scenario: Cold process cache is a refusal, not an error response
+- **WHEN** a freshly started worker process that has never cached this user's
+  vault root receives a tool call from that user
+- **THEN** the call SHALL be refused with the same tool error rather than
+  raising an unhandled exception
+
+#### Scenario: The index survives the refusal
+- **WHEN** the account's vault path is assigned again to the same directory
+- **THEN** the previously indexed rows SHALL still be present, so tool calls
+  resume without a full re-index
+
+### Requirement: A refused tool call is recorded in the usage log
+A tool call refused for a missing vault assignment SHALL be written to
+`usage_logs` like any other tool error, carrying an error marker and the same
+allow-listed parameters as a successful call, and no additional field.
+
+#### Scenario: Refusal is auditable
+- **WHEN** a tool call is refused for a missing vault assignment
+- **THEN** a `usage_logs` row SHALL be written for that tool with an error
+  marker in `params` and the tool's normal allow-listed parameters
+
+#### Scenario: Refusal adds no new logged field
+- **WHEN** that row is written
+- **THEN** `params` SHALL contain no parameter outside the tool's existing
+  allow-list plus the error marker
+
+### Requirement: Single-user mode is unaffected by the admission gate
+In single-user mode the vault root SHALL continue to come from configuration
+and every tool SHALL continue to run, regardless of the multi-user vault-path
+cache.
+
+#### Scenario: Single-user call with an empty multi-user cache
+- **WHEN** a tool is called with no current user id (single-user mode, or the
+  registry-evaluation sandbox mode that bypasses authentication) and the
+  multi-user vault-path cache is empty
+- **THEN** the tool body SHALL run against the configured vault path and the
+  usage log SHALL carry no error marker
+
+### Requirement: Refreshing a user's cached vault root removes a revoked assignment
+Refreshing the cached vault root for a single user SHALL write the user's
+current assignment or remove the cached entry when the user has no usable
+assignment, so that a revocation takes effect on the next authenticated tool
+call in every worker process without depending on an explicit cache-clear call.
+
+#### Scenario: Mid-session unassignment in a process that did not serve the panel request
+- **WHEN** a user's vault path is cleared and a worker process that still holds
+  the previous value refreshes that user's cached root while authenticating the
+  next tool call
+- **THEN** the cached entry SHALL be removed and the tool call SHALL be refused
+
+#### Scenario: Deactivated user
+- **WHEN** the refresh finds the user inactive or absent
+- **THEN** the cached entry SHALL be removed

--- a/openspec/changes/vault-unassignment-revokes-tools/specs/mcp-request-routing/spec.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/specs/mcp-request-routing/spec.md
@@ -33,6 +33,16 @@ previously warmed, and MUST NOT delete the caller's `notes_metadata`,
 - **THEN** the call SHALL be refused with the same tool error rather than
   raising an unhandled exception
 
+#### Scenario: Operator-facing label matches the enforcement
+- **WHEN** an administrator opens the vault-path selector on the user edit page
+- **THEN** the unassigned option SHALL state that every MCP tool refuses and
+  that the index is kept for reassignment
+
+#### Scenario: Every registered tool is covered
+- **WHEN** the set of tools registered on the MCP server is enumerated
+- **THEN** each one SHALL delegate to an implementation carrying the shared
+  admission gate, so a tool added later inherits it by being registered
+
 #### Scenario: The index survives the refusal
 - **WHEN** the account's vault path is assigned again to the same directory
 - **THEN** the previously indexed rows SHALL still be present, so tool calls
@@ -80,3 +90,28 @@ call in every worker process without depending on an explicit cache-clear call.
 #### Scenario: Deactivated user
 - **WHEN** the refresh finds the user inactive or absent
 - **THEN** the cached entry SHALL be removed
+
+### Requirement: A concurrent cache refresh cannot re-admit a revoked caller
+The vault root that admits a tool call SHALL be the value read while
+authenticating that request, and a concurrent or stale refresh of the shared
+process-level cache SHALL NOT be able to override it. The snapshot SHALL be
+scoped to the request and to the user it was read for, and SHALL NOT be
+consulted in single-user mode.
+
+#### Scenario: Stale bulk refresh lands after the revocation
+- **WHEN** a bulk cache refresh whose database snapshot predates the
+  revocation completes *after* the request's own refresh observed the cleared
+  assignment, and the request then calls a tool
+- **THEN** the call SHALL be refused, even though the shared cache once again
+  holds the previous vault root
+
+#### Scenario: Snapshot does not answer for another user
+- **WHEN** a vault root is resolved for a user other than the one the request
+  authenticated as
+- **THEN** the request snapshot SHALL be ignored and the shared cache
+  consulted instead
+
+#### Scenario: Snapshot does not outlive the request
+- **WHEN** the authenticated request completes
+- **THEN** the snapshot SHALL be cleared, leaving later work in that process
+  with no request-scoped vault root

--- a/openspec/changes/vault-unassignment-revokes-tools/specs/mcp-request-routing/spec.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/specs/mcp-request-routing/spec.md
@@ -115,3 +115,50 @@ consulted in single-user mode.
 - **WHEN** the authenticated request completes
 - **THEN** the snapshot SHALL be cleared, leaving later work in that process
   with no request-scoped vault root
+
+### Requirement: An ownerless credential is refused in multi-user mode
+A credential that is not bound to a user SHALL be rejected at authentication whenever multi-user mode is enabled, and resolving a vault root with no user SHALL raise rather than falling back to the globally configured vault path.
+Single-user mode SHALL be unaffected, and the panel bootstrap flow — which
+claims unbound rows for the first administrator — SHALL keep working.
+
+#### Scenario: Key minted before multi-user was enabled
+- **WHEN** multi-user mode is enabled and a still-active API key whose owner is
+  unset is presented to the MCP endpoint
+- **THEN** the request SHALL be rejected as unauthenticated, with the same
+  response body as any other rejected key
+
+#### Scenario: OAuth token with no owner
+- **WHEN** the same situation arises for an OAuth access token
+- **THEN** the request SHALL be rejected as unauthenticated
+
+#### Scenario: No fallback to the configured vault path
+- **WHEN** a vault root is resolved with no user while multi-user mode is
+  enabled
+- **THEN** resolution SHALL fail, so no caller can reach the globally
+  configured vault by having no owner
+
+#### Scenario: Single-user mode still serves an unbound credential
+- **WHEN** multi-user mode is disabled and a credential with no owner is
+  presented
+- **THEN** the request SHALL authenticate and resolve the configured vault path
+  as before
+
+### Requirement: The panel vault browser uses the root it just read
+The control panel's vault browser SHALL browse the vault root returned by the
+refresh it performs for the signed-in user, not a subsequent re-read of the
+shared process cache, and SHALL render its empty state when that refresh
+reports no assignment.
+
+#### Scenario: Stale refresh lands between the read and the browse
+- **WHEN** a bulk cache refresh predating the revocation repopulates the shared
+  cache after the page's own refresh observed the cleared assignment
+- **THEN** the page SHALL render the no-vault empty state and list no folders
+  or notes
+
+### Requirement: The admission gate performs no database work
+Resolving the caller's vault root for admission SHALL NOT issue a database
+statement, so the check costs nothing on the hot path.
+
+#### Scenario: Assigned caller invokes a tool
+- **WHEN** an assigned caller's tool call passes the admission gate
+- **THEN** the gate SHALL have opened no database session

--- a/openspec/changes/vault-unassignment-revokes-tools/tasks.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/tasks.md
@@ -64,7 +64,39 @@
       snapshot does not outlive the request
 - [x] 5.14 Assert the *rendered* option text from `user_edit.html`
 
+## 7. Ownerless credentials (multi-user mode)
+
+- [x] 7.1 `APIKeyMiddleware` 401s an API key with `user_id IS NULL` when
+      `settings.multi_user_mode`, logging `reason=ownerless_credential` and
+      returning the same body as any other rejected key
+- [x] 7.2 Same on the OAuth-token branch
+- [x] 7.3 `_vault_root(None)` raises in multi-user mode instead of returning
+      `settings.vault_path`
+- [x] 7.4 Confirm the bootstrap backfill in `src/auth/routes.py` is unaffected:
+      it runs in the panel POST `/admin/auth/register`, never through
+      `APIKeyMiddleware`, and only while `users` is empty
+- [x] 7.5 Single-user mode unchanged — an unbound credential still
+      authenticates and resolves `settings.vault_path`
+
+## 8. Panel vault browser
+
+- [x] 8.1 `vault_page` uses the `Path | None` returned by
+      `warm_user_vault_cache` instead of re-reading the shared cache through
+      `_vault_root`
+- [x] 8.2 None renders the existing `vault_error` empty state; `vault.html` is
+      not edited
+- [x] 8.3 Deterministic replay test: the warm returns None while a stale bulk
+      warm restores the revoked root, and the page still refuses
+
+## 9. Cost
+
+- [x] 9.1 Test asserting the admission gate opens no database session for an
+      assigned request (both DB entry points booby-trapped, and the gate is a
+      sync function)
+
 ## 6. Documentation
 
 - [x] 6.1 Record the gate in `CLAUDE.md` next to the multi-user vault behaviour
 - [x] 6.2 `openspec validate vault-unassignment-revokes-tools --strict` passes
+- [x] 6.3 CLAUDE.md records the ownerless-credential rule and the
+      warm-then-resolve hazard in the panel

--- a/openspec/changes/vault-unassignment-revokes-tools/tasks.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/tasks.md
@@ -1,0 +1,53 @@
+## 1. Admission gate
+
+- [x] 1.1 Add `_NO_VAULT_MESSAGE`, `_NO_VAULT_MARKER` and
+      `_vault_admission_error()` to `src/mcp_server/tools.py`, resolving
+      `_vault_root(current_user_id.get())` and returning the refusal string on
+      `RuntimeError` (with an operator-facing `logger.warning`)
+- [x] 1.2 Call the gate from `_tracked`'s wrapper *before* awaiting the tool
+      body; on refusal use the message as the result and skip the body
+- [x] 1.3 Confirm single-user / sandbox mode passes the gate (`current_user_id`
+      is None → `settings.vault_path`, cache untouched)
+- [x] 1.4 Enumerate exemptions: none. `get_vault_guide` reads the vault's
+      `CLAUDE.md`; `check_upload` reports a vault path/size/digest; every other
+      `_tracked` tool reads or writes vault content or metadata
+
+## 2. Usage logging
+
+- [x] 2.1 Log the refusal through the existing single `_log_usage` call site
+      with `params["error"] = _NO_VAULT_MARKER`
+- [x] 2.2 Keep the tool's normal allow-listed params and add no other field
+
+## 3. Cache semantics
+
+- [x] 3.1 Make the single-user form of `warm_user_vault_cache` evict when the
+      query returns no row, so a revocation lands in every worker process
+- [x] 3.2 Leave the bulk form add-only (documented in design.md) and keep
+      `_vault_root` a pure cache lookup — no DB query per tool call
+- [x] 3.3 Record in `_vault_root`'s docstring that it is now the admission gate
+
+## 4. Panel copy
+
+- [x] 4.1 Change the `user_edit.html` option label to
+      `(unassigned — every MCP tool refuses; index kept for reassignment)`
+
+## 5. Tests
+
+- [x] 5.1 DB-only tools (`semantic_search`, `keyword_search`, `list_notes`,
+      `get_recent`, `get_tags`) refuse for a user with no cached root
+- [x] 5.2 Graph tools (`get_backlinks`, `get_links`, `get_neighborhood`,
+      `find_orphans`, `find_related`) refuse
+- [x] 5.3 Disk-touching tools and `get_vault_guide` refuse through the same gate
+- [x] 5.4 The refusal echoes neither the query nor any path
+- [x] 5.5 Single-user mode still runs the tool body with an empty cache, and an
+      assigned user still passes the gate
+- [x] 5.6 The refusal is logged with the error marker and no extra field
+- [x] 5.7 `warm_user_vault_cache` evicts a stale entry when the row is gone
+- [x] 5.8 A cold cache refuses rather than raising
+- [x] 5.9 Full suite green; new tests verified to fail against the pre-change
+      code
+
+## 6. Documentation
+
+- [x] 6.1 Record the gate in `CLAUDE.md` next to the multi-user vault behaviour
+- [x] 6.2 `openspec validate vault-unassignment-revokes-tools --strict` passes

--- a/openspec/changes/vault-unassignment-revokes-tools/tasks.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/tasks.md
@@ -25,6 +25,12 @@
 - [x] 3.2 Leave the bulk form add-only (documented in design.md) and keep
       `_vault_root` a pure cache lookup — no DB query per tool call
 - [x] 3.3 Record in `_vault_root`'s docstring that it is now the admission gate
+- [x] 3.4 Add `current_vault_root` / `UNSET_VAULT_ROOT` to `src/auth/session.py`
+      and bind the per-request root in `APIKeyMiddleware` (both the API-key and
+      OAuth branches), resetting it in the same `finally` as the other
+      ContextVars
+- [x] 3.5 Make `_vault_root` prefer the request snapshot over the shared dict,
+      keyed by user id, and never consult it for `user_id is None`
 
 ## 4. Panel copy
 
@@ -46,6 +52,17 @@
 - [x] 5.8 A cold cache refuses rather than raising
 - [x] 5.9 Full suite green; new tests verified to fail against the pre-change
       code
+- [x] 5.10 The refusal matrix enumerates every tool registered on the MCP
+      server by introspecting `mcp._tool_manager`, not a hand list
+- [x] 5.11 Structural test: every registered tool delegates to a
+      `_tracked`-wrapped impl (via the `__tracked_tool__` marker)
+- [x] 5.12 Deterministic ordered-race test: a stale bulk warm landing after the
+      per-request eviction still leaves the call refused — with a negative
+      control proving the bulk warm really does repopulate the shared dict
+- [x] 5.13 End-to-end test through `APIKeyMiddleware`: the key authenticates,
+      the snapshot binds as `(user_id, None)`, the tool refuses, and the
+      snapshot does not outlive the request
+- [x] 5.14 Assert the *rendered* option text from `user_edit.html`
 
 ## 6. Documentation
 

--- a/openspec/changes/vault-unassignment-revokes-tools/tasks.md
+++ b/openspec/changes/vault-unassignment-revokes-tools/tasks.md
@@ -63,6 +63,17 @@
       the snapshot binds as `(user_id, None)`, the tool refuses, and the
       snapshot does not outlive the request
 - [x] 5.14 Assert the *rendered* option text from `user_edit.html`
+- [x] 5.15 Repeat the stale-bulk-warm middleware race through the **OAuth**
+      branch, asserting the scope really mapped to `readwrite` so the refusal
+      is the gate's doing and not a permission error in disguise
+- [x] 5.16 Assert `current_vault_root` is back to `UNSET_VAULT_ROOT` after a
+      downstream exception and after a `CancelledError` (client disconnect),
+      on both auth branches — read *inside* the middleware's own context, since
+      reading it after `asyncio.run` is vacuous on a copied context
+- [x] 5.17 Assert the refusal persists a real `UsageLog` row — identity, tool,
+      exact allow-listed params plus the marker, response size, and a commit —
+      not merely that `_log_usage` was called; plus a success control with no
+      marker
 
 ## 7. Ownerless credentials (multi-user mode)
 

--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -1,5 +1,6 @@
 from contextvars import ContextVar
 from dataclasses import dataclass
+from pathlib import Path
 
 from fastapi import Depends, HTTPException, Request, status
 from sqlalchemy import select
@@ -10,6 +11,32 @@ from src.database import get_session
 from src.models.db import User
 
 current_user_id: ContextVar[int | None] = ContextVar("current_user_id", default=None)
+
+
+class _UnsetVaultRoot:
+    """Sentinel: this context carries no authenticated vault snapshot."""
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return "<unset vault root>"
+
+
+UNSET_VAULT_ROOT = _UnsetVaultRoot()
+
+# The authenticated request's *own* answer to "where is this user's vault, right
+# now" — `(user_id, Path)` when assigned, `(user_id, None)` when the user has no
+# usable assignment, and `UNSET_VAULT_ROOT` outside a request (indexer, panel,
+# tests).
+#
+# It exists because the process-level cache in `src/services/vault.py` is shared
+# with the indexer's bulk warm, and a bulk `SELECT` that started *before* an
+# admin cleared `vault_path` can land *after* the per-request warm evicted the
+# entry — re-admitting a user whose assignment was already revoked, mid-call.
+# A snapshot bound to this request cannot be overwritten by another task, so
+# `_vault_root` prefers it whenever it is set. See "The vault assignment is the
+# admission gate for every tool" in CLAUDE.md.
+current_vault_root: ContextVar[tuple[int, Path | None] | _UnsetVaultRoot] = ContextVar(
+    "current_vault_root", default=UNSET_VAULT_ROOT
+)
 
 
 @dataclass

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -783,22 +783,32 @@ async def vault_page(
     folder = request.query_params.get("folder", "")
     selected_note = request.query_params.get("note")
 
+    from src.services.vault import _vault_root, vault_unassigned_error
+
     # Resolve the per-user vault root. In single-user mode `user.id` is None
     # and `_vault_root(None)` returns `settings.vault_path` — the legacy
-    # behavior. In multi-user mode, this requires the cache to be warmed
-    # for the user; login already does that, but we re-warm here so a
-    # session that survived a process restart (no warm yet) still works.
-    if user.id is not None:
-        await warm_user_vault_cache(session, user.id)
+    # behavior.
+    #
+    # In multi-user mode we use the root the warm *itself* read, not a re-read
+    # of the shared `_user_vault_cache`. The indexer's bulk warm writes to that
+    # dict too and is add-only, so a bulk SELECT taken before the admin cleared
+    # `vault_path` can land between the warm and the lookup and hand this page
+    # the vault the user no longer holds — the same race `current_vault_root`
+    # closes for tool calls (issue #66). A None here is the refusal, rendered
+    # as the friendly empty state rather than a 500.
+    vault = None
+    vault_error = None
+    if user.id is None:
+        try:
+            vault = _vault_root(None)
+        except RuntimeError as e:
+            vault_error = str(e)
+    else:
+        vault = await warm_user_vault_cache(session, user.id)
+        if vault is None:
+            vault_error = vault_unassigned_error(user.id)
 
-    from src.services.vault import _vault_root
-
-    # `_vault_root` raises RuntimeError if the user has no `vault_path`
-    # assigned in multi-user mode. Surface that as a friendly empty state
-    # rather than a 500.
-    try:
-        vault = _vault_root(user.id)
-    except RuntimeError as e:
+    if vault_error is not None:
         return templates.TemplateResponse(request, "vault.html", _panel_context(request, user, {
             "active": "vault",
             "current_folder": "",
@@ -809,7 +819,7 @@ async def vault_page(
             "note_content": None,
             "note_title": None,
             "note_tags": [],
-            "vault_error": str(e),
+            "vault_error": vault_error,
         }))
 
     if folder:

--- a/src/control_panel/templates/user_edit.html
+++ b/src/control_panel/templates/user_edit.html
@@ -31,7 +31,7 @@
                     <div class="field">
                         <label class="field-label">Vault Path</label>
                         <select name="vault_path" class="field-select" id="vault-select">
-                            <option value="">(unassigned — vault tools error)</option>
+                            <option value="">(unassigned — every MCP tool refuses; index kept for reassignment)</option>
                             {% for v in available_vaults %}
                             <option value="{{ v }}" {% if v == target.vault_path %}selected{% endif %}>{{ v }}</option>
                             {% endfor %}

--- a/src/mcp_server/auth.py
+++ b/src/mcp_server/auth.py
@@ -122,6 +122,34 @@ class APIKeyMiddleware:
                         await response(scope, receive, send)
                         return
 
+                    if api_key.user_id is None and settings.multi_user_mode:
+                        # An ownerless key in multi-user mode. These exist: a
+                        # key minted while multi-user was off keeps
+                        # `user_id = NULL`, and the bootstrap backfill in
+                        # `src/auth/routes.py` only claims those rows when
+                        # `users` is *empty* — flip the flag after users
+                        # exist and the NULLs are never adopted. Such a key
+                        # used to be treated as single-user by every layer:
+                        # the warm was skipped and `_vault_root(None)`
+                        # returned the global `settings.vault_path`, so an
+                        # ownerless readwrite key could edit the whole vault.
+                        # Refuse it here, with the same body as any other
+                        # rejected key.
+                        logger.warning(
+                            "auth_failure",
+                            extra={
+                                "reason": "ownerless_credential",
+                                "key_id": api_key.id,
+                            },
+                        )
+                        response = JSONResponse(
+                            {"error": "Invalid or revoked key"},
+                            status_code=401,
+                            headers={"WWW-Authenticate": _www_authenticate("invalid_token")},
+                        )
+                        await response(scope, receive, send)
+                        return
+
                     if api_key.user_id is not None:
                         result = await session.execute(
                             select(User.is_active).where(User.id == api_key.user_id)
@@ -205,6 +233,24 @@ class APIKeyMiddleware:
                         await response(scope, receive, send)
                         return
 
+
+                    if oauth_token.user_id is None and settings.multi_user_mode:
+                        # Same as the API-key branch above: an ownerless token
+                        # in multi-user mode would resolve the global vault.
+                        logger.warning(
+                            "auth_failure",
+                            extra={
+                                "reason": "ownerless_credential",
+                                "key_id": oauth_token.id,
+                            },
+                        )
+                        response = JSONResponse(
+                            {"error": "Invalid or revoked token"},
+                            status_code=401,
+                            headers={"WWW-Authenticate": _www_authenticate("invalid_token")},
+                        )
+                        await response(scope, receive, send)
+                        return
 
                     if oauth_token.user_id is not None:
                         result = await session.execute(

--- a/src/mcp_server/auth.py
+++ b/src/mcp_server/auth.py
@@ -9,7 +9,7 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
 
-from src.auth.session import current_user_id
+from src.auth.session import UNSET_VAULT_ROOT, current_user_id, current_vault_root
 from src.config import settings
 from src.database import async_session
 from src.models.db import APIKey, OAuthToken, User
@@ -90,6 +90,13 @@ class APIKeyMiddleware:
         token_key = current_api_key_id.set(None)
         token_oauth = current_oauth_token_id.set(None)
         token_user = current_user_id.set(None)
+        # Bound below from the authenticated user's *own* freshly read
+        # `vault_path`. It stays unset for single-user keys (no user row) so
+        # `_vault_root(None)` keeps answering from settings. Resetting it in
+        # `finally` alongside the others keeps the snapshot request-scoped —
+        # that is what stops the indexer's bulk warm from re-admitting a user
+        # whose assignment was revoked mid-request (issue #66).
+        token_vault = current_vault_root.set(UNSET_VAULT_ROOT)
 
         try:
             if token.startswith("omcp_"):
@@ -162,11 +169,18 @@ class APIKeyMiddleware:
                     current_api_key_id.set(api_key.id)
                     current_user_id.set(api_key.user_id)
                     # In single-user mode `api_key.user_id` is None so this
-                    # is a no-op. In multi-user mode, warm the vault-path
-                    # cache so sync `_vault_root(user_id)` calls inside the
-                    # request handler don't hit a cold cache.
+                    # is skipped entirely. In multi-user mode, read the user's
+                    # `vault_path` now and bind the answer to this request:
+                    # it both warms the shared cache (so sync
+                    # `_vault_root(user_id)` calls don't hit a cold one) and
+                    # gives `_vault_root` a snapshot no other task can
+                    # overwrite. A None here means "unassigned", and every
+                    # tool call in this request is refused (issue #66).
                     if api_key.user_id is not None:
-                        await warm_user_vault_cache(session, api_key.user_id)
+                        current_vault_root.set((
+                            api_key.user_id,
+                            await warm_user_vault_cache(session, api_key.user_id),
+                        ))
             else:
                 # OAuth token auth
                 token_hash = hash_key(token)
@@ -233,7 +247,10 @@ class APIKeyMiddleware:
                     current_oauth_token_id.set(oauth_token.id)
                     current_user_id.set(oauth_token.user_id)
                     if oauth_token.user_id is not None:
-                        await warm_user_vault_cache(session, oauth_token.user_id)
+                        current_vault_root.set((
+                            oauth_token.user_id,
+                            await warm_user_vault_cache(session, oauth_token.user_id),
+                        ))
 
             await self.app(scope, receive, send)
         finally:
@@ -241,3 +258,4 @@ class APIKeyMiddleware:
             current_api_key_id.reset(token_key)
             current_oauth_token_id.reset(token_oauth)
             current_user_id.reset(token_user)
+            current_vault_root.reset(token_vault)

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -103,6 +103,58 @@ def _truncate_params(params: dict) -> dict:
     }
 
 
+_NO_VAULT_MESSAGE = (
+    "Error: no vault is assigned to this account, so no vault tool can run. "
+    "Ask an administrator to assign a vault path to your user in the control "
+    "panel."
+)
+
+# Marker written into `usage_logs.params` for a call refused by the gate. It
+# carries no new information — the user id and tool name are already columns.
+_NO_VAULT_MARKER = "no_vault_assigned"
+
+
+def _vault_admission_error() -> str | None:
+    """Refuse the call when the caller has no resolvable vault root.
+
+    Unassigning `users.vault_path` used to revoke only the *disk*-touching
+    tools: `semantic_search`, `keyword_search`, `list_notes`, `get_recent` and
+    every graph tool are served entirely from `notes_metadata` /
+    `note_embeddings`, never call `_vault_root`, and those rows are never
+    deleted (the indexer skips users with a NULL `vault_path`, so nothing ever
+    prunes them). The result was an indefinite, fully queryable mirror of the
+    content the user last held — file paths, titles, tags, frontmatter and
+    chunk excerpts — reachable with an unchanged API key, while the panel told
+    the operator "vault tools error" (issue #66).
+
+    So the gate lives here, in the decorator every tool shares, rather than in
+    the individual tools: resolve the root **once, before the body runs**, and
+    fail the whole call if it cannot be resolved. Every `_tracked` tool reads
+    or writes vault content or vault metadata, so there is nothing to exempt —
+    `get_vault_guide` reads the vault's `CLAUDE.md`, `check_upload` reports a
+    vault path. Fail closed and keep the list at zero.
+
+    Single-user mode is untouched: `current_user_id` is None there (the
+    sentinel's `id` is None and sandbox mode never sets it), and `_vault_root`
+    answers from `settings.vault_path` without consulting the cache.
+
+    Preserving the index rows is deliberate — a reassignment of the same path
+    should not have to re-embed the vault from scratch.
+    """
+    uid = current_user_id.get()
+    try:
+        _vault_root(uid)
+    except RuntimeError:
+        # Unassigned, deactivated, or a cold cache. All three mean the same
+        # thing to the caller and all three must refuse: a cold cache is not
+        # permission to serve stale rows.
+        logger.warning(
+            "tool_refused_no_vault", extra={"user_id": uid}
+        )
+        return _NO_VAULT_MESSAGE
+    return None
+
+
 def _tracked(tool_name: str, param_keys: list[str], transforms: dict | None = None):
     """Decorator that times the call and logs it to usage_logs.
 
@@ -127,7 +179,16 @@ def _tracked(tool_name: str, param_keys: list[str], transforms: dict | None = No
             # the same task starts from empty rather than inheriting them.
             token = timing.begin()
             try:
-                result = await fn(*args, **kwargs)
+                # Admission gate: a caller with no resolvable vault root never
+                # reaches the tool body, including the DB-only ones. The
+                # refusal is still logged, like any other tool error.
+                refusal = _vault_admission_error()
+                if refusal is not None:
+                    result = refusal
+                    extra = {"error": _NO_VAULT_MARKER}
+                else:
+                    result = await fn(*args, **kwargs)
+                    extra = {}
                 duration_ms = int((time.monotonic() - start) * 1000)
                 params = {}
                 # Resolve logged params by NAME via the wrapped signature so
@@ -146,6 +207,7 @@ def _tracked(tool_name: str, param_keys: list[str], transforms: dict | None = No
                 except TypeError:
                     params = {}
                 logged = _truncate_params(params)
+                logged.update(extra)
                 # Whatever the service measured. Absent for tools that measure
                 # nothing, so `params` keeps its current shape for them.
                 logged.update(timing.current() or {})

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -215,6 +215,12 @@ def _tracked(tool_name: str, param_keys: list[str], transforms: dict | None = No
                 return result
             finally:
                 timing.clear(token)
+
+        # Structural marker. `tests/test_issue_66_*` asserts that every tool
+        # registered on the MCP server delegates to something carrying it, so
+        # "the admission gate is inherited by construction" is checked rather
+        # than asserted.
+        wrapper.__tracked_tool__ = tool_name
         return wrapper
     return decorator
 

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -96,11 +96,31 @@ def clear_user_vault_cache(user_id: int | None = None) -> None:
         _user_vault_cache.pop(user_id, None)
 
 
+UNOWNED_IN_MULTI_USER_ERROR = (
+    "No vault root: multi-user mode is enabled and this credential is not "
+    "bound to a user."
+)
+
+
+def vault_unassigned_error(user_id: int) -> str:
+    """The one wording for "this user has no usable vault assignment".
+
+    Shared by `_vault_root` and the panel's vault browser so the operator and
+    the agent are told the same thing.
+    """
+    return (
+        f"Vault path for user_id={user_id} is not assigned. The user has no "
+        "`vault_path`, or is inactive."
+    )
+
+
 def _vault_root(user_id: int | None = None) -> Path:
     """Return the vault root for the given user.
 
     Single-user mode / `user_id is None` → `settings.vault_path` (legacy
-    behavior). Multi-user mode → cached `users.vault_path` lookup. The cache
+    behavior). **In multi-user mode `user_id is None` raises instead** — see
+    the ownerless-credential note below. Multi-user mode → cached
+    `users.vault_path` lookup. The cache
     must have been warmed for this user (auth middleware / indexer / panel
     routes do this before invoking tools); a miss raises a clear RuntimeError
     rather than silently falling back to the global path or silently blocking
@@ -126,15 +146,20 @@ def _vault_root(user_id: int | None = None) -> Path:
     answering for the wrong vault.
     """
     if user_id is None:
+        if settings.multi_user_mode:
+            # An ownerless credential in multi-user mode. `APIKeyMiddleware`
+            # already refuses those (see `ownerless_credential`), so reaching
+            # here means some other path resolved a root with no user — and
+            # falling back to `settings.vault_path` would hand it the *global*
+            # vault, which in multi-user mode belongs to nobody in particular
+            # and is exactly the write nobody authorised. Fail closed.
+            raise RuntimeError(UNOWNED_IN_MULTI_USER_ERROR)
         return Path(settings.vault_path)
     snapshot = current_vault_root.get()
     if not isinstance(snapshot, _UnsetVaultRoot) and snapshot[0] == user_id:
         root = snapshot[1]
         if root is None:
-            raise RuntimeError(
-                f"Vault path for user_id={user_id} is not assigned. The user "
-                "has no `vault_path`, or is inactive."
-            )
+            raise RuntimeError(vault_unassigned_error(user_id))
         return root
     cached = _user_vault_cache.get(user_id)
     if cached is None:

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -22,6 +22,9 @@ logger = logging.getLogger(__name__)
 # `clear_user_vault_cache(user_id=...)` when the admin edits a user. Single-user
 # mode never touches this cache because `_vault_root()` is called with
 # `user_id=None` everywhere.
+#
+# The single-user form of `warm_user_vault_cache` is *authoritative*: it writes
+# the current value or removes the entry. It is not an add-only warm.
 _user_vault_cache: dict[int, Path] = {}
 
 
@@ -44,8 +47,19 @@ async def warm_user_vault_cache(session, user_id: int | None = None) -> None:
             )
         )
         row = result.first()
-        if row is not None:
-            _user_vault_cache[row.id] = Path(row.vault_path)
+        if row is None:
+            # No usable assignment any more: unassigned, deactivated, or the
+            # row is gone. **Evict** rather than leaving the previous value in
+            # place. This warm runs on every authenticated MCP request, and
+            # `_vault_root` is now the admission gate every tool passes through
+            # (`_tracked`), so a stale entry would keep a revoked assignment
+            # queryable until the process restarts — issue #66. Callers that
+            # mutate `users.vault_path` still call `clear_user_vault_cache`;
+            # this makes the refusal independent of them, and of the fact that
+            # each worker process holds its own cache.
+            _user_vault_cache.pop(user_id, None)
+            return
+        _user_vault_cache[row.id] = Path(row.vault_path)
         return
 
     result = await session.execute(
@@ -80,6 +94,13 @@ def _vault_root(user_id: int | None = None) -> Path:
     routes do this before invoking tools); a miss raises a clear RuntimeError
     rather than silently falling back to the global path or silently blocking
     the event loop on a sync DB call.
+
+    This is also the admission gate for every MCP tool: `_tracked` calls it
+    once before the tool body runs and refuses the call when it raises, so a
+    user with no vault assignment cannot reach the database-backed tools
+    either (issue #66). Keep it a pure cache lookup — the per-request warm in
+    `APIKeyMiddleware` is what makes it correct, and a DB query here would be
+    a query on every tool call.
     """
     if user_id is None:
         return Path(settings.vault_path)

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -12,6 +12,7 @@ from pathlib import Path, PurePosixPath
 import yaml
 from sqlalchemy import select
 
+from src.auth.session import _UnsetVaultRoot, current_vault_root
 from src.config import settings
 
 logger = logging.getLogger(__name__)
@@ -24,17 +25,25 @@ logger = logging.getLogger(__name__)
 # `user_id=None` everywhere.
 #
 # The single-user form of `warm_user_vault_cache` is *authoritative*: it writes
-# the current value or removes the entry. It is not an add-only warm.
+# the current value or removes the entry, and returns what it read. It is not an
+# add-only warm. The bulk form still is — which is why the value it returns is
+# also bound to the request (`current_vault_root`) rather than trusted from this
+# dict: see `_vault_root`.
 _user_vault_cache: dict[int, Path] = {}
 
 
-async def warm_user_vault_cache(session, user_id: int | None = None) -> None:
+async def warm_user_vault_cache(session, user_id: int | None = None) -> Path | None:
     """Populate `_user_vault_cache` for one user (or every active user).
 
     Called by the indexer at the start of each multi-user pass, by the API-key
     middleware after authenticating a user, and (in phase 4) by panel routes
     before they hit vault tools. In single-user mode the cache is unused so
     callers can skip the warmup; nothing breaks if they don't.
+
+    The **single-user form returns the freshly read root, or None** when the
+    user has no usable assignment. `APIKeyMiddleware` binds that answer to the
+    request via `current_vault_root`, which is what makes admission immune to
+    the bulk warm racing it — see `_vault_root`. The bulk form returns None.
     """
     from src.models.db import User
 
@@ -58,9 +67,10 @@ async def warm_user_vault_cache(session, user_id: int | None = None) -> None:
             # this makes the refusal independent of them, and of the fact that
             # each worker process holds its own cache.
             _user_vault_cache.pop(user_id, None)
-            return
-        _user_vault_cache[row.id] = Path(row.vault_path)
-        return
+            return None
+        root = Path(row.vault_path)
+        _user_vault_cache[row.id] = root
+        return root
 
     result = await session.execute(
         select(User.id, User.vault_path).where(
@@ -70,6 +80,7 @@ async def warm_user_vault_cache(session, user_id: int | None = None) -> None:
     )
     for row in result.all():
         _user_vault_cache[row.id] = Path(row.vault_path)
+    return None
 
 
 def clear_user_vault_cache(user_id: int | None = None) -> None:
@@ -101,9 +112,30 @@ def _vault_root(user_id: int | None = None) -> Path:
     either (issue #66). Keep it a pure cache lookup — the per-request warm in
     `APIKeyMiddleware` is what makes it correct, and a DB query here would be
     a query on every tool call.
+
+    **The authenticated request's own snapshot wins over the shared dict.**
+    `_user_vault_cache` is process-global and the indexer's bulk warm writes to
+    it, so a bulk `SELECT` issued *before* an admin cleared `vault_path` can
+    land *after* the per-request warm evicted the entry and re-admit a user
+    whose assignment was already revoked — mid-call, with a write tool in
+    flight. `current_vault_root` is bound once per authenticated request by
+    `APIKeyMiddleware` and no other task can overwrite it, so consulting it
+    first makes admission fail closed under that interleaving. It is keyed by
+    user id: a snapshot for a different user (nested contexts, a panel route
+    resolving somebody else's root) falls through to the dict rather than
+    answering for the wrong vault.
     """
     if user_id is None:
         return Path(settings.vault_path)
+    snapshot = current_vault_root.get()
+    if not isinstance(snapshot, _UnsetVaultRoot) and snapshot[0] == user_id:
+        root = snapshot[1]
+        if root is None:
+            raise RuntimeError(
+                f"Vault path for user_id={user_id} is not assigned. The user "
+                "has no `vault_path`, or is inactive."
+            )
+        return root
     cached = _user_vault_cache.get(user_id)
     if cached is None:
         raise RuntimeError(

--- a/tests/test_issue_66_vault_unassignment_revokes_tools.py
+++ b/tests/test_issue_66_vault_unassignment_revokes_tools.py
@@ -1,0 +1,233 @@
+"""Regression tests for GitHub issue #66.
+
+Unassigning a user's `vault_path` in the control panel was presented to the
+operator as "vault tools error", but only the *disk*-touching tools actually
+stopped. `semantic_search`, `keyword_search`, `list_notes`, `get_recent` and
+every graph tool are served from `notes_metadata` / `note_embeddings` filtered
+by `user_id` alone — they never called `_vault_root`. Nothing prunes those rows
+either (the indexer's `_active_user_ids()` skips users with a NULL
+`vault_path`), so an unassigned user kept an indefinite, fully queryable mirror
+of the content they last held, reachable with an unchanged API key.
+
+The fix puts the admission gate in `_tracked`, the decorator every MCP tool
+shares: resolve the caller's vault root once, before the tool body runs, and
+refuse the whole call when it cannot be resolved.
+
+These tests exercise the real tool impls with an empty vault cache. A refusal
+happens *before* the body, so no DB, network or embedding access occurs — if
+the gate regressed, the tools would try to open a database connection and the
+tests would fail loudly rather than silently pass.
+"""
+
+import asyncio
+import os
+import tempfile
+
+# `src.mcp_server.tools` pulls in `src.config`, whose module-level `Settings()`
+# reads `./.env`. Provide minimal defaults and chdir to a dir without a `.env`
+# BEFORE importing, keeping the module fully offline. (Same preamble as
+# tests/test_issue_8_tracked_param_mapping.py.)
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+import pytest  # noqa: E402
+
+import src.mcp_server.tools as tools  # noqa: E402
+import src.services.vault as vault  # noqa: E402
+from src.auth.session import _SingleUserSentinel, current_user_id  # noqa: E402
+
+
+UNASSIGNED_UID = 4242
+
+
+@pytest.fixture
+def cold_cache():
+    """A process-level vault cache with no entry for `UNASSIGNED_UID`.
+
+    This is exactly the state after `clear_user_vault_cache(target.id)` on the
+    NULL transition — and also the state of a freshly started worker whose
+    per-request warm found no row. Both must refuse.
+    """
+    saved = dict(vault._user_vault_cache)
+    vault._user_vault_cache.clear()
+    try:
+        yield
+    finally:
+        vault._user_vault_cache.clear()
+        vault._user_vault_cache.update(saved)
+
+
+@pytest.fixture
+def as_unassigned_user(cold_cache):
+    token = current_user_id.set(UNASSIGNED_UID)
+    try:
+        yield UNASSIGNED_UID
+    finally:
+        current_user_id.reset(token)
+
+
+def _run_capturing_log(coro_fn, *args, **kwargs):
+    """Run a `_tracked` tool impl, returning `(result, logged_params, tool)`.
+
+    `_log_usage` is stubbed so no database is touched by the *logging*; if the
+    gate failed to refuse, the tool body itself would still try to connect.
+    """
+    captured = {}
+
+    async def fake_log_usage(tool, params, duration_ms, response_size):
+        captured["tool"] = tool
+        captured["params"] = params
+
+    original = tools._log_usage
+    tools._log_usage = fake_log_usage
+    try:
+        result = asyncio.run(coro_fn(*args, **kwargs))
+    finally:
+        tools._log_usage = original
+    return result, captured.get("params"), captured.get("tool")
+
+
+# --- (a) DB-backed and graph tools refuse ------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name, call",
+    [
+        # DB-only: never touched `_vault_root` before this fix.
+        ("semantic_search", lambda: tools.semantic_search_impl("salary negotiation")),
+        ("keyword_search", lambda: tools.search_notes_impl("salary negotiation")),
+        ("list_notes", lambda: tools.list_notes_impl()),
+        ("get_recent", lambda: tools.get_recent_impl()),
+        ("get_tags", lambda: tools.get_tags_impl()),
+        # Graph tools: same position.
+        ("get_backlinks", lambda: tools.get_backlinks_impl("Projects/Alpha.md")),
+        ("get_links", lambda: tools.get_links_impl("Projects/Alpha.md")),
+        ("get_neighborhood", lambda: tools.get_neighborhood_impl("Projects/Alpha.md")),
+        ("find_orphans", lambda: tools.find_orphans_impl()),
+        ("find_related", lambda: tools.find_related_impl("Projects/Alpha.md")),
+        # Disk-touching tools already errored, but must keep doing so through
+        # the shared gate rather than by accident deeper down.
+        ("read_note", lambda: tools.read_note_impl("Projects/Alpha.md")),
+        ("get_vault_guide", lambda: tools.get_vault_guide_impl()),
+        ("list_files", lambda: tools.list_files_impl()),
+    ],
+)
+def test_unassigned_user_is_refused_by_every_tool(as_unassigned_user, name, call):
+    result, params, _ = _run_capturing_log(call)
+    assert isinstance(result, str), f"{name} returned {type(result)!r}"
+    assert result == tools._NO_VAULT_MESSAGE, f"{name} did not refuse: {result[:200]!r}"
+    # The refusal must not name a path, a note or an excerpt.
+    assert "Projects/Alpha.md" not in result
+    assert params is not None, f"{name} refusal was not logged"
+
+
+def test_semantic_search_refusal_leaks_no_chunk_text(as_unassigned_user):
+    """The concrete harm in #66: `semantic_search` returned 200-char excerpts
+    of the user's notes. The refusal is a fixed string with no query echo."""
+    result, _, _ = _run_capturing_log(
+        lambda: tools.semantic_search_impl("salary negotiation")
+    )
+    assert "salary negotiation" not in result
+
+
+# --- (b) single-user mode is unaffected --------------------------------------
+
+
+def test_single_user_sentinel_id_is_none():
+    """The gate keys off `current_user_id`, which is None in single-user mode
+    precisely because the sentinel's id is None."""
+    assert _SingleUserSentinel().id is None
+
+
+def test_single_user_mode_passes_the_gate(cold_cache):
+    """`current_user_id` unset (single-user mode / sandbox mode) → the gate
+    resolves `settings.vault_path` and the tool body runs, even though the
+    multi-user cache is completely empty."""
+    ran = {}
+
+    @tools._tracked("fake_tool", ["q"])
+    async def fake_tool(q: str) -> str:
+        ran["yes"] = True
+        return "served"
+
+    assert current_user_id.get() is None
+    result, params, tool = _run_capturing_log(lambda: fake_tool("hello"))
+    assert ran.get("yes") is True
+    assert result == "served"
+    assert tool == "fake_tool"
+    assert params == {"q": "hello"}
+    assert "error" not in params
+
+
+def test_warm_cache_makes_an_assigned_user_pass(as_unassigned_user, tmp_path):
+    """Sanity check on the other side of the gate: with the user's root in the
+    cache the body runs. Guards against a gate that refuses everyone."""
+    ran = {}
+
+    @tools._tracked("fake_tool", [])
+    async def fake_tool() -> str:
+        ran["yes"] = True
+        return "served"
+
+    vault._user_vault_cache[UNASSIGNED_UID] = tmp_path
+    result, params, _ = _run_capturing_log(lambda: fake_tool())
+    assert ran.get("yes") is True
+    assert result == "served"
+    assert "error" not in params
+
+
+# --- (c) the refusal is logged ----------------------------------------------
+
+
+def test_refusal_is_logged_with_an_error_marker(as_unassigned_user):
+    result, params, tool = _run_capturing_log(
+        lambda: tools.list_notes_impl(folder="Private", limit=50)
+    )
+    assert result == tools._NO_VAULT_MESSAGE
+    assert tool == "list_notes"
+    assert params["error"] == tools._NO_VAULT_MARKER
+    # The usual allow-listed params are still recorded, and nothing beyond
+    # them: a refusal must not become a new disclosure channel.
+    assert params["folder"] == "Private"
+    assert params["limit"] == 50
+    assert set(params) == {"folder", "limit", "tags", "frontmatter", "error"}
+
+
+# --- cache semantics: the refusal must not depend on cache warmth ------------
+
+
+def test_warm_user_vault_cache_evicts_when_the_row_is_gone(cold_cache):
+    """`warm_user_vault_cache` runs on every authenticated MCP request. It used
+    to be a silent no-op for a NULL `vault_path`, which left a previously
+    cached root in place — so a mid-session unassignment stayed invisible in
+    any worker process that did not handle the panel request. It must now
+    *evict*, making the gate independent of the panel's
+    `clear_user_vault_cache` call and of the worker that served it."""
+    from pathlib import Path
+
+    class _EmptyResult:
+        def first(self):
+            return None
+
+    class _FakeSession:
+        async def execute(self, stmt):
+            return _EmptyResult()
+
+    vault._user_vault_cache[UNASSIGNED_UID] = Path("/vaults/alpha")
+    asyncio.run(vault.warm_user_vault_cache(_FakeSession(), UNASSIGNED_UID))
+    assert UNASSIGNED_UID not in vault._user_vault_cache
+
+    with pytest.raises(RuntimeError):
+        vault._vault_root(UNASSIGNED_UID)
+
+
+def test_gate_refuses_on_a_cold_cache_rather_than_raising(as_unassigned_user):
+    """A fresh process that never warmed this user must refuse with a tool
+    error, not a 500. (`warm_user_vault_cache` is a no-op there — there is
+    nothing to evict — so the gate cannot lean on eviction alone.)"""
+    assert UNASSIGNED_UID not in vault._user_vault_cache
+    result, params, _ = _run_capturing_log(lambda: tools.get_backlinks_impl("A.md"))
+    assert result == tools._NO_VAULT_MESSAGE
+    assert params["error"] == tools._NO_VAULT_MARKER

--- a/tests/test_issue_66_vault_unassignment_revokes_tools.py
+++ b/tests/test_issue_66_vault_unassignment_revokes_tools.py
@@ -576,3 +576,267 @@ def test_unassigned_option_states_what_the_code_does():
         "index kept for reassignment)</option>"
     ) in rendered
     assert "vault tools error" not in rendered
+
+
+# --- ownerless credentials in multi-user mode --------------------------------
+#
+# A key or token whose `user_id` is NULL is the single-user shape. It survives
+# a configuration cycle: mint a key with multi-user off, then turn multi-user
+# on *after* users already exist, and the bootstrap backfill in
+# `src/auth/routes.py` — which only claims NULL rows while `users` is empty —
+# never adopts it. Every layer then treated that credential as single-user: the
+# middleware skipped the warm, `current_user_id` stayed None, and
+# `_vault_root(None)` handed back the global `settings.vault_path`. An
+# ownerless *readwrite* key could edit the whole vault.
+
+
+@pytest.fixture
+def multi_user_mode(monkeypatch):
+    monkeypatch.setattr(vault.settings, "multi_user_mode", True)
+    monkeypatch.setattr(mcp_auth.settings, "multi_user_mode", True)
+    yield
+
+
+def test_vault_root_refuses_an_ownerless_caller_in_multi_user_mode(multi_user_mode):
+    with pytest.raises(RuntimeError) as excinfo:
+        vault._vault_root(None)
+    assert "multi-user" in str(excinfo.value)
+
+
+def test_vault_root_still_serves_single_user_mode():
+    """The same call, with multi-user off, is the legacy path and must work."""
+    assert vault.settings.multi_user_mode is False
+    assert vault._vault_root(None) == Path(vault.settings.vault_path)
+
+
+def test_tools_refuse_an_ownerless_caller_in_multi_user_mode(
+    cold_cache, multi_user_mode
+):
+    """Belt and braces: even if such a credential reached a tool, the gate
+    refuses instead of resolving the global vault."""
+    assert current_user_id.get() is None
+    result, params, _ = _run_capturing_log(
+        lambda: tools.edit_note_impl("Projects/Alpha.md", "clobbered")
+    )
+    assert result == tools._NO_VAULT_MESSAGE
+    assert params["error"] == tools._NO_VAULT_MARKER
+
+
+class _OAuthMiddlewareSession(_MiddlewareSession):
+    """Same as `_MiddlewareSession`, for the OAuth branch: the first select
+    hits `oauth_tokens` rather than `api_keys`."""
+
+    async def execute(self, stmt):
+        sql = str(stmt)
+        if sql.startswith("UPDATE"):
+            return _EmptyResult()
+        if "vault_path" in sql:
+            return _RowsResult([self.vault_row] if self.vault_row else [])
+        if "FROM oauth_tokens" in sql:
+            return _RowsResult([self.api_key])
+        return _ScalarResult(self.user_active)
+
+
+def _run_middleware(credential, *, token_value, downstream=None, oauth=False):
+    """Drive `APIKeyMiddleware` with a faked session; return the sent messages."""
+    sent = []
+
+    async def _send(message):
+        sent.append(message)
+
+    async def _receive():  # pragma: no cover - never awaited
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def _ok(scope, receive, send):
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    async def run():
+        original = mcp_auth.async_session
+        if oauth:
+            mcp_auth.async_session = lambda: _OAuthMiddlewareSession(
+                credential, vault_row=None
+            )
+        else:
+            mcp_auth.async_session = lambda: _MiddlewareSession(
+                credential, vault_row=None
+            )
+        try:
+            app = mcp_auth.APIKeyMiddleware(downstream or _ok)
+            await app(
+                {
+                    "type": "http",
+                    "method": "POST",
+                    "path": "/mcp/",
+                    "headers": [(b"authorization", f"Bearer {token_value}".encode())],
+                },
+                _receive,
+                _send,
+            )
+        finally:
+            mcp_auth.async_session = original
+
+    asyncio.run(run())
+    return sent
+
+
+def _body_of(sent):
+    return b"".join(
+        m.get("body", b"") for m in sent if m["type"] == "http.response.body"
+    )
+
+
+def test_middleware_rejects_an_ownerless_api_key_in_multi_user_mode(
+    cold_cache, multi_user_mode
+):
+    from src.models.db import APIKey
+
+    key = APIKey(
+        id=9,
+        key_hash="x",
+        permission="readwrite",
+        user_id=None,
+        expires_at=None,
+        is_active=True,
+    )
+    sent = _run_middleware(key, token_value="omcp_ownerless")
+    assert sent[0]["status"] == 401
+    # Same body as any other rejected key: which check failed is not disclosed.
+    assert b"Invalid or revoked key" in _body_of(sent)
+
+
+def test_middleware_rejects_an_ownerless_oauth_token_in_multi_user_mode(
+    cold_cache, multi_user_mode
+):
+    from datetime import datetime, timedelta, timezone
+
+    from src.models.db import OAuthToken
+
+    tok = OAuthToken(
+        id=11,
+        token_hash="x",
+        token_type="access",
+        scope="readwrite",
+        user_id=None,
+        revoked=False,
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+    sent = _run_middleware(tok, token_value="oauth_ownerless", oauth=True)
+    assert sent[0]["status"] == 401
+    assert b"Invalid or revoked token" in _body_of(sent)
+
+
+def test_middleware_accepts_an_ownerless_api_key_in_single_user_mode(cold_cache):
+    """Single-user mode is the whole point of a NULL `user_id`. Untouched."""
+    from src.models.db import APIKey
+
+    assert mcp_auth.settings.multi_user_mode is False
+    key = APIKey(
+        id=9,
+        key_hash="x",
+        permission="readwrite",
+        user_id=None,
+        expires_at=None,
+        is_active=True,
+    )
+    sent = _run_middleware(key, token_value="omcp_legacy")
+    assert sent[0]["status"] == 200
+
+
+# --- the panel vault browser loses the same race -----------------------------
+
+
+def test_panel_vault_browser_refuses_when_the_warm_reports_unassigned(
+    cold_cache, multi_user_mode
+):
+    """`vault_page` warmed the cache and then re-read the shared dict, so the
+    same stale bulk warm that could re-admit a tool call could hand the panel
+    an unassigned user's vault. It must use what the warm returned."""
+    from starlette.requests import Request
+
+    import src.control_panel.routes as panel
+
+    captured = {}
+
+    class _FakeTemplates:
+        def TemplateResponse(self, request, name, ctx):
+            captured["name"] = name
+            captured["ctx"] = ctx
+            return "rendered"
+
+    async def fake_warm(session, user_id):
+        # The request's own read says NULL, so it evicts...
+        vault._user_vault_cache.pop(user_id, None)
+        # ...and the indexer's older bulk query lands right here, putting the
+        # revoked root back into the shared dict.
+        vault._user_vault_cache[user_id] = STALE_ROOT
+        return None
+
+    original_templates = panel.templates
+    original_warm = panel.warm_user_vault_cache
+    panel.templates = _FakeTemplates()
+    panel.warm_user_vault_cache = fake_warm
+    try:
+        request = Request({
+            "type": "http",
+            "method": "GET",
+            "path": "/admin/vault",
+            "query_string": b"",
+            "headers": [],
+        })
+        user = SimpleNamespace(
+            id=UNASSIGNED_UID, is_admin=False, username="bob", is_active=True
+        )
+        result = asyncio.run(panel.vault_page(request, session=None, user=user))
+    finally:
+        panel.templates = original_templates
+        panel.warm_user_vault_cache = original_warm
+
+    assert result == "rendered"
+    assert captured["name"] == "vault.html"
+    ctx = captured["ctx"]
+    assert ctx["vault_error"], "the page did not refuse"
+    assert str(UNASSIGNED_UID) in ctx["vault_error"]
+    assert ctx["notes"] == [] and ctx["folders"] == []
+    # And it did not browse the stale root the bulk warm restored.
+    assert vault._user_vault_cache[UNASSIGNED_UID] == STALE_ROOT
+
+
+# --- the gate costs no database round trip -----------------------------------
+
+
+def test_admission_gate_issues_no_database_statements(cold_cache, tmp_path):
+    """The gate runs on every tool call, so it must stay a cache/ContextVar
+    read. Both database entry points reachable from it are booby-trapped: a
+    single statement would raise."""
+    import inspect
+
+    # A synchronous function cannot await a DB round trip in the first place.
+    assert not inspect.iscoroutinefunction(tools._vault_admission_error)
+
+    ran = {}
+
+    @tools._tracked("fake_tool", [])
+    async def fake_tool() -> str:
+        ran["yes"] = True
+        return "served"
+
+    def _boom(*a, **kw):
+        raise AssertionError("the admission gate opened a database session")
+
+    original_session = tools.async_session
+    original_warm = vault.warm_user_vault_cache
+    uid_token = current_user_id.set(UNASSIGNED_UID)
+    root_token = current_vault_root.set((UNASSIGNED_UID, tmp_path))
+    tools.async_session = _boom
+    vault.warm_user_vault_cache = _boom
+    try:
+        result, _, _ = _run_capturing_log(lambda: fake_tool())
+    finally:
+        tools.async_session = original_session
+        vault.warm_user_vault_cache = original_warm
+        current_vault_root.reset(root_token)
+        current_user_id.reset(uid_token)
+
+    assert ran.get("yes") is True
+    assert result == "served"

--- a/tests/test_issue_66_vault_unassignment_revokes_tools.py
+++ b/tests/test_issue_66_vault_unassignment_revokes_tools.py
@@ -13,6 +13,14 @@ The fix puts the admission gate in `_tracked`, the decorator every MCP tool
 shares: resolve the caller's vault root once, before the tool body runs, and
 refuse the whole call when it cannot be resolved.
 
+The second half of the fix is *which* root the gate reads. `_user_vault_cache`
+is process-global and the indexer's bulk warm writes to it, so a bulk `SELECT`
+issued before an admin cleared `vault_path` can land after the per-request warm
+evicted the entry — re-admitting a revoked user mid-call. `APIKeyMiddleware`
+therefore binds the root it read to the request (`current_vault_root`), and the
+gate prefers that snapshot; `test_stale_bulk_warm_cannot_readmit_*` pins the
+ordered interleaving.
+
 These tests exercise the real tool impls with an empty vault cache. A refusal
 happens *before* the body, so no DB, network or embedding access occurs — if
 the gate regressed, the tools would try to open a database connection and the
@@ -22,6 +30,8 @@ tests would fail loudly rather than silently pass.
 import asyncio
 import os
 import tempfile
+from pathlib import Path
+from types import SimpleNamespace
 
 # `src.mcp_server.tools` pulls in `src.config`, whose module-level `Settings()`
 # reads `./.env`. Provide minimal defaults and chdir to a dir without a `.env`
@@ -30,16 +40,25 @@ import tempfile
 os.environ.setdefault("SECRET_KEY", "test")
 os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
 os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+_TEMPLATES = Path(__file__).resolve().parent.parent / "src" / "control_panel" / "templates"
 os.chdir(tempfile.gettempdir())
 
 import pytest  # noqa: E402
 
+import src.mcp_server.auth as mcp_auth  # noqa: E402
 import src.mcp_server.tools as tools  # noqa: E402
 import src.services.vault as vault  # noqa: E402
-from src.auth.session import _SingleUserSentinel, current_user_id  # noqa: E402
+from src.auth.session import (  # noqa: E402
+    UNSET_VAULT_ROOT,
+    _SingleUserSentinel,
+    current_user_id,
+    current_vault_root,
+)
+from src.mcp_server.server import mcp  # noqa: E402
 
 
 UNASSIGNED_UID = 4242
+STALE_ROOT = Path("/vaults/alpha")
 
 
 @pytest.fixture
@@ -62,9 +81,11 @@ def cold_cache():
 @pytest.fixture
 def as_unassigned_user(cold_cache):
     token = current_user_id.set(UNASSIGNED_UID)
+    root_token = current_vault_root.set(UNSET_VAULT_ROOT)
     try:
         yield UNASSIGNED_UID
     finally:
+        current_vault_root.reset(root_token)
         current_user_id.reset(token)
 
 
@@ -89,38 +110,82 @@ def _run_capturing_log(coro_fn, *args, **kwargs):
     return result, captured.get("params"), captured.get("tool")
 
 
-# --- (a) DB-backed and graph tools refuse ------------------------------------
+# --- (a) every registered tool refuses ---------------------------------------
 
 
-@pytest.mark.parametrize(
-    "name, call",
-    [
-        # DB-only: never touched `_vault_root` before this fix.
-        ("semantic_search", lambda: tools.semantic_search_impl("salary negotiation")),
-        ("keyword_search", lambda: tools.search_notes_impl("salary negotiation")),
-        ("list_notes", lambda: tools.list_notes_impl()),
-        ("get_recent", lambda: tools.get_recent_impl()),
-        ("get_tags", lambda: tools.get_tags_impl()),
-        # Graph tools: same position.
-        ("get_backlinks", lambda: tools.get_backlinks_impl("Projects/Alpha.md")),
-        ("get_links", lambda: tools.get_links_impl("Projects/Alpha.md")),
-        ("get_neighborhood", lambda: tools.get_neighborhood_impl("Projects/Alpha.md")),
-        ("find_orphans", lambda: tools.find_orphans_impl()),
-        ("find_related", lambda: tools.find_related_impl("Projects/Alpha.md")),
-        # Disk-touching tools already errored, but must keep doing so through
-        # the shared gate rather than by accident deeper down.
-        ("read_note", lambda: tools.read_note_impl("Projects/Alpha.md")),
-        ("get_vault_guide", lambda: tools.get_vault_guide_impl()),
-        ("list_files", lambda: tools.list_files_impl()),
-    ],
-)
-def test_unassigned_user_is_refused_by_every_tool(as_unassigned_user, name, call):
-    result, params, _ = _run_capturing_log(call)
-    assert isinstance(result, str), f"{name} returned {type(result)!r}"
-    assert result == tools._NO_VAULT_MESSAGE, f"{name} did not refuse: {result[:200]!r}"
+def _registered_tools():
+    """Every tool the MCP server actually exposes, by introspection.
+
+    A hand-maintained list is the shape of bug #66 itself: the tools that
+    leaked were the ones nobody thought to add to a list. Enumerating the
+    server's own registry means a tool added later is covered on the day it is
+    registered, or this test fails.
+    """
+    return sorted(mcp._tool_manager.list_tools(), key=lambda t: t.name)
+
+
+def _dummy_args(fn):
+    """Plausible values for a tool's required parameters.
+
+    The values are never used — the gate refuses before the body runs — but the
+    call must be well-formed enough to reach the wrapper.
+    """
+    import inspect
+
+    kwargs = {}
+    for name, param in inspect.signature(fn).parameters.items():
+        if param.default is not inspect.Parameter.empty:
+            continue
+        annotation = str(param.annotation)
+        if "int" in annotation:
+            kwargs[name] = 1
+        elif "bool" in annotation:
+            kwargs[name] = False
+        elif "list" in annotation:
+            kwargs[name] = []
+        elif "dict" in annotation:
+            kwargs[name] = {}
+        else:
+            kwargs[name] = "Projects/Alpha.md"
+    return kwargs
+
+
+def test_the_registry_is_not_empty():
+    """Guard the guard: an introspection matrix that finds zero tools would
+    pass vacuously."""
+    assert len(_registered_tools()) >= 25
+
+
+@pytest.mark.parametrize("tool", _registered_tools(), ids=lambda t: t.name)
+def test_unassigned_user_is_refused_by_every_registered_tool(as_unassigned_user, tool):
+    """No exemptions. `get_vault_guide` returns the vault's own CLAUDE.md and
+    `check_upload` reports a published vault path, so every registered tool
+    reads or writes vault content or vault metadata."""
+    result, params, _ = _run_capturing_log(lambda: tool.fn(**_dummy_args(tool.fn)))
+    assert isinstance(result, str), f"{tool.name} returned {type(result)!r}"
+    assert result == tools._NO_VAULT_MESSAGE, (
+        f"{tool.name} did not refuse: {result[:200]!r}"
+    )
     # The refusal must not name a path, a note or an excerpt.
     assert "Projects/Alpha.md" not in result
-    assert params is not None, f"{name} refusal was not logged"
+    assert params is not None, f"{tool.name} refusal was not logged"
+
+
+def test_every_registered_tool_delegates_to_a_tracked_impl():
+    """design.md claims the gate is "enforced by construction" — a new tool
+    inherits it by being registered. That is only true while every registered
+    tool delegates to a `_tracked`-wrapped impl, so check it structurally
+    rather than trusting the parametrized matrix above to be re-read."""
+    import src.mcp_server.server as server
+
+    unwrapped = []
+    for tool in _registered_tools():
+        referenced = [
+            getattr(server, name, None) for name in tool.fn.__code__.co_names
+        ]
+        if not any(hasattr(obj, "__tracked_tool__") for obj in referenced):
+            unwrapped.append(tool.name)
+    assert unwrapped == [], f"tools not delegating to a _tracked impl: {unwrapped}"
 
 
 def test_semantic_search_refusal_leaks_no_chunk_text(as_unassigned_user):
@@ -161,6 +226,17 @@ def test_single_user_mode_passes_the_gate(cold_cache):
     assert "error" not in params
 
 
+def test_single_user_mode_ignores_a_snapshot_for_another_user(cold_cache):
+    """A bound snapshot must never reach `_vault_root(None)`: single-user mode
+    answers from settings, full stop."""
+    token = current_vault_root.set((UNASSIGNED_UID, None))
+    try:
+        assert current_user_id.get() is None
+        assert vault._vault_root(None) == Path(vault.settings.vault_path)
+    finally:
+        current_vault_root.reset(token)
+
+
 def test_warm_cache_makes_an_assigned_user_pass(as_unassigned_user, tmp_path):
     """Sanity check on the other side of the gate: with the user's root in the
     cache the body runs. Guards against a gate that refuses everyone."""
@@ -176,6 +252,19 @@ def test_warm_cache_makes_an_assigned_user_pass(as_unassigned_user, tmp_path):
     assert ran.get("yes") is True
     assert result == "served"
     assert "error" not in params
+
+
+def test_snapshot_for_a_different_user_falls_through_to_the_cache(
+    as_unassigned_user, tmp_path
+):
+    """The snapshot is keyed by user id. A context carrying somebody else's
+    snapshot must not answer for this user — in either direction."""
+    vault._user_vault_cache[UNASSIGNED_UID] = tmp_path
+    token = current_vault_root.set((UNASSIGNED_UID + 1, None))
+    try:
+        assert vault._vault_root(UNASSIGNED_UID) == tmp_path
+    finally:
+        current_vault_root.reset(token)
 
 
 # --- (c) the refusal is logged ----------------------------------------------
@@ -198,29 +287,58 @@ def test_refusal_is_logged_with_an_error_marker(as_unassigned_user):
 # --- cache semantics: the refusal must not depend on cache warmth ------------
 
 
+class _EmptyResult:
+    def first(self):
+        return None
+
+    def all(self):
+        return []
+
+
+class _RowsResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeSession:
+    """A session whose `execute` always answers with `result`."""
+
+    def __init__(self, result):
+        self._result = result
+
+    async def execute(self, stmt):
+        return self._result
+
+
 def test_warm_user_vault_cache_evicts_when_the_row_is_gone(cold_cache):
     """`warm_user_vault_cache` runs on every authenticated MCP request. It used
     to be a silent no-op for a NULL `vault_path`, which left a previously
-    cached root in place — so a mid-session unassignment stayed invisible in
-    any worker process that did not handle the panel request. It must now
-    *evict*, making the gate independent of the panel's
-    `clear_user_vault_cache` call and of the worker that served it."""
-    from pathlib import Path
-
-    class _EmptyResult:
-        def first(self):
-            return None
-
-    class _FakeSession:
-        async def execute(self, stmt):
-            return _EmptyResult()
-
-    vault._user_vault_cache[UNASSIGNED_UID] = Path("/vaults/alpha")
-    asyncio.run(vault.warm_user_vault_cache(_FakeSession(), UNASSIGNED_UID))
+    cached root in place. It must now *evict*, and report the None so the
+    caller can bind it to the request."""
+    vault._user_vault_cache[UNASSIGNED_UID] = STALE_ROOT
+    got = asyncio.run(
+        vault.warm_user_vault_cache(_FakeSession(_EmptyResult()), UNASSIGNED_UID)
+    )
+    assert got is None
     assert UNASSIGNED_UID not in vault._user_vault_cache
 
     with pytest.raises(RuntimeError):
         vault._vault_root(UNASSIGNED_UID)
+
+
+def test_warm_user_vault_cache_returns_the_assigned_root(cold_cache):
+    row = SimpleNamespace(id=UNASSIGNED_UID, vault_path=str(STALE_ROOT))
+    got = asyncio.run(
+        vault.warm_user_vault_cache(_FakeSession(_RowsResult([row])), UNASSIGNED_UID)
+    )
+    assert got == STALE_ROOT
+    assert vault._user_vault_cache[UNASSIGNED_UID] == STALE_ROOT
 
 
 def test_gate_refuses_on_a_cold_cache_rather_than_raising(as_unassigned_user):
@@ -231,3 +349,230 @@ def test_gate_refuses_on_a_cold_cache_rather_than_raising(as_unassigned_user):
     result, params, _ = _run_capturing_log(lambda: tools.get_backlinks_impl("A.md"))
     assert result == tools._NO_VAULT_MESSAGE
     assert params["error"] == tools._NO_VAULT_MARKER
+
+
+# --- the ordered race: a stale bulk warm must not re-admit -------------------
+
+
+def _replay_the_race():
+    """Drive the exact interleaving, in order, on one thread.
+
+    1. user 4242 holds /vaults/alpha; the indexer's bulk `SELECT` is issued
+       (snapshot taken — it still sees the old row);
+    2. the admin commits `vault_path = NULL`;
+    3. an MCP request authenticates: the per-request warm reads NULL, evicts
+       the cache entry and hands the None to the middleware;
+    4. the *older* bulk query finally returns and re-inserts /vaults/alpha into
+       the shared dict;
+    5. the request, still in flight, calls a tool.
+
+    Returns the value `_vault_root` produced at step 5 — or the RuntimeError.
+    """
+    vault._user_vault_cache[UNASSIGNED_UID] = STALE_ROOT
+    stale_row = SimpleNamespace(id=UNASSIGNED_UID, vault_path=str(STALE_ROOT))
+
+    fresh = asyncio.run(
+        vault.warm_user_vault_cache(_FakeSession(_EmptyResult()), UNASSIGNED_UID)
+    )
+    assert fresh is None
+    assert UNASSIGNED_UID not in vault._user_vault_cache
+
+    # The stale bulk result lands afterwards. The bulk form is add-only by
+    # design (see design.md), so it *does* put the revoked root back.
+    asyncio.run(vault.warm_user_vault_cache(_FakeSession(_RowsResult([stale_row]))))
+    assert vault._user_vault_cache[UNASSIGNED_UID] == STALE_ROOT
+    return fresh
+
+
+def test_stale_bulk_warm_really_does_repopulate_the_shared_dict(
+    as_unassigned_user,
+):
+    """The negative control that makes the next test meaningful: without a
+    request-scoped snapshot, the shared dict alone would re-admit the revoked
+    user, and a write tool would then target the vault they no longer hold."""
+    _replay_the_race()
+    assert vault._vault_root(UNASSIGNED_UID) == STALE_ROOT
+
+
+def test_stale_bulk_warm_cannot_readmit_a_revoked_user(as_unassigned_user):
+    """With the middleware's own answer bound to the request, the late bulk
+    result cannot re-admit: the gate reads the snapshot, not the dict."""
+    fresh = _replay_the_race()
+    token = current_vault_root.set((UNASSIGNED_UID, fresh))
+    try:
+        with pytest.raises(RuntimeError):
+            vault._vault_root(UNASSIGNED_UID)
+        result, params, _ = _run_capturing_log(
+            lambda: tools.edit_note_impl("Projects/Alpha.md", "clobbered")
+        )
+        assert result == tools._NO_VAULT_MESSAGE
+        assert params["error"] == tools._NO_VAULT_MARKER
+    finally:
+        current_vault_root.reset(token)
+
+
+# --- end to end through APIKeyMiddleware ------------------------------------
+
+
+class _MiddlewareSession:
+    """Answers the four statements `APIKeyMiddleware` issues on the API-key
+    path, dispatching on the rendered SQL so the test does not depend on
+    call order."""
+
+    def __init__(self, api_key, user_active=True, vault_row=None):
+        self.api_key = api_key
+        self.user_active = user_active
+        self.vault_row = vault_row
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def commit(self):
+        self.committed = True
+
+    async def execute(self, stmt):
+        sql = str(stmt)
+        if sql.startswith("UPDATE"):
+            return _EmptyResult()
+        if "vault_path" in sql:
+            return _RowsResult([self.vault_row] if self.vault_row else [])
+        if "FROM api_keys" in sql:
+            return _RowsResult([self.api_key])
+        # select(User.is_active)
+        return _ScalarResult(self.user_active)
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+def _patch_rows_result_scalar():
+    """`_RowsResult` also has to answer `.scalar_one_or_none()` for the
+    api_keys lookup."""
+    _RowsResult.scalar_one_or_none = lambda self: (
+        self._rows[0] if self._rows else None
+    )
+
+
+_patch_rows_result_scalar()
+
+
+def test_api_key_middleware_binds_the_snapshot_and_the_tool_refuses(cold_cache):
+    """R3 end to end: an unchanged, still-active API key belonging to a user
+    whose `vault_path` was cleared authenticates fine, and the tool call it
+    carries is refused — even though a stale bulk warm repopulates the shared
+    cache while the request is in flight."""
+    from src.models.db import APIKey
+
+    api_key = APIKey(
+        id=7,
+        key_hash="x",
+        permission="readwrite",
+        user_id=UNASSIGNED_UID,
+        expires_at=None,
+        is_active=True,
+    )
+    vault._user_vault_cache[UNASSIGNED_UID] = STALE_ROOT
+    stale_row = SimpleNamespace(id=UNASSIGNED_UID, vault_path=str(STALE_ROOT))
+
+    captured = {}
+
+    async def downstream(scope, receive, send):
+        # The user's row is already NULL, so the middleware's warm evicted the
+        # entry. Now the indexer's older bulk query lands mid-request.
+        assert UNASSIGNED_UID not in vault._user_vault_cache
+        await vault.warm_user_vault_cache(_FakeSession(_RowsResult([stale_row])))
+        assert vault._user_vault_cache[UNASSIGNED_UID] == STALE_ROOT
+
+        captured["user_id"] = current_user_id.get()
+        captured["snapshot"] = current_vault_root.get()
+        captured["result"] = await tools.semantic_search_impl("salary negotiation")
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    async def receive():  # pragma: no cover - never awaited
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    sent = []
+
+    async def send(message):
+        sent.append(message)
+
+    async def run():
+        original_session = mcp_auth.async_session
+        original_log = tools._log_usage
+
+        async def fake_log_usage(*a, **kw):
+            return None
+
+        mcp_auth.async_session = lambda: _MiddlewareSession(api_key, vault_row=None)
+        tools._log_usage = fake_log_usage
+        try:
+            app = mcp_auth.APIKeyMiddleware(downstream)
+            await app(
+                {
+                    "type": "http",
+                    "method": "POST",
+                    "path": "/mcp/",
+                    "headers": [(b"authorization", b"Bearer omcp_testkey")],
+                },
+                receive,
+                send,
+            )
+        finally:
+            mcp_auth.async_session = original_session
+            tools._log_usage = original_log
+
+    asyncio.run(run())
+
+    assert sent and sent[0]["status"] == 200, "the request was not authenticated"
+    assert captured["user_id"] == UNASSIGNED_UID
+    assert captured["snapshot"] == (UNASSIGNED_UID, None)
+    assert captured["result"] == tools._NO_VAULT_MESSAGE
+    # And the snapshot does not outlive the request.
+    assert current_vault_root.get() is UNSET_VAULT_ROOT
+
+
+# --- panel copy --------------------------------------------------------------
+
+
+def test_unassigned_option_states_what_the_code_does():
+    """The option label asserted an enforcement outcome the code did not
+    deliver. Assert the *rendered* text, not the source line, so a template
+    refactor cannot quietly restore the old promise."""
+    from jinja2 import ChainableUndefined, ChoiceLoader, DictLoader, Environment, FileSystemLoader
+
+    env = Environment(
+        loader=ChoiceLoader([
+            # Stub the layout: this test is about one option in one template.
+            DictLoader({"base.html": "{% block title %}{% endblock %}{% block content %}{% endblock %}"}),
+            FileSystemLoader(str(_TEMPLATES)),
+        ]),
+        undefined=ChainableUndefined,
+        autoescape=True,
+    )
+    rendered = env.get_template("user_edit.html").render(
+        target=SimpleNamespace(
+            id=1,
+            username="bob",
+            vault_path="/vaults/alpha",
+            is_admin=False,
+            is_active=True,
+        ),
+        available_vaults=["/vaults/alpha"],
+        csrf_token="t",
+        is_self=False,
+    )
+    assert (
+        '<option value="">(unassigned — every MCP tool refuses; '
+        "index kept for reassignment)</option>"
+    ) in rendered
+    assert "vault tools error" not in rendered

--- a/tests/test_issue_66_vault_unassignment_revokes_tools.py
+++ b/tests/test_issue_66_vault_unassignment_revokes_tools.py
@@ -527,6 +527,11 @@ def test_api_key_middleware_binds_the_snapshot_and_the_tool_refuses(cold_cache):
                 receive,
                 send,
             )
+            # Read the ContextVar back *here*, inside the same context the
+            # middleware ran in. Asserting it after `asyncio.run` returns would
+            # be vacuous: the task gets a copied context, so nothing the
+            # middleware set was ever visible out there in the first place.
+            captured["after"] = current_vault_root.get()
         finally:
             mcp_auth.async_session = original_session
             tools._log_usage = original_log
@@ -538,7 +543,7 @@ def test_api_key_middleware_binds_the_snapshot_and_the_tool_refuses(cold_cache):
     assert captured["snapshot"] == (UNASSIGNED_UID, None)
     assert captured["result"] == tools._NO_VAULT_MESSAGE
     # And the snapshot does not outlive the request.
-    assert current_vault_root.get() is UNSET_VAULT_ROOT
+    assert captured["after"] is UNSET_VAULT_ROOT
 
 
 # --- panel copy --------------------------------------------------------------
@@ -637,8 +642,16 @@ class _OAuthMiddlewareSession(_MiddlewareSession):
         return _ScalarResult(self.user_active)
 
 
-def _run_middleware(credential, *, token_value, downstream=None, oauth=False):
-    """Drive `APIKeyMiddleware` with a faked session; return the sent messages."""
+def _run_middleware(credential, *, token_value, downstream=None, oauth=False,
+                    after=None, expect_exc=None):
+    """Drive `APIKeyMiddleware` with a faked session; return the sent messages.
+
+    `after`, if given, is filled with the ContextVar state read *inside* the
+    middleware's own context once the call returns — reading it after
+    `asyncio.run` would be vacuous, since the task runs on a copied context.
+    `expect_exc` names an exception the downstream app is expected to raise;
+    it is caught so the `after` snapshot can still be taken.
+    """
     sent = []
 
     async def _send(message):
@@ -663,16 +676,30 @@ def _run_middleware(credential, *, token_value, downstream=None, oauth=False):
             )
         try:
             app = mcp_auth.APIKeyMiddleware(downstream or _ok)
-            await app(
-                {
-                    "type": "http",
-                    "method": "POST",
-                    "path": "/mcp/",
-                    "headers": [(b"authorization", f"Bearer {token_value}".encode())],
-                },
-                _receive,
-                _send,
-            )
+            raised = None
+            try:
+                await app(
+                    {
+                        "type": "http",
+                        "method": "POST",
+                        "path": "/mcp/",
+                        "headers": [
+                            (b"authorization", f"Bearer {token_value}".encode())
+                        ],
+                    },
+                    _receive,
+                    _send,
+                )
+            except BaseException as exc:  # noqa: BLE001 - re-raised below
+                raised = exc
+            if after is not None:
+                after["vault_root"] = current_vault_root.get()
+                after["user_id"] = current_user_id.get()
+                after["raised"] = raised
+            if raised is not None and not (
+                expect_exc is not None and isinstance(raised, expect_exc)
+            ):
+                raise raised
         finally:
             mcp_auth.async_session = original
 
@@ -840,3 +867,268 @@ def test_admission_gate_issues_no_database_statements(cold_cache, tmp_path):
 
     assert ran.get("yes") is True
     assert result == "served"
+
+
+# --- the OAuth branch loses (and closes) the same race -----------------------
+
+
+def _stale_bulk_warm_downstream(captured, tool_call):
+    """A downstream ASGI app that replays the race and then calls a tool.
+
+    The middleware's own warm already evicted the entry (the user's row is
+    NULL). Here the indexer's *older* bulk query lands, putting the revoked
+    root back into the shared dict, and only then does the request reach a
+    tool.
+    """
+
+    async def downstream(scope, receive, send):
+        assert UNASSIGNED_UID not in vault._user_vault_cache
+        stale_row = SimpleNamespace(id=UNASSIGNED_UID, vault_path=str(STALE_ROOT))
+        await vault.warm_user_vault_cache(_FakeSession(_RowsResult([stale_row])))
+        assert vault._user_vault_cache[UNASSIGNED_UID] == STALE_ROOT
+
+        captured["user_id"] = current_user_id.get()
+        captured["permission"] = mcp_auth.current_permission.get()
+        captured["snapshot"] = current_vault_root.get()
+        captured["result"] = await tool_call()
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    return downstream
+
+
+def _oauth_token(user_id=UNASSIGNED_UID, scope="readwrite"):
+    from datetime import datetime, timedelta, timezone
+
+    from src.models.db import OAuthToken
+
+    return OAuthToken(
+        id=21,
+        token_hash="x",
+        token_type="access",
+        scope=scope,
+        user_id=user_id,
+        revoked=False,
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+
+def test_oauth_middleware_binds_the_snapshot_and_the_tool_refuses(cold_cache):
+    """The API-key branch is not the only way in. An OAuth access token for a
+    user whose `vault_path` was cleared must be refused at the tool too, with
+    a stale bulk warm landing mid-request."""
+    vault._user_vault_cache[UNASSIGNED_UID] = STALE_ROOT
+    captured = {}
+    after = {}
+
+    original_log = tools._log_usage
+
+    async def fake_log_usage(*a, **kw):
+        return None
+
+    tools._log_usage = fake_log_usage
+    try:
+        sent = _run_middleware(
+            _oauth_token(),
+            token_value="oauth_live",
+            oauth=True,
+            downstream=_stale_bulk_warm_downstream(
+                captured, lambda: tools.get_backlinks_impl("Projects/Alpha.md")
+            ),
+            after=after,
+        )
+    finally:
+        tools._log_usage = original_log
+
+    assert sent and sent[0]["status"] == 200, "the token was not authenticated"
+    assert captured["user_id"] == UNASSIGNED_UID
+    # The scope really did map to a write permission — the refusal is the
+    # gate's doing, not a permission error in disguise.
+    assert captured["permission"] == "readwrite"
+    assert captured["snapshot"] == (UNASSIGNED_UID, None)
+    assert captured["result"] == tools._NO_VAULT_MESSAGE
+    # ...and the stale root the bulk warm restored was ignored, not consumed.
+    assert vault._user_vault_cache[UNASSIGNED_UID] == STALE_ROOT
+    assert after["vault_root"] is UNSET_VAULT_ROOT
+
+
+# --- the snapshot is reset on every exit path --------------------------------
+
+
+@pytest.mark.parametrize("oauth", [False, True], ids=["api_key", "oauth"])
+def test_snapshot_is_reset_after_a_downstream_exception(cold_cache, oauth):
+    """`current_vault_root` is reset in the middleware's `finally`. If an
+    exception could strand it, the next request handled on this context would
+    inherit a stale — possibly *permissive* — snapshot."""
+    from src.models.db import APIKey
+
+    credential = (
+        _oauth_token()
+        if oauth
+        else APIKey(
+            id=31,
+            key_hash="x",
+            permission="readwrite",
+            user_id=UNASSIGNED_UID,
+            expires_at=None,
+            is_active=True,
+        )
+    )
+    after = {}
+
+    async def boom(scope, receive, send):
+        # The snapshot is bound at this point...
+        assert current_vault_root.get() == (UNASSIGNED_UID, None)
+        raise RuntimeError("downstream exploded")
+
+    _run_middleware(
+        credential,
+        token_value="oauth_x" if oauth else "omcp_x",
+        oauth=oauth,
+        downstream=boom,
+        after=after,
+        expect_exc=RuntimeError,
+    )
+
+    assert isinstance(after["raised"], RuntimeError)
+    # ...and cleared here, even though the request died.
+    assert after["vault_root"] is UNSET_VAULT_ROOT
+    assert after["user_id"] is None
+
+
+@pytest.mark.parametrize("oauth", [False, True], ids=["api_key", "oauth"])
+def test_snapshot_is_reset_after_a_client_disconnect(cold_cache, oauth):
+    """A cancelled request (client disconnect / server shutdown) unwinds
+    through `CancelledError`, which is a BaseException — a `finally` catches
+    it, an `except Exception` would not."""
+    from src.models.db import APIKey
+
+    credential = (
+        _oauth_token()
+        if oauth
+        else APIKey(
+            id=32,
+            key_hash="x",
+            permission="readwrite",
+            user_id=UNASSIGNED_UID,
+            expires_at=None,
+            is_active=True,
+        )
+    )
+    after = {}
+
+    async def disconnect(scope, receive, send):
+        assert current_vault_root.get() == (UNASSIGNED_UID, None)
+        raise asyncio.CancelledError()
+
+    _run_middleware(
+        credential,
+        token_value="oauth_x" if oauth else "omcp_x",
+        oauth=oauth,
+        downstream=disconnect,
+        after=after,
+        expect_exc=asyncio.CancelledError,
+    )
+
+    assert isinstance(after["raised"], asyncio.CancelledError)
+    assert after["vault_root"] is UNSET_VAULT_ROOT
+    assert after["user_id"] is None
+
+
+# --- the refusal really lands in usage_logs ----------------------------------
+
+
+class _RecordingSession:
+    """Captures what `_log_usage` adds and whether it committed."""
+
+    def __init__(self):
+        self.added = []
+        self.commits = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.commits += 1
+
+
+def test_refused_call_persists_a_usage_log_row(as_unassigned_user):
+    """Not "`_log_usage` was called" — the actual `UsageLog` object it builds,
+    with the identity, the tool, the exact allow-listed params plus the error
+    marker, and a commit.
+
+    `_log_usage` swallows its own exceptions, so a row that failed to build
+    would look like silence. Asserting on the captured object is what makes
+    this test see that.
+    """
+    from src.models.db import UsageLog
+
+    recording = _RecordingSession()
+    original = tools.async_session
+    key_token = mcp_auth.current_api_key_id.set(77)
+    oauth_token_ctx = mcp_auth.current_oauth_token_id.set(None)
+    tools.async_session = lambda: recording
+    try:
+        result = asyncio.run(
+            tools.list_notes_impl(folder="Private", limit=50, tags=["salary"])
+        )
+    finally:
+        tools.async_session = original
+        mcp_auth.current_oauth_token_id.reset(oauth_token_ctx)
+        mcp_auth.current_api_key_id.reset(key_token)
+
+    assert result == tools._NO_VAULT_MESSAGE
+    assert recording.commits == 1, "the usage log was not committed"
+    assert len(recording.added) == 1
+    row = recording.added[0]
+    assert isinstance(row, UsageLog)
+
+    assert row.tool == "list_notes"
+    assert row.user_id == UNASSIGNED_UID
+    assert row.key_id == 77
+    assert row.oauth_token_id is None
+    assert row.response_size == len(tools._NO_VAULT_MESSAGE)
+    assert isinstance(row.duration_ms, int) and row.duration_ms >= 0
+
+    # Exactly the tool's allow-list plus the marker — a refusal must not become
+    # a new disclosure channel, and the marker must actually be persisted.
+    assert row.params == {
+        "folder": "Private",
+        "limit": 50,
+        "tags": ["salary"],
+        "frontmatter": None,
+        "error": tools._NO_VAULT_MARKER,
+    }
+
+
+def test_successful_call_persists_no_error_marker(as_unassigned_user, tmp_path):
+    """The control: the same path with a vault assigned writes the same row
+    shape *without* the marker, so the marker means what it says."""
+    from src.models.db import UsageLog
+
+    @tools._tracked("fake_tool", ["q"])
+    async def fake_tool(q: str) -> str:
+        return "served"
+
+    recording = _RecordingSession()
+    original = tools.async_session
+    tools.async_session = lambda: recording
+    vault._user_vault_cache[UNASSIGNED_UID] = tmp_path
+    try:
+        result = asyncio.run(fake_tool("hello"))
+    finally:
+        tools.async_session = original
+
+    assert result == "served"
+    assert recording.commits == 1
+    row = recording.added[0]
+    assert isinstance(row, UsageLog)
+    assert row.tool == "fake_tool"
+    assert row.params == {"q": "hello"}
+    assert "error" not in row.params


### PR DESCRIPTION
Closes #66.

- `_tracked` resolves the caller's vault root before any tool body runs and refuses with a fixed error when no vault is assigned — DB-backed search and graph tools can no longer outlive the assignment. Index rows are preserved.
- The per-request warm result is bound to a `current_vault_root` ContextVar (API-key and OAuth branches) and is authoritative over the shared cache, so a stale bulk warm cannot re-admit an unassigned user.
- In `multi_user_mode`, credentials with `user_id IS NULL` are rejected by the middleware and `_vault_root(None)` raises (configuration-cycle hole).
- `vault_page` uses the warm's return value directly; `user_edit.html` option label states what the code does.
- OpenSpec change `vault-unassignment-revokes-tools` (archived after deploy).

Gates: openspec-verifier no gaps; Codex adversarial 3 rounds (the last remaining MAJOR lives in transfer.py and ships with the transfer PR); 1073 passed / 5 skipped on the rebased branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mSEspK9GFPSdxmK9XrrMQ