### PR TITLE
OAuth grant families (migration 014), registered-scope clamp, cross-user client refusal (#64 #67 #68 #65 #76)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,7 +229,29 @@ vanished from the page, so the operator saw a blank space that read as success.
   Revoke is exactly the defect.
 - **`/revoke` (RFC 7009) is family-scoped too**, which §2.1 explicitly permits.
   Anything narrower reproduces the near no-op for any client presenting its
-  access token.
+  access token. It **authenticates the client** per its registered method and
+  requires a submitted `client_id` to match the token's — without that, any
+  holder of any token value ended a 30-day grant. §2.2 governs the other
+  direction: a foreign or unknown token is answered 200 with nothing done, so
+  the endpoint is not an oracle for who owns a token value. The only real
+  error is naming the right client and failing to authenticate as it.
+- **No token is minted without an owner, and the mint paths serialize with the
+  multi-user bootstrap.** `register_submit` claims ownerless rows with
+  `UPDATE ... WHERE user_id IS NULL`, whose snapshot is taken at statement
+  start, so a mint committing afterwards left tokens belonging to nobody. Both
+  token handlers take the *same* advisory key the bootstrap already held
+  (`USER_BOOTSTRAP_LOCK_KEY` — a wire constant: changing it un-serializes the
+  window during a rolling deploy) and, under `multi_user_mode`, refuse to mint
+  a NULL-owner token at all. Lock order is bootstrap-then-grant on the only
+  path that takes both; the panel takes the grant lock and never the bootstrap
+  key, so there is no cycle.
+- **The first-authorizer claim is `UPDATE ... WHERE user_id IS NULL
+  RETURNING`**, not an ORM assignment on a row read from this transaction's
+  snapshot — two users consenting to the same unbound client both saw NULL and
+  the second write silently re-bound it. `_handle_refresh` and
+  `src/mcp_server/auth.py` additionally refuse a grant whose owner is not the
+  client's, so a legacy or race-created cross-user grant cannot rotate or
+  authenticate.
 - **The registered scope caps every path.** `src/oauth/scope.py` holds the one
   definition (`clamp_scope`, `client_can_write`, `token_has_write`); the OAuth
   routes, `src/mcp_server/auth.py` and the panel all use it. The panel refuses
@@ -240,11 +262,30 @@ vanished from the page, so the operator saw a blank space that read as success.
   at the source rather than by unioning the panel listing, which would hand the
   other user the owner's cascading Delete. Single-user mode cannot trigger it.
 - **The panel lists revoked and expired rows, dimmed**, with one "Revoke
-  access" control and one scope select *per grant*. Live tokens are always
-  shown; dead ones are capped per grant with the remainder counted, because a
-  client refreshing hourly leaves hundreds in a 30-day window. Status also
-  reads the owner's `User.is_active` ("Owner inactive"), which
-  `APIKeyMiddleware` already enforces and the page used to badge green (#76).
+  access" control and one scope select *per grant*. Status also reads the
+  owner's `User.is_active` ("Owner inactive"), which `APIKeyMiddleware` already
+  enforces and the page used to badge green (#76).
+- **Live rows are queried unbounded; only history is capped.** One `LIMIT` over
+  all of a client's tokens applied *before* grants were identified let a chatty
+  grant's rotations push another grant's live refresh token off the page —
+  a working credential with no control to revoke it. Losing the tail of the
+  history costs a row nobody can act on; losing a live row costs a revocation.
+  When the history query hits its cap the page says so rather than printing a
+  total it did not count.
+- **A grant's permission is `any(token_has_write(...))` over its live rows.**
+  014's backfill can legitimately merge two pre-014 sessions of one client and
+  user, one `read` and one `readwrite`; reading the newest row alone showed
+  "read" while an older live access token still held write. Such a family is
+  marked "mixed", and saving the select writes one clamped scope across all of
+  it — which is what makes it uniform again. `offline_access` is read the same
+  way, so a write cannot strip the marker from a sibling that carried it.
+- **014 verifies a pre-existing `grant_id` column rather than patching it.**
+  The backfill is a partition only because the migration created the column;
+  on a column somebody else added, `WHERE grant_id IS NULL` becomes a patch
+  that hands a NULL row beside a stamped sibling a *fresh* id — splitting one
+  grant in two, so revoking either leaves the other alive. It therefore refuses
+  a wrong type, an index name squatting on another column, any NULL row, and
+  any id spanning more than one `(client_id, user_id)`.
 - **`cleanup_expired_tokens` retains on `expires_at`, never `created_at`.** Its
   revoked branch used to have no age condition at all, so the indexer deleted
   every revoked token within five minutes — the same blank space the listing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,6 +227,15 @@ vanished from the page, so the operator saw a blank space that read as success.
   replaced access token run to its expiry is right for rotation and wrong for
   revocation — an hour of surviving write access after the operator clicked
   Revoke is exactly the defect.
+- **Revocation takes effect at the next authenticated request; a request
+  already in flight completes.** `APIKeyMiddleware` resolves the token once, at
+  the start of the request, so a tool call authenticated microseconds before a
+  revoke or downgrade commits still runs with the permission it was granted.
+  Closing that would mean holding the grant lock across tool execution —
+  arbitrary vault I/O, embedding calls, network fetches — trading a bounded,
+  sub-second staleness for unbounded lock contention on every request. Accepted
+  and documented, at the same optimistic level as `edit_note(expected=…)` and
+  the transfer fingerprint check.
 - **`/revoke` (RFC 7009) is family-scoped too**, which §2.1 explicitly permits.
   Anything narrower reproduces the near no-op for any client presenting its
   access token. It **authenticates the client** per its registered method and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,6 +245,16 @@ vanished from the page, so the operator saw a blank space that read as success.
   client refreshing hourly leaves hundreds in a 30-day window. Status also
   reads the owner's `User.is_active` ("Owner inactive"), which
   `APIKeyMiddleware` already enforces and the page used to badge green (#76).
+- **`cleanup_expired_tokens` retains on `expires_at`, never `created_at`.** Its
+  revoked branch used to have no age condition at all, so the indexer deleted
+  every revoked token within five minutes — the same blank space the listing
+  exists to prevent, just delayed. Revocation time is not stored, but a token
+  can only be revoked while it exists (`R <= expires_at`), so a 7-day window
+  measured from `expires_at` *guarantees* a revoked row stays visible for at
+  least 7 days after revocation. `created_at` inverts that: a refresh token
+  minted 30 days ago and revoked a minute ago would be purged at once. Once
+  age-gated the revoked branch is a strict subset of the expiry branch, which
+  is why the predicate is a single comparison rather than an `or_`.
 
 ## Key Decisions
 - API keys use `omcp_` prefix, stored as SHA-256 hashes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Self-hosted MCP server exposing an Obsidian vault (~2,577 markdown files) via se
 - `src/main.py` — FastAPI app, lifespan, MCP mount
 - `src/config.py` — pydantic-settings
 - `src/database.py` — async SQLAlchemy engine/session
-- `src/models/db.py` — ORM models (api_keys, usage_logs, notes_metadata, note_embeddings, note_links, transfer_tokens)
+- `src/models/db.py` — ORM models (api_keys, usage_logs, notes_metadata, note_embeddings, note_links, transfer_tokens, oauth_clients/codes/tokens)
 - `src/mcp_server/` — MCP server, tools, auth middleware
 - `src/services/` — vault ops, search, embeddings, indexer, transfer, anchored FS
 - `src/transfer/` — public `/transfer/*` capability-redemption routes
@@ -152,7 +152,8 @@ lost the constraint is unknown. Its rules, all load-bearing:
   statement / per lock acquisition**, not a budget for the transaction. 013
   `RESET`s both at the end of `upgrade()`: `SET LOCAL` lasts for the
   transaction, and `alembic/env.py` runs *every* pending revision in one, so a
-  future 014 would otherwise inherit them.
+  later revision would otherwise inherit them. 014 does the same for the same
+  reason.
 - **Lock order is child-first.** The five other tables are backfilled and set
   NOT NULL before `oauth_clients` is locked, matching the app's own direction
   (`src/oauth/routes.py` locks `oauth_codes` `FOR UPDATE`, then reads
@@ -184,6 +185,66 @@ violating-row / NULL-method / missing-column / wrong-default / wrong-type /
 Idempotence is exercised by `alembic stamp 012` then `upgrade head`, not by a
 second `upgrade head` — the latter is a no-op at the alembic level and proves
 nothing about the migration body.
+
+The same module also gates **014**'s backfill, which `alembic check` is blind to
+in a different way: it sees the column, its NOT NULL and its index, and nothing
+about *which rows got which grant*. So the 014 cases assert the grouping
+directly — one family per `(client_id, user_id)`, never a family spanning two
+users, never a user's rows split across two families — plus stamp-back
+idempotence (which must not re-stamp existing `grant_id`s) and the downgrade.
+
+## OAuth grant families
+
+A `/authorize` approval is **one grant**; the token endpoint mints an
+access/refresh pair from it and every rotation mints another pair.
+`oauth_tokens.grant_id` (migration 014, NOT NULL, indexed) is what ties them
+together, and it is the *only* way a family is ever resolved — the decision in
+#64 was explicit that a second "find the family" path is how the bug comes
+back. `src/oauth/grants.py` owns the primitives.
+
+Why it exists: without it the panel could only offer per-row controls, and both
+were near no-ops. Revoking the access row left the refresh token to mint a
+fresh, identically-scoped pair on the client's next 401 retry (access tokens
+live one hour). Downgrading the access row silently reverted, because
+`_handle_refresh` copies the **refresh** token's scope. The revoked row then
+vanished from the page, so the operator saw a blank space that read as success.
+
+- **Invariant: one `grant_id` ⇒ one `(client_id, user_id)`.** Established at
+  every write site and by 014's group key. Family writes therefore do **not**
+  re-filter by `user_id` — under a broken invariant that predicate would turn a
+  complete revocation into a partial one, which is the failure the whole thing
+  exists to remove. `_assert_oauth_token_owner` still guards the token the
+  operator names, and because a family cannot span users that covers it.
+- **`lock_grant` is correctness, not tuning.** Under READ COMMITTED an
+  `UPDATE … WHERE grant_id = :g` takes its snapshot at statement start, so rows
+  a concurrent `_handle_refresh` *inserts* afterwards are invisible to it: the
+  panel reports "revoked" and the client keeps the pair it just rotated into.
+  Row locks cannot close that — the rows do not exist yet. Both sides take
+  `pg_advisory_xact_lock` on the grant **before** touching any family row, so
+  the order is total and nothing deadlocks; `_handle_refresh` does one unlocked
+  `grant_id` lookup first because it cannot lock what it has not identified.
+- **Revocation kills in-flight access tokens; rotation does not.** Letting the
+  replaced access token run to its expiry is right for rotation and wrong for
+  revocation — an hour of surviving write access after the operator clicked
+  Revoke is exactly the defect.
+- **`/revoke` (RFC 7009) is family-scoped too**, which §2.1 explicitly permits.
+  Anything narrower reproduces the near no-op for any client presenting its
+  access token.
+- **The registered scope caps every path.** `src/oauth/scope.py` holds the one
+  definition (`clamp_scope`, `client_can_write`, `token_has_write`); the OAuth
+  routes, `src/mcp_server/auth.py` and the panel all use it. The panel refuses
+  `readwrite` for a client not registered for it *and* clamps what it writes,
+  and `_handle_refresh` re-clamps on every rotation — otherwise a scope raised
+  above the registration survives forever (#67).
+- **`authorize_post` refuses a client bound to a different user** (#68). Fixed
+  at the source rather than by unioning the panel listing, which would hand the
+  other user the owner's cascading Delete. Single-user mode cannot trigger it.
+- **The panel lists revoked and expired rows, dimmed**, with one "Revoke
+  access" control and one scope select *per grant*. Live tokens are always
+  shown; dead ones are capped per grant with the remainder counted, because a
+  client refreshing hourly leaves hundreds in a 30-day window. Status also
+  reads the owner's `User.is_active` ("Owner inactive"), which
+  `APIKeyMiddleware` already enforces and the page used to badge green (#76).
 
 ## Key Decisions
 - API keys use `omcp_` prefix, stored as SHA-256 hashes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,11 +230,14 @@ vanished from the page, so the operator saw a blank space that read as success.
 - **`/revoke` (RFC 7009) is family-scoped too**, which §2.1 explicitly permits.
   Anything narrower reproduces the near no-op for any client presenting its
   access token. It **authenticates the client** per its registered method and
-  requires a submitted `client_id` to match the token's — without that, any
-  holder of any token value ended a 30-day grant. §2.2 governs the other
-  direction: a foreign or unknown token is answered 200 with nothing done, so
-  the endpoint is not an oracle for who owns a token value. The only real
-  error is naming the right client and failing to authenticate as it.
+  requires `client_id` to be **present and exactly equal** to the token's —
+  without that, any holder of any token value ended a 30-day grant. Absence is
+  not a match: a public client has no secret to check, so "omit `client_id`"
+  would be a universal bypass proving nothing, and unlike `/token` there is no
+  PKCE verifier binding the request to the initiating client. §2.2 governs the
+  other direction: a foreign, unnamed or unknown token is answered 200 with
+  nothing done, so the endpoint is not an oracle for who owns a token value.
+  The only real error is naming the right client and failing to authenticate.
 - **No token is minted without an owner, and the mint paths serialize with the
   multi-user bootstrap.** `register_submit` claims ownerless rows with
   `UPDATE ... WHERE user_id IS NULL`, whose snapshot is taken at statement
@@ -263,8 +266,12 @@ vanished from the page, so the operator saw a blank space that read as success.
   other user the owner's cascading Delete. Single-user mode cannot trigger it.
 - **The panel lists revoked and expired rows, dimmed**, with one "Revoke
   access" control and one scope select *per grant*. Status also reads the
-  owner's `User.is_active` ("Owner inactive"), which `APIKeyMiddleware` already
-  enforces and the page used to badge green (#76).
+  owner's `User.is_active` ("Owner inactive") **and `has_vault_scope`** ("No
+  vault scope"), both of which `APIKeyMiddleware` already enforces and the page
+  used to badge green (#76). A no-vault-scope grant counts as dead: offering a
+  Revoke and a scope select for a credential the middleware 401s is the same
+  over-reporting of liveness, and that select could only ever write a scope the
+  client is not registered for.
 - **Live rows are queried unbounded; only history is capped.** One `LIMIT` over
   all of a client's tokens applied *before* grants were identified let a chatty
   grant's rotations push another grant's live refresh token off the page —
@@ -284,8 +291,16 @@ vanished from the page, so the operator saw a blank space that read as success.
   on a column somebody else added, `WHERE grant_id IS NULL` becomes a patch
   that hands a NULL row beside a stamped sibling a *fresh* id — splitting one
   grant in two, so revoking either leaves the other alive. It therefore refuses
-  a wrong type, an index name squatting on another column, any NULL row, and
-  any id spanning more than one `(client_id, user_id)`.
+  a wrong type, any NULL row, any id spanning more than one
+  `(client_id, user_id)`, and an index of its name that is not *exactly* its
+  index. That last check reads `pg_index` — table, `indisvalid`,
+  `indpred IS NULL`, `indexprs IS NULL`, and exactly one key column equal to
+  `grant_id`'s attnum. "Which column is it on?" is not enough: a partial index
+  covers a subset of rows, an expression index cannot serve an equality lookup,
+  a multi-column index leads with the wrong key, and an INVALID leftover from a
+  failed `CREATE INDEX CONCURRENTLY` serves nothing — `CREATE INDEX IF NOT
+  EXISTS` keeps all of them, and autogenerate compares index *names*, so the
+  check would look installed while staying dirty forever.
 - **`cleanup_expired_tokens` retains on `expires_at`, never `created_at`.** Its
   revoked branch used to have no age condition at all, so the indexer deleted
   every revoked token within five minutes — the same blank space the listing

--- a/alembic/versions/014_oauth_grant_id.py
+++ b/alembic/versions/014_oauth_grant_id.py
@@ -58,6 +58,24 @@ inserted between the backfill and `SET NOT NULL`. The explicit post-check is
 belt-and-braces: it raises with a count rather than letting `SET NOT NULL`
 report a generic constraint failure.
 
+**Split a family.** The backfill is a *partition* of rows that have no grant,
+and that is only true when this migration created the column — then every row
+is NULL and the grouping covers all of them. If the column **pre-exists**,
+`WHERE grant_id IS NULL` stops being a partition and becomes a patch: a NULL
+row beside a stamped sibling would get a **fresh** id, turning one grant into
+two, so revoking either would leave the other alive. That is the exact defect
+014 exists to remove, reintroduced by the migration.
+
+There is no safe repair for that state — the right id for a NULL row is
+whatever its siblings carry, and "sibling" is only definable through the
+grouping we would be inventing. So, in 013's spirit, a pre-existing column is
+*verified, not adopted*: it must be `character varying(64)`, our index name
+must be free or already on it, no row may be NULL, and no existing `grant_id`
+may span more than one `(client_id, user_id)` — that last one because every
+family operation resolves a family by `grant_id` alone, so adopting a
+cross-owner id would let one user's Revoke reach another's grant. Any of those
+raises, names the offending rows, and the whole transaction rolls back.
+
 Lock footprint is one table, and a child one at that (`oauth_tokens` references
 both `oauth_clients` and `users`), so this migration cannot close a wait cycle
 with 013's parent-then-child order or with the app's own
@@ -89,16 +107,129 @@ INDEX = "ix_oauth_tokens_grant_id"
 # `secrets.token_urlsafe(24)` (32 chars); the backfill writes a uuid (36).
 COLUMN_TYPE = sa.String(64)
 
+# How PostgreSQL prints that type. A pre-existing column of any other shape is
+# refused rather than adopted -- see `_require_pre_existing_column_is_ours`.
+EXPECTED_TYPE = "character varying(64)"
 
-def _column_exists(bind) -> bool:
+
+def _column_shape(bind):
+    """`(attnotnull, formatted_type)` for `grant_id`, or None if absent."""
     return bind.execute(
         sa.text(
-            "SELECT 1 FROM pg_attribute "
-            "WHERE attrelid = CAST(:table AS regclass) AND attname = :column "
-            "  AND attnum > 0 AND NOT attisdropped"
+            "SELECT a.attnotnull, format_type(a.atttypid, a.atttypmod) "
+            "FROM pg_attribute a "
+            "WHERE a.attrelid = CAST(:table AS regclass) AND a.attname = :column "
+            "  AND a.attnum > 0 AND NOT a.attisdropped"
         ),
         {"table": TABLE, "column": COLUMN},
-    ).scalar_one_or_none() is not None
+    ).first()
+
+
+def _index_column(bind):
+    """The column our index name is defined on, or None if the name is free."""
+    return bind.execute(
+        sa.text(
+            "SELECT a.attname FROM pg_index i "
+            "JOIN pg_class c ON c.oid = i.indexrelid "
+            "JOIN pg_attribute a ON a.attrelid = i.indrelid "
+            "                   AND a.attnum = ANY(i.indkey) "
+            "WHERE c.relname = :index"
+        ),
+        {"index": INDEX},
+    ).scalar_one_or_none()
+
+
+def _require_pre_existing_column_is_ours(bind, shape) -> None:
+    """A `grant_id` this migration did not create must already be 014's shape.
+
+    Same philosophy as 013: reconcile a database that has the shape, refuse to
+    guess for one that does not. A `text` or `varchar(32)` column under our
+    name is not something we can widen and then trust, because we would be
+    trusting values we did not write.
+    """
+    _, formatted_type = shape
+    if formatted_type != EXPECTED_TYPE:
+        raise RuntimeError(
+            f"{TABLE}.{COLUMN} already exists as {formatted_type}, not "
+            f"{EXPECTED_TYPE}. 014 reconciles a column it created; it will not "
+            "adopt one of a different shape. Inspect it by hand, then re-run. "
+            "Nothing has been changed."
+        )
+
+    index_column = _index_column(bind)
+    if index_column not in (None, COLUMN):
+        raise RuntimeError(
+            f"index {INDEX} already exists on column {index_column!r}, not "
+            f"{COLUMN!r}. `alembic check` would stay dirty forever. Drop or "
+            "rename it by hand, then re-run. Nothing has been changed."
+        )
+
+
+def _assert_no_partial_stamping(bind) -> None:
+    """A pre-existing column with NULLs is a *split family* waiting to happen.
+
+    This is the case the first draft got wrong. If some rows carry a
+    `grant_id` and their siblings do not, backfilling only the NULLs assigns
+    those siblings a **fresh** id -- so one grant becomes two, and revoking
+    either one leaves the other alive. That is precisely the defect 014 exists
+    to remove, reintroduced by the migration itself.
+
+    There is no safe repair: the correct id for a NULL row is whatever its
+    siblings carry, but "sibling" is only definable through the grouping we
+    would be inventing. So refuse, name the rows, and let a human decide.
+    """
+    offenders = bind.execute(
+        sa.text(
+            f"SELECT id FROM {TABLE} WHERE {COLUMN} IS NULL ORDER BY id LIMIT 20"
+        )
+    ).scalars().all()
+    if not offenders:
+        return
+    total = bind.execute(
+        sa.text(f"SELECT count(*) FROM {TABLE} WHERE {COLUMN} IS NULL")
+    ).scalar_one()
+    raise RuntimeError(
+        f"{TABLE}.{COLUMN} already exists but {total} row(s) are NULL "
+        f"(ids: {', '.join(str(i) for i in offenders)}"
+        f"{', ...' if total > len(offenders) else ''}). 014 will not backfill "
+        "them: a NULL beside a stamped sibling means assigning a fresh id and "
+        "splitting one grant into two, so a revocation would miss half of it. "
+        "Decide the correct grant_id for these rows by hand, or drop the "
+        "column and let 014 create it. Nothing has been changed."
+    )
+
+
+def _assert_no_grant_spans_two_owners(bind) -> None:
+    """One `grant_id` must mean one `(client_id, user_id)`.
+
+    That invariant is what lets every family operation resolve a family as
+    `grant_id == g` with no `user_id` predicate (see `src/oauth/grants.py`).
+    A pre-existing column could carry ids that violate it -- and adopting them
+    would make a single panel Revoke reach into another user's grant.
+
+    Sentinel-free: `count(DISTINCT user_id)` ignores NULLs, so the third
+    disjunct is what catches a mix of NULL and non-NULL owners.
+    """
+    offenders = bind.execute(
+        sa.text(
+            f"SELECT {COLUMN} FROM {TABLE} "
+            f"WHERE {COLUMN} IS NOT NULL "
+            f"GROUP BY {COLUMN} "
+            "HAVING count(DISTINCT client_id) > 1 "
+            "    OR count(DISTINCT user_id) > 1 "
+            "    OR (count(user_id) > 0 AND count(user_id) < count(*)) "
+            f"ORDER BY {COLUMN} LIMIT 20"
+        )
+    ).scalars().all()
+    if offenders:
+        raise RuntimeError(
+            f"{len(offenders)} pre-existing {COLUMN} value(s) span more than one "
+            f"(client_id, user_id): {', '.join(repr(g) for g in offenders)}. "
+            "A grant family must belong to exactly one client and one user -- "
+            "revocation and scope changes resolve a family by grant_id alone, "
+            "so adopting these would let one user's Revoke reach another's "
+            "grant. Fix them by hand, then re-run. Nothing has been changed."
+        )
 
 
 def upgrade() -> None:
@@ -111,11 +242,21 @@ def upgrade() -> None:
     op.execute("SET LOCAL lock_timeout = '10s'")
     op.execute("SET LOCAL statement_timeout = '60s'")
 
-    if not _column_exists(bind):
+    shape = _column_shape(bind)
+    if shape is None:
         # Nullable for the length of this transaction only. ADD COLUMN takes
         # ACCESS EXCLUSIVE and holds it to COMMIT, so the nullable window is
-        # never observable by another session.
+        # never observable by another session, and every row is NULL at this
+        # point by construction -- which is what makes the backfill below a
+        # partition rather than a patch.
         op.add_column(TABLE, sa.Column(COLUMN, COLUMN_TYPE, nullable=True))
+    else:
+        # The column pre-exists: this is a re-run, or somebody added it. 014
+        # will complete a column it can *verify*, and refuse one it would have
+        # to guess about. See each helper for what it refuses and why.
+        _require_pre_existing_column_is_ours(bind, shape)
+        _assert_no_partial_stamping(bind)
+        _assert_no_grant_spans_two_owners(bind)
 
     # One id per (client_id, user_id) over the rows that do not have one yet.
     #

--- a/alembic/versions/014_oauth_grant_id.py
+++ b/alembic/versions/014_oauth_grant_id.py
@@ -125,18 +125,53 @@ def _column_shape(bind):
     ).first()
 
 
-def _index_column(bind):
-    """The column our index name is defined on, or None if the name is free."""
+def _existing_index(bind):
+    """Everything we need to judge a pre-existing index of our name.
+
+    `(relname_of_table, indisvalid, is_partial, has_expressions, key_attnums)`,
+    or None when the name is free.
+
+    The first version of this asked only "which column is it on?" and matched
+    with `attnum = ANY(indkey)`. That accepts an impostor several ways over: a
+    *partial* index (`WHERE token_type = 'access'`) covers a subset of rows, an
+    *expression* index (`lower(grant_id)`) cannot serve an equality lookup on
+    the column, a *multi-column* index leads with the wrong key, one on another
+    table entirely shares nothing but the name, and an INVALID leftover from a
+    failed `CREATE INDEX CONCURRENTLY` is not usable at all. Every one of those
+    would be kept by `CREATE INDEX IF NOT EXISTS` and leave `alembic check`
+    permanently dirty while looking installed — autogenerate compares index
+    *names*.
+
+    `indkey` is an int2vector; `string_to_array(indkey::text, ' ')` is the
+    portable way to read it as an array. A zero entry means an expression
+    column, which `indexprs IS NOT NULL` already catches.
+    """
     return bind.execute(
         sa.text(
-            "SELECT a.attname FROM pg_index i "
+            "SELECT t.relname AS table_name, "
+            "       i.indisvalid, "
+            "       (i.indpred IS NOT NULL) AS is_partial, "
+            "       (i.indexprs IS NOT NULL) AS has_expressions, "
+            "       string_to_array(i.indkey::text, ' ')::int[] AS key_attnums "
+            "FROM pg_index i "
             "JOIN pg_class c ON c.oid = i.indexrelid "
-            "JOIN pg_attribute a ON a.attrelid = i.indrelid "
-            "                   AND a.attnum = ANY(i.indkey) "
+            "JOIN pg_class t ON t.oid = i.indrelid "
             "WHERE c.relname = :index"
         ),
         {"index": INDEX},
-    ).scalar_one_or_none()
+    ).first()
+
+
+def _column_attnum(bind) -> int:
+    """`pg_attribute.attnum` for `grant_id` — what `indkey` holds."""
+    return bind.execute(
+        sa.text(
+            "SELECT attnum FROM pg_attribute "
+            "WHERE attrelid = CAST(:table AS regclass) AND attname = :column "
+            "  AND attnum > 0 AND NOT attisdropped"
+        ),
+        {"table": TABLE, "column": COLUMN},
+    ).scalar_one()
 
 
 def _require_pre_existing_column_is_ours(bind, shape) -> None:
@@ -156,13 +191,38 @@ def _require_pre_existing_column_is_ours(bind, shape) -> None:
             "Nothing has been changed."
         )
 
-    index_column = _index_column(bind)
-    if index_column not in (None, COLUMN):
-        raise RuntimeError(
-            f"index {INDEX} already exists on column {index_column!r}, not "
-            f"{COLUMN!r}. `alembic check` would stay dirty forever. Drop or "
-            "rename it by hand, then re-run. Nothing has been changed."
-        )
+    existing = _existing_index(bind)
+    if existing is not None:
+        table_name, indisvalid, is_partial, has_expressions, key_attnums = existing
+        expected = [_column_attnum(bind)]
+        problem = None
+        if table_name != TABLE:
+            problem = f"it indexes table {table_name!r}, not {TABLE!r}"
+        elif not indisvalid:
+            problem = (
+                "it is INVALID (a failed CREATE INDEX CONCURRENTLY leaves one "
+                "behind); it cannot serve a lookup"
+            )
+        elif is_partial:
+            problem = (
+                "it is a partial index (has a WHERE clause), so it covers only "
+                "some rows"
+            )
+        elif has_expressions:
+            problem = "it indexes an expression, not the bare column"
+        elif list(key_attnums) != expected:
+            problem = (
+                f"its key columns are attnums {list(key_attnums)}, not exactly "
+                f"[{expected[0]}] ({COLUMN})"
+            )
+        if problem is not None:
+            raise RuntimeError(
+                f"index {INDEX} already exists but {problem}. "
+                "`CREATE INDEX IF NOT EXISTS` would keep it and `alembic check` "
+                "would stay dirty forever, because autogenerate compares index "
+                "names. Drop or rename it by hand, then re-run. Nothing has "
+                "been changed."
+            )
 
 
 def _assert_no_partial_stamping(bind) -> None:

--- a/alembic/versions/014_oauth_grant_id.py
+++ b/alembic/versions/014_oauth_grant_id.py
@@ -1,0 +1,186 @@
+"""Give every OAuth token the grant family it was minted from (issue #64).
+
+`oauth_tokens` had `client_id` and `user_id` but nothing tying an access token
+to the refresh token minted beside it. So the panel could only offer per-row
+controls, and both of them were near no-ops:
+
+- **Revoke** flipped one row. The sibling refresh token was untouched, and the
+  client's ordinary 401-then-refresh cycle minted a fresh, identically-scoped
+  access token within the hour. The operator saw the row disappear and read
+  that as success.
+- **Downgrade** wrote one row's scope. `_handle_refresh` copies the *refresh*
+  token's scope, so a downgrade applied to the access row silently restored
+  itself on the next rotation -- write access the owner believed they had
+  removed.
+
+`grant_id` is the missing identifier. One value per consent event: both tokens
+minted from a single `/authorize` approval share it, and every pair produced by
+later rotation inherits it. Revocation and downgrade then act on the family.
+
+## Backfill
+
+Existing rows predate the column, so one `grant_id` is assigned per distinct
+`(client_id, user_id)` group. That is imperfect exactly where a client genuinely
+backed two concurrent sessions for the same user -- those collapse into one
+family and are revoked together -- but it is strictly better than today's
+per-row behaviour, it fails *closed* (over-revoking, never under-revoking), and
+it converges: every grant issued after this migration is exact.
+
+`user_id IS NOT DISTINCT FROM` rather than `=`: single-user-mode tokens carry
+`user_id IS NULL`, and `NULL = NULL` is NULL, so an `=` join would leave every
+single-user token unmatched and the `SET NOT NULL` below would fail. `GROUP BY`
+already treats NULLs as one group, which is the semantic we want on both sides.
+
+Revoked rows are backfilled too, and deliberately: the column is NOT NULL, and
+the decision in #64 was explicit that leaving `grant_id` nullable with a
+fallback "find the family" path is how this bug comes back. Two code paths for
+resolving a family is the defect, not a safety margin. Grouping revoked rows in
+with the live ones only affects *display* -- family writes touch non-revoked
+rows only -- and it is what makes the panel able to show a grant's revocation
+history at all.
+
+## What this migration must never do
+
+**Invent a grant.** Rows that already carry a `grant_id` are not re-stamped:
+the backfill's group source and its target are both restricted to
+`grant_id IS NULL`. Re-running the migration (the schema gate does exactly
+that, via `alembic stamp 013` then `upgrade head`) therefore cannot split a
+family in two by handing its rows fresh identifiers.
+
+**Merge two users.** The group key is `(client_id, user_id)`, so a family never
+spans users. That is the invariant every family operation in
+`src/oauth/grants.py` leans on -- it is why those operations do not re-filter
+by `user_id`, which would give incomplete revocation a way back in.
+
+**Leave a NULL behind.** The `ADD COLUMN` takes ACCESS EXCLUSIVE on
+`oauth_tokens` and holds it for the whole transaction, so no row can be
+inserted between the backfill and `SET NOT NULL`. The explicit post-check is
+belt-and-braces: it raises with a count rather than letting `SET NOT NULL`
+report a generic constraint failure.
+
+Lock footprint is one table, and a child one at that (`oauth_tokens` references
+both `oauth_clients` and `users`), so this migration cannot close a wait cycle
+with 013's parent-then-child order or with the app's own
+`oauth_codes -> oauth_clients -> oauth_tokens` direction. `lock_timeout` /
+`statement_timeout` make a blocked migration fail fast instead of stalling the
+deploy, and both are RESET at the end because alembic runs every pending
+revision in one transaction and `SET LOCAL` would otherwise leak into 015.
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-08-20
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "014"
+down_revision: Union[str, None] = "013"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE = "oauth_tokens"
+COLUMN = "grant_id"
+INDEX = "ix_oauth_tokens_grant_id"
+
+# Matches `OAuthToken.grant_id` (String(64)). The application mints
+# `secrets.token_urlsafe(24)` (32 chars); the backfill writes a uuid (36).
+COLUMN_TYPE = sa.String(64)
+
+
+def _column_exists(bind) -> bool:
+    return bind.execute(
+        sa.text(
+            "SELECT 1 FROM pg_attribute "
+            "WHERE attrelid = CAST(:table AS regclass) AND attname = :column "
+            "  AND attnum > 0 AND NOT attisdropped"
+        ),
+        {"table": TABLE, "column": COLUMN},
+    ).scalar_one_or_none() is not None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # Fail fast instead of queueing behind a long-lived transaction: the deploy
+    # migrates before recreating the container, so a stalled migration is a
+    # stalled deploy while the old container is still serving. Per statement and
+    # per lock acquisition, not a budget for the whole transaction.
+    op.execute("SET LOCAL lock_timeout = '10s'")
+    op.execute("SET LOCAL statement_timeout = '60s'")
+
+    if not _column_exists(bind):
+        # Nullable for the length of this transaction only. ADD COLUMN takes
+        # ACCESS EXCLUSIVE and holds it to COMMIT, so the nullable window is
+        # never observable by another session.
+        op.add_column(TABLE, sa.Column(COLUMN, COLUMN_TYPE, nullable=True))
+
+    # One id per (client_id, user_id) over the rows that do not have one yet.
+    #
+    # MATERIALIZED is load-bearing: `gen_random_uuid()` is volatile, and an
+    # inlined subquery could be re-evaluated per outer row, which would hand
+    # every token its own private "family" -- the exact opposite of the point.
+    # Materialising the CTE forces one evaluation per group.
+    #
+    # Both the group source and the update target are restricted to
+    # `grant_id IS NULL`, so a row that already belongs to a family keeps it.
+    # That is what makes a re-run (stamp 013 -> upgrade head) a no-op rather
+    # than a re-partitioning of live grants.
+    op.execute(
+        """
+        WITH families AS MATERIALIZED (
+            SELECT client_id,
+                   user_id,
+                   gen_random_uuid()::text AS grant_id
+            FROM oauth_tokens
+            WHERE grant_id IS NULL
+            GROUP BY client_id, user_id
+        )
+        UPDATE oauth_tokens AS t
+        SET grant_id = f.grant_id
+        FROM families AS f
+        WHERE t.grant_id IS NULL
+          AND t.client_id = f.client_id
+          AND t.user_id IS NOT DISTINCT FROM f.user_id
+        """
+    )
+
+    remaining = bind.execute(
+        sa.text(f"SELECT count(*) FROM {TABLE} WHERE {COLUMN} IS NULL")
+    ).scalar_one()
+    if remaining:
+        raise RuntimeError(
+            f"{remaining} {TABLE} row(s) still have a NULL {COLUMN} after the "
+            "backfill, so the column cannot be made NOT NULL. Nothing has been "
+            "changed -- the whole migration rolls back."
+        )
+
+    # Idempotent in Postgres: SET NOT NULL on an already-NOT NULL column is
+    # accepted and does nothing.
+    op.execute(f"ALTER TABLE {TABLE} ALTER COLUMN {COLUMN} SET NOT NULL")
+
+    # The name matters: `OAuthToken.grant_id` declares `index=True`, so
+    # autogenerate expects exactly SQLAlchemy's default `ix_<table>_<column>`.
+    # A differently-named index would leave `alembic check` dirty forever.
+    op.execute(f"CREATE INDEX IF NOT EXISTS {INDEX} ON {TABLE} ({COLUMN})")
+
+    # `SET LOCAL` is scoped to the transaction and alembic runs every pending
+    # revision in *one* -- without this a future 015 would silently inherit
+    # these timeouts and blame its own SQL when a long index build trips them.
+    op.execute("RESET lock_timeout")
+    op.execute("RESET statement_timeout")
+
+
+def downgrade() -> None:
+    """Drop the family identifier.
+
+    Unlike 013's nullability fix there is nothing to preserve: the column did
+    not exist before 014, so no pre-014 database can be missing it and no
+    ownership marker is needed. Downgrading does destroy the grouping -- a
+    subsequent re-upgrade re-derives it from `(client_id, user_id)`, which is
+    the same approximation the original backfill made.
+    """
+    op.execute(f"DROP INDEX IF EXISTS {INDEX}")
+    op.drop_column(TABLE, COLUMN)

--- a/alembic/versions/014_oauth_grant_id.py
+++ b/alembic/versions/014_oauth_grant_id.py
@@ -125,41 +125,74 @@ def _column_shape(bind):
     ).first()
 
 
-def _existing_index(bind):
+def _table_oid(bind) -> int:
+    """The OID `oauth_tokens` resolves to, through the session's search_path.
+
+    Every other statement in this migration names the table unqualified, so
+    they all resolve the same way. Taking the OID once and keying the catalog
+    lookups off it is what keeps the checks talking about the same object the
+    DDL will touch.
+    """
+    return bind.execute(
+        sa.text("SELECT CAST(:table AS regclass)::oid"), {"table": TABLE}
+    ).scalar_one()
+
+
+def _existing_index(bind, table_oid: int):
     """Everything we need to judge a pre-existing index of our name.
 
-    `(relname_of_table, indisvalid, is_partial, has_expressions, key_attnums)`,
-    or None when the name is free.
+    `(indrelid, indisvalid, is_partial, has_expressions, key_attnums)`, or None
+    when the name is free **in the table's own schema**.
 
-    The first version of this asked only "which column is it on?" and matched
-    with `attnum = ANY(indkey)`. That accepts an impostor several ways over: a
-    *partial* index (`WHERE token_type = 'access'`) covers a subset of rows, an
-    *expression* index (`lower(grant_id)`) cannot serve an equality lookup on
-    the column, a *multi-column* index leads with the wrong key, one on another
-    table entirely shares nothing but the name, and an INVALID leftover from a
-    failed `CREATE INDEX CONCURRENTLY` is not usable at all. Every one of those
-    would be kept by `CREATE INDEX IF NOT EXISTS` and leave `alembic check`
-    permanently dirty while looking installed — autogenerate compares index
-    *names*.
+    Two rounds of narrowing got this here. The first version asked only "which
+    column is it on?" and matched with `attnum = ANY(indkey)`, which accepts an
+    impostor several ways over: a *partial* index (`WHERE token_type='access'`)
+    covers a subset of rows, an *expression* index (`lower(grant_id)`) cannot
+    serve an equality lookup on the column, a *multi-column* index leads with
+    the wrong key, and an INVALID leftover from a failed `CREATE INDEX
+    CONCURRENTLY` is not usable at all. Each would be kept by `CREATE INDEX IF
+    NOT EXISTS` and leave `alembic check` permanently dirty while looking
+    installed, because autogenerate compares index *names*.
+
+    The second was that the lookup matched `relname` across **every schema**.
+    An unrelated `shadow.ix_oauth_tokens_grant_id` is not our index and cannot
+    collide with anything we create — `CREATE INDEX` places the index in its
+    table's schema — yet it would be found and the migration would refuse a
+    database that is perfectly fine. So the index is resolved by OID in the
+    namespace of the table we just resolved, which is exactly the name
+    `CREATE INDEX IF NOT EXISTS` tests against.
+
+    More than one row is impossible (`pg_class` is unique on
+    `(relname, relnamespace)`) and is nevertheless treated as fatal rather than
+    silently taking the first: if that assumption ever stops holding, guessing
+    which object the DDL will hit is the wrong response.
 
     `indkey` is an int2vector; `string_to_array(indkey::text, ' ')` is the
     portable way to read it as an array. A zero entry means an expression
     column, which `indexprs IS NOT NULL` already catches.
     """
-    return bind.execute(
+    rows = bind.execute(
         sa.text(
-            "SELECT t.relname AS table_name, "
+            "SELECT i.indrelid, "
             "       i.indisvalid, "
             "       (i.indpred IS NOT NULL) AS is_partial, "
             "       (i.indexprs IS NOT NULL) AS has_expressions, "
             "       string_to_array(i.indkey::text, ' ')::int[] AS key_attnums "
             "FROM pg_index i "
             "JOIN pg_class c ON c.oid = i.indexrelid "
-            "JOIN pg_class t ON t.oid = i.indrelid "
-            "WHERE c.relname = :index"
+            "WHERE c.relname = :index "
+            "  AND c.relnamespace = ("
+            "        SELECT relnamespace FROM pg_class WHERE oid = :table_oid)"
         ),
-        {"index": INDEX},
-    ).first()
+        {"index": INDEX, "table_oid": table_oid},
+    ).all()
+    if len(rows) > 1:
+        raise RuntimeError(
+            f"{len(rows)} relations named {INDEX} in the schema of {TABLE}. "
+            "That should be impossible, and 014 will not guess which one "
+            "`CREATE INDEX IF NOT EXISTS` would match. Nothing has been changed."
+        )
+    return rows[0] if rows else None
 
 
 def _column_attnum(bind) -> int:
@@ -191,13 +224,17 @@ def _require_pre_existing_column_is_ours(bind, shape) -> None:
             "Nothing has been changed."
         )
 
-    existing = _existing_index(bind)
+    table_oid = _table_oid(bind)
+    existing = _existing_index(bind, table_oid)
     if existing is not None:
-        table_name, indisvalid, is_partial, has_expressions, key_attnums = existing
+        indrelid, indisvalid, is_partial, has_expressions, key_attnums = existing
         expected = [_column_attnum(bind)]
         problem = None
-        if table_name != TABLE:
-            problem = f"it indexes table {table_name!r}, not {TABLE!r}"
+        if indrelid != table_oid:
+            # Same schema, same name, different table — only reachable if the
+            # index was created on another relation and then that relation was
+            # renamed into this one's place.
+            problem = f"it indexes another relation, not {TABLE!r}"
         elif not indisvalid:
             problem = (
                 "it is INVALID (a failed CREATE INDEX CONCURRENTLY leaves one "

--- a/openspec/changes/oauth-grant-families/design.md
+++ b/openspec/changes/oauth-grant-families/design.md
@@ -1,0 +1,128 @@
+## Context
+
+`OAuthToken` carried `client_id` and `user_id` and nothing else that could
+group rows. Every "act on the grant" behaviour the panel appeared to offer was
+therefore unimplementable, and the two controls it did offer were misleading
+rather than merely incomplete.
+
+## Goals / Non-Goals
+
+**Goals.** One durable identifier per consent event; one code path that
+resolves a family; revocation and downgrade that survive a rotation; a
+registered scope that caps every path; a panel that shows the same liveness the
+middleware enforces.
+
+**Non-Goals.** Per-session grants for pre-014 tokens (impossible to recover —
+the information was never stored). A UI for browsing full token history. Any
+change to how API keys are displayed (#76's keys/users half is separate work).
+
+## Decisions
+
+### D1 — `grant_id` is NOT NULL, with a backfill, not nullable with a fallback
+
+The alternative was leaving `grant_id` NULL for pre-014 rows and resolving
+those families by `(client_id, user_id)` at read time. Rejected in the issue's
+decision comment, and correctly: two code paths for "find the family" is how
+this bug returns. The backfill assigns one id per distinct
+`(client_id, user_id)` over *all* rows, including revoked ones, so exactly one
+resolution rule exists from the first minute after the migration.
+
+The approximation is stated honestly: where a client genuinely backed two
+concurrent sessions for one user, those collapse into one family and are
+revoked together. That errs toward over-revoking, and it converges — every
+grant issued after the migration is exact.
+
+### D2 — Families are resolved by `grant_id` alone, never by `grant_id AND user_id`
+
+A `user_id` predicate on the family write looks like defence in depth and is
+not: under a broken invariant it converts a *complete* revocation into a
+partial one, which is the failure mode this whole change exists to remove. The
+invariant (one `grant_id` ⇒ one `(client_id, user_id)`) is instead established
+at every write site and by the backfill's group key, and asserted directly in
+`tests/integration/test_schema_check.py`.
+
+Authorization is unaffected: `_assert_oauth_token_owner` still guards the token
+the operator names, and because the family cannot span users that check covers
+everything the write touches.
+
+### D3 — A transaction-scoped advisory lock on the family, taken before any family row
+
+Row locks cannot make revocation linearizable here, because the rows that would
+escape it *do not exist yet*. Under READ COMMITTED an
+`UPDATE … WHERE grant_id = :g` takes its snapshot at statement start; a
+concurrent `_handle_refresh` that commits two new rows afterwards leaves them
+untouched, and the operator is told the grant is revoked while the client keeps
+the pair it just rotated into.
+
+`pg_advisory_xact_lock(key)` on a key derived from the `grant_id` closes it.
+Both sides take that one lock **before** touching any family row, so the
+acquisition order is total and there is no cycle to deadlock on; the lock
+releases on COMMIT or ROLLBACK. The subsequent statement takes a fresh
+snapshot, which is precisely what makes the concurrently-inserted rows visible.
+
+`_handle_refresh` needs the id before it can lock, so it does one unlocked
+lookup of `grant_id` by token hash, takes the lock, and only then runs the
+authoritative `FOR UPDATE` select. The unlocked lookup deliberately does not
+filter on `revoked` — it is finding a family, not authorizing a refresh.
+
+The key is derived in Python (SHA-256 of a namespace prefix plus the id, folded
+to a signed 64-bit int) rather than with Postgres' `hashtext()`, which is
+undocumented and has changed algorithm between majors.
+
+### D4 — Revocation kills in-flight access tokens; rotation does not
+
+`_handle_refresh` still lets the access token it replaces run to its natural
+expiry. That is correct for rotation — the client may have requests in flight.
+It is wrong for revocation, so the family revoke covers access rows too. An
+hour of surviving write access after the operator clicked Revoke is exactly the
+failure being fixed.
+
+### D5 — The RFC 7009 endpoint is family-scoped too
+
+RFC 7009 §2.1 explicitly permits revoking the associated refresh token, and
+anything narrower reproduces the same near no-op for any client that presents
+its access token. Nothing is leaked by the widening: the caller already holds a
+credential from this family, and the RFC requires HTTP 200 either way.
+
+### D6 — The panel refuses an over-registration scope rather than clamping it silently
+
+`update_oauth_token_scope` rejects `readwrite` for a client not registered for
+it (redirect, no write) *and* clamps the value it does write. The refusal is
+the honest signal — an operator who deliberately selected `readwrite` should
+not be told nothing happened when the select snaps back — and the clamp is what
+guarantees no path can write a scope above the registration even if a future
+caller skips the refusal.
+
+### D7 — #68 is fixed at the source (option b), not by unioning the panel listing
+
+Unioning the client list means gating every client-level action, and the
+obvious version of that renders the owner's "Delete this client and revoke all
+its tokens?" button to the other user. Refusing the reuse in `authorize_post`
+also closes the converse hazard, where the owner's Delete silently kills
+another user's live grant. Single-user mode is untouched: there is no session
+identity, so the check cannot fire.
+
+### D8 — Revocation history is bounded, not unbounded
+
+Revoked and expired rows are now listed, because a row that silently vanishes
+is what made a no-op Revoke read as success. But a client refreshing hourly
+leaves hundreds of rotated-away tokens in a 30-day window. Every *live* token
+is always rendered; dead ones are capped at five per grant with the remainder
+counted in a "+ N earlier" line, and the per-client scan is bounded so one
+chatty client cannot make the page unbounded.
+
+## Risks / Trade-offs
+
+- **Deploy ordering.** 014 makes `grant_id` NOT NULL, so a container running
+  pre-014 code cannot insert tokens after the migration. `make deploy` migrates
+  then recreates, so the window is the recreate itself; a token exchange landing
+  inside it fails with a 500 and the client retries. Acceptable, and the same
+  shape as every other NOT NULL this repo has added.
+- **Lock contention.** The advisory lock serializes concurrent operations on
+  one grant. Grants are per-connector-per-user and refreshes are hourly, so
+  contention is effectively nil; when it happens the loser waits, it does not
+  fail.
+- **Re-clamping on refresh changes returned scope strings.** A client whose
+  registration was narrowed after the grant now sees a narrower `scope` in the
+  refresh response. That is the point, and RFC 6749 §5.1 requires the response
+  to state the granted scope when it differs from what was requested.

--- a/openspec/changes/oauth-grant-families/design.md
+++ b/openspec/changes/oauth-grant-families/design.md
@@ -126,3 +126,12 @@ chatty client cannot make the page unbounded.
   registration was narrowed after the grant now sees a narrower `scope` in the
   refresh response. That is the point, and RFC 6749 §5.1 requires the response
   to state the granted scope when it differs from what was requested.
+- **Revocation takes effect at the next authenticated request; an in-flight
+  request completes.** `APIKeyMiddleware` resolves the token once, at the start
+  of the request, so a tool call authenticated microseconds before a revoke or
+  downgrade commits still runs with the permission it was granted. Closing that
+  would mean holding the grant lock across tool execution — arbitrary vault I/O,
+  embedding calls, network fetches — which trades a bounded, sub-second
+  staleness for unbounded lock contention on every request. Accepted as a
+  documented limitation: it is the same optimistic level as `edit_note(expected=…)`
+  and the transfer fingerprint check, declared rather than implied.

--- a/openspec/changes/oauth-grant-families/proposal.md
+++ b/openspec/changes/oauth-grant-families/proposal.md
@@ -1,0 +1,79 @@
+## Why
+
+Four defects in the OAuth surface all reduce to the same thing: **the panel and
+the token endpoint disagree about what a grant is**, and the disagreement
+always resolves in favour of more access than the owner intended.
+
+- **#64.** `oauth_tokens` had no identifier tying an access token to the refresh
+  token minted beside it, so the panel could only offer per-row controls — and
+  both were near no-ops. Revoking the access row left the refresh token to mint
+  a fresh, identically-scoped pair on the client's next 401 retry (access
+  tokens live one hour). Downgrading the access row silently reverted, because
+  `_handle_refresh` copies the *refresh* token's scope. The revoked row then
+  vanished from the page, so the operator was shown a blank space that read as
+  success.
+- **#67.** `update_oauth_token_scope` validated the submitted scope against the
+  literal tuple `('read','readwrite')` and never clamped it against
+  `OAuthClient.scope`. A client registered read-only via DCR could be raised to
+  `readwrite` from the panel — permanently, since rotation re-minted from the
+  token's own scope forever after.
+- **#68.** A client binds to its first authorizing user and never rebinds, so a
+  second user authorizing the same `client_id` got live tokens under a client
+  they do not own: invisible in their panel (which filters by
+  `OAuthClient.user_id`) and destroyable by the owner's Delete cascade.
+- **#76 (OAuth half).** `oauth.html` printed "Active" from `revoked`/`expired`
+  alone while `APIKeyMiddleware` additionally requires the owning
+  `User.is_active`. A deactivated user's tokens were dead and badged green.
+- **#65 (gaps 1–2).** The tests shipped with #62 built the template context by
+  hand, so `oauth_page`'s `has_write` derivation was untested, and one
+  assertion exercised only Python's `in` operator.
+
+## What Changes
+
+- **`oauth_tokens.grant_id`** (migration 014): opaque, indexed, NOT NULL. One
+  value per consent event; both tokens minted from one `/authorize` approval
+  share it and every rotation inherits it. Backfilled one id per distinct
+  `(client_id, user_id)`.
+- **Family-scoped writes.** `revoke_oauth_token`, `update_oauth_token_scope`
+  and the RFC 7009 `/revoke` endpoint act on every non-revoked token in the
+  family, in one transaction, under a transaction-scoped advisory lock that a
+  concurrent `_handle_refresh` also takes — so a rotation cannot slip a new
+  pair past a revocation's snapshot.
+- **One scope definition.** New dependency-free `src/oauth/scope.py` holding
+  `clamp_scope`, `client_can_write` and `token_has_write`. The OAuth routes,
+  the ASGI auth middleware and the control panel all use it.
+- **The registration is the cap, everywhere.** The panel refuses `readwrite`
+  for a client not registered for it, `oauth.html` does not render the option,
+  and `_handle_refresh` re-clamps on every rotation.
+- **Cross-user client reuse is refused** in `authorize_post`.
+- **The panel shows what is true.** Revoked and expired rows stay listed
+  (dimmed, history capped per grant), one "Revoke access" control per grant
+  instead of one per row, and an "Owner inactive" badge derived from the
+  owner's `User.is_active`.
+
+## Capabilities
+
+### Modified Capabilities
+- `oauth-authorization-integrity`: grant families, family-scoped revocation and
+  scope changes, the registered-scope cap on every path, cross-user client
+  refusal, and effective credential status in the panel.
+
+## Impact
+
+- `alembic/versions/014_oauth_grant_id.py` — new
+- `src/oauth/scope.py`, `src/oauth/grants.py` — new
+- `src/models/db.py` — `OAuthToken.grant_id`
+- `src/oauth/routes.py` — stamp, inherit, re-clamp, cross-user refusal,
+  family-scoped `/revoke`
+- `src/control_panel/routes.py` — `oauth_page`, `revoke_oauth_token`,
+  `update_oauth_token_scope`
+- `src/control_panel/templates/oauth.html` — per-grant rendering
+- `src/mcp_server/auth.py` — one-line swap to the shared helper
+- `tests/` — `test_issue_64_grant_families.py`,
+  `test_issue_67_panel_scope_clamp.py`,
+  `test_issue_68_cross_user_client.py`, rewritten
+  `test_oauth_panel_scope_display.py`, `_oauth_grant_fakes.py`, and seven new
+  cases in `tests/integration/test_schema_check.py`
+
+Carries a migration, so `make test-schema` is a required gate and
+`make db-check` must report "No new upgrade operations detected" after deploy.

--- a/openspec/changes/oauth-grant-families/specs/oauth-authorization-integrity/spec.md
+++ b/openspec/changes/oauth-grant-families/specs/oauth-authorization-integrity/spec.md
@@ -1,0 +1,134 @@
+## ADDED Requirements
+
+### Requirement: Every OAuth token belongs to exactly one grant family
+Every `oauth_tokens` row SHALL carry a non-null `grant_id` identifying the consent event it descends from. Both tokens minted from a single `/authorize` approval MUST share one `grant_id`, every token pair produced by a later rotation MUST inherit the `grant_id` of the refresh token it rotated, and a `grant_id` MUST belong to exactly one `(client_id, user_id)` pair.
+
+#### Scenario: One consent produces one family
+- **WHEN** an authorization code is exchanged at the token endpoint
+- **THEN** the issued access token and refresh token SHALL carry the same, freshly generated `grant_id`
+
+#### Scenario: Rotation stays inside its family
+- **WHEN** a refresh token is exchanged for a new token pair
+- **THEN** both new tokens SHALL carry the `grant_id` of the refresh token that was presented
+- **AND** no new `grant_id` SHALL be generated
+
+#### Scenario: Pre-existing tokens are backfilled without merging users
+- **WHEN** migration 014 runs against a database whose tokens predate `grant_id`
+- **THEN** every row SHALL receive a `grant_id`, one per distinct `(client_id, user_id)` group, with NULL `user_id` treated as a single group
+- **AND** no `grant_id` SHALL be shared by rows belonging to two different users
+- **AND** all rows sharing a `(client_id, user_id)` pair SHALL share one `grant_id`
+
+#### Scenario: Re-running the migration preserves existing families
+- **WHEN** migration 014 executes again against a database whose rows already carry a `grant_id`
+- **THEN** no existing `grant_id` value SHALL be changed
+
+### Requirement: Revoking an OAuth grant revokes every live token in its family
+Panel revocation and the RFC 7009 revocation endpoint SHALL mark every non-revoked token sharing the target's `grant_id` as revoked, in a single transaction, including access tokens that have not yet expired. Revocation MUST NOT be satisfiable by a subsequent refresh.
+
+#### Scenario: Revoking through the access token kills the refresh token
+- **WHEN** an operator revokes a grant from the control panel using its access token row
+- **THEN** the paired refresh token SHALL also be marked revoked
+- **AND** a later refresh presenting that refresh token SHALL be rejected with `invalid_grant`
+
+#### Scenario: Revocation covers tokens minted by an earlier rotation
+- **WHEN** a grant has rotated one or more times and older non-revoked tokens are still within their lifetime
+- **THEN** revoking the grant SHALL mark every one of those tokens revoked
+
+#### Scenario: The RFC 7009 endpoint is grant-scoped
+- **WHEN** a client presents any token of a grant to `POST /revoke`
+- **THEN** every non-revoked token in that grant SHALL be revoked
+- **AND** the endpoint SHALL still respond HTTP 200
+
+#### Scenario: A different grant is untouched
+- **WHEN** a client has two grants and one of them is revoked
+- **THEN** no token belonging to the other grant SHALL be modified
+
+#### Scenario: Revocation is not lost to a concurrent rotation
+- **WHEN** a revocation and a refresh of the same grant execute concurrently
+- **THEN** both SHALL serialize on a transaction-scoped lock keyed by that `grant_id`, taken before either reads or writes any token row of the family
+- **AND** the outcome SHALL be either a rejected refresh or a revocation that also covers the newly minted pair
+
+### Requirement: A scope change applies to every live token in the grant family
+A scope change made from the control panel SHALL be written to every non-revoked token sharing the target's `grant_id` in one transaction, and MUST NOT be reverted by a subsequent rotation. Revoked tokens MUST keep the scope they carried when they were revoked.
+
+#### Scenario: Downgrading the access row also downgrades the refresh row
+- **WHEN** an operator changes a grant's scope to `read` using its access token row
+- **THEN** the paired refresh token's scope SHALL also become `read`
+
+#### Scenario: A downgrade survives the next refresh
+- **WHEN** the client refreshes after the grant was downgraded to `read`
+- **THEN** the newly minted tokens SHALL NOT carry `readwrite`
+- **AND** the token response's `scope` SHALL NOT contain `readwrite`
+
+#### Scenario: Revoked rows keep their historical scope
+- **WHEN** a grant containing a revoked token has its scope changed
+- **THEN** the revoked token's scope SHALL be left unchanged
+
+### Requirement: No path may grant a scope above the client's registration
+`OAuthClient.scope` SHALL cap every grant that client can hold, on every path that writes a token scope: consent approval, authorization-code exchange, panel scope changes, and refresh-token rotation. A request for a scope the client is not registered for MUST NOT result in that scope being written.
+
+#### Scenario: The token endpoint clamps the code's scope
+- **WHEN** an authorization code carrying `readwrite` is exchanged and its client is not registered for `readwrite`
+- **THEN** the issued tokens SHALL NOT carry `readwrite`
+- **AND** the token response's `scope` SHALL NOT contain `readwrite`
+
+#### Scenario: The panel refuses to raise a read-only client
+- **WHEN** an operator submits `readwrite` for a grant whose client is registered `read`
+- **THEN** no token scope SHALL be modified
+- **AND** the request SHALL not be committed
+
+#### Scenario: The panel does not offer an unavailable option
+- **WHEN** the OAuth page renders a client registered without `readwrite`
+- **THEN** the scope control SHALL NOT contain a `readwrite` option
+
+#### Scenario: Rotation re-clamps against the current registration
+- **WHEN** a token carrying `readwrite` is rotated and its client's registered scope no longer includes `readwrite`
+- **THEN** the newly minted tokens SHALL NOT carry `readwrite`
+
+#### Scenario: A legitimate write grant is preserved
+- **WHEN** a `readwrite` token is rotated and its client is registered for `readwrite`
+- **THEN** the newly minted tokens SHALL still carry `readwrite`
+
+### Requirement: An OAuth client bound to one user MUST NOT mint grants for another
+In multi-user mode, `authorize_post` SHALL reject an approval when the client is already bound to a different user than the authenticated session identity, and MUST NOT mint an authorization code. The token endpoint SHALL re-check the same condition before exchanging a code. Single-user mode SHALL be unaffected.
+
+#### Scenario: A code for a client another user has since claimed is not exchangeable
+- **WHEN** an authorization code stamped with one user is presented and its client is now bound to a different user
+- **THEN** the exchange SHALL be rejected with `invalid_grant`
+- **AND** no token SHALL be minted
+- **AND** the code SHALL NOT be marked used
+
+#### Scenario: A second user cannot authorize someone else's client
+- **WHEN** an authenticated user approves consent for a client whose `user_id` is a different user
+- **THEN** the request SHALL be rejected with HTTP 403 and `error: access_denied`
+- **AND** no authorization code SHALL be minted
+- **AND** the client's existing `user_id` SHALL be left unchanged
+
+#### Scenario: The first authorizer still claims an unbound client
+- **WHEN** an authenticated user approves consent for a client whose `user_id` is null
+- **THEN** the client SHALL be bound to that user and the authorization code SHALL be minted
+
+#### Scenario: Single-user mode is unaffected
+- **WHEN** the server runs in single-user mode and a consent approval is submitted
+- **THEN** the approval SHALL proceed regardless of any `user_id` stored on the client
+
+### Requirement: The OAuth panel SHALL show the status the middleware enforces
+The OAuth page SHALL derive each grant's status from revocation, expiry and the owning user's `is_active`, using the same scope-membership helper the authentication middleware uses, and SHALL list revoked and expired tokens rather than omitting them. The page MUST present one revocation control and one scope control per grant, never one per token row.
+
+#### Scenario: A deactivated owner's grant is not shown as active
+- **WHEN** a token's owning user has `is_active = false`
+- **THEN** the grant SHALL be badged "Owner inactive" and SHALL NOT be badged "Active"
+
+#### Scenario: Revoked tokens remain visible
+- **WHEN** a grant has been revoked
+- **THEN** its token rows SHALL still be listed with a "Revoked" status
+- **AND** no revocation or scope control SHALL be offered for that grant
+
+#### Scenario: One grant, one set of controls
+- **WHEN** a grant's access and refresh tokens are both live
+- **THEN** the page SHALL render exactly one revocation control and exactly one scope control for that grant
+
+#### Scenario: The displayed permission is membership-based
+- **WHEN** a token's scope is `offline_access readwrite`
+- **THEN** the scope control SHALL show `readwrite` as the selected value
+- **AND** that value SHALL be derived by the route from the token's scope, not supplied to the template independently

--- a/openspec/changes/oauth-grant-families/specs/oauth-authorization-integrity/spec.md
+++ b/openspec/changes/oauth-grant-families/specs/oauth-authorization-integrity/spec.md
@@ -124,6 +124,11 @@ The OAuth page SHALL derive each grant's status from revocation, expiry and the 
 - **THEN** its token rows SHALL still be listed with a "Revoked" status
 - **AND** no revocation or scope control SHALL be offered for that grant
 
+#### Scenario: Periodic cleanup does not erase a revocation
+- **WHEN** the periodic token cleanup runs after a grant has been revoked
+- **THEN** a revoked token SHALL only be deleted once its `expires_at` is more than the retention window in the past
+- **AND** a token revoked while still within its lifetime SHALL therefore remain listed for at least that window after it was revoked
+
 #### Scenario: One grant, one set of controls
 - **WHEN** a grant's access and refresh tokens are both live
 - **THEN** the page SHALL render exactly one revocation control and exactly one scope control for that grant

--- a/openspec/changes/oauth-grant-families/tasks.md
+++ b/openspec/changes/oauth-grant-families/tasks.md
@@ -33,6 +33,7 @@
 - [x] 5.1 `oauth_page` groups tokens into grants, includes revoked/expired rows, caps history per grant and bounds the per-client scan
 - [x] 5.2 Derive effective status including the owner's `User.is_active`; add the "Owner inactive" badge
 - [x] 5.3 Rewrite `oauth.html` for one block per grant: one "Revoke access" control, one scope select, dimmed history rows, "+ N earlier" line
+- [x] 5.4 Age-gate the revoked branch of `cleanup_expired_tokens` on `expires_at` (it had no age condition at all, so the indexer deleted every revocation's evidence within 5 minutes); document why `expires_at` and not `created_at`
 
 ## 6. Tests
 
@@ -42,10 +43,11 @@
 - [x] 6.4 `tests/test_issue_67_panel_scope_clamp.py` — panel refusal, option gating, rotation re-clamp, helper unit tests
 - [x] 6.5 `tests/test_issue_68_cross_user_client.py` — refusal, no rebinding, owner/unbound/single-user paths, deny path
 - [x] 6.6 Seven new cases in `tests/integration/test_schema_check.py` for 014's backfill, NOT NULL, index name, idempotence and downgrade; update the head-revision assertions to `014`
+- [x] 6.7 `tests/test_issue_64_token_cleanup_retention.py` — structural comparison of the emitted WHERE clause plus a small real evaluator, so the retention window is pinned by behaviour and not by reading one bind parameter
 
 ## 7. Gates
 
-- [x] 7.1 `pytest --ignore=tests/integration` green (995 passed, 5 skipped; baseline 940/5)
+- [x] 7.1 `pytest --ignore=tests/integration` green (1006 passed, 5 skipped; baseline 940/5)
 - [x] 7.2 `make test-schema` green (20 passed) — includes `alembic check` clean on every path
 - [x] 7.3 `openspec validate oauth-grant-families --strict`
 - [ ] 7.4 Adversarial Codex pass (orchestrator-run)

--- a/openspec/changes/oauth-grant-families/tasks.md
+++ b/openspec/changes/oauth-grant-families/tasks.md
@@ -45,10 +45,22 @@
 - [x] 6.6 Seven new cases in `tests/integration/test_schema_check.py` for 014's backfill, NOT NULL, index name, idempotence and downgrade; update the head-revision assertions to `014`
 - [x] 6.7 `tests/test_issue_64_token_cleanup_retention.py` — structural comparison of the emitted WHERE clause plus a small real evaluator, so the retention window is pinned by behaviour and not by reading one bind parameter
 
+## 8. Adversarial round 1 (Codex FAIL: 1 BLOCKER, 6 MAJOR, 2 MINOR)
+
+- [x] 8.1 BLOCKER — bootstrap vs mint race: both token handlers take the bootstrap advisory lock (key shared from `src/oauth/grants.py`; value unchanged for rolling deploys) and refuse to mint a NULL-owner token under `multi_user_mode`
+- [x] 8.2 MAJOR — `/revoke` authenticates the client per its registered method and requires a submitted `client_id` to match the token's; a foreign or unknown token stays a uniform 200 (RFC 7009 §2.2)
+- [x] 8.3 MAJOR — the first-authorizer claim is `UPDATE ... WHERE user_id IS NULL RETURNING`, with a fresh-snapshot re-read and a refusal when the winner is another user
+- [x] 8.4 MAJOR — `_handle_refresh` rejects a grant whose owner is not the client's; `src/mcp_server/auth.py` rejects the same mismatch for access tokens
+- [x] 8.5 MAJOR — `oauth_page` reads live rows unbounded and caps only history, so no live grant can be pushed off the page
+- [x] 8.6 MAJOR — a mixed-scope family reports `any(token_has_write(...))`, is marked "mixed", and a scope write makes it uniform across the family
+- [x] 8.7 MAJOR — 014 verifies a pre-existing `grant_id` column instead of patching it: refuses a wrong type, a squatting index name, any NULL row, or any id spanning two owners
+- [x] 8.8 MINOR — `clamp_scope` fails closed on an empty intersection (section 3 above)
+- [x] 8.9 MINOR — fakes match the literal `pg_advisory_xact_lock` and honour LIMIT/OFFSET; `tests/integration/test_oauth_grants_pg.py` adds real-Postgres coverage of revoke-vs-refresh ordering (deterministically gated, not a `gather` and a hope), concurrent first consent, and client-authenticated `/revoke`
+
 ## 7. Gates
 
-- [x] 7.1 `pytest --ignore=tests/integration` green (1006 passed, 5 skipped; baseline 940/5)
-- [x] 7.2 `make test-schema` green (20 passed) — includes `alembic check` clean on every path
+- [x] 7.1 `pytest --ignore=tests/integration` green (1063 passed, 5 skipped; baseline 940/5)
+- [x] 7.2 `make test-schema` green (27 passed) — includes `alembic check` clean on every path
 - [x] 7.3 `openspec validate oauth-grant-families --strict`
-- [ ] 7.4 Adversarial Codex pass (orchestrator-run)
+- [x] 7.4 Adversarial Codex round 1 findings addressed (section 8); re-run is orchestrator's
 - [ ] 7.5 Deploy + `make db-check` (orchestrator-run)

--- a/openspec/changes/oauth-grant-families/tasks.md
+++ b/openspec/changes/oauth-grant-families/tasks.md
@@ -65,10 +65,16 @@
 - [x] 9.3 MINOR — 014's index check reads `pg_index` (table, `indisvalid`, `indpred`, `indexprs`, exact key attnums); partial / expression / multi-column / wrong-table / INVALID impostors all refused
 - [x] 9.4 MINOR — the fake matches only the exact normalized lock statement and interprets both `expires_at` directions (and the history disjunction as a disjunction); `tests/test_oauth_grant_fakes_fidelity.py` pins both, verified by mutation
 
+## 10. Adversarial round 3 (Codex: 1 MAJOR accepted, 1 MINOR, 1 NIT)
+
+- [x] 10.1 MAJOR **accepted as a documented limitation** — a request authenticated just before a revoke/downgrade commits still runs its tool with the stale permission. Holding the grant lock across tool execution would trade bounded, sub-second staleness for unbounded contention on every request; recorded in design.md and the CLAUDE.md OAuth section
+- [x] 10.2 MINOR — 014's pre-existing-index lookup is schema-qualified: table resolved to an OID, index resolved by name **in that table's namespace**, more than one match fatal. A shadow-schema index of the same name no longer refuses a healthy database
+- [x] 10.3 NIT — the hidden-history line reads "earlier inactive token(s)" instead of naming only two of the three inactive reasons
+
 ## 7. Gates
 
-- [x] 7.1 `pytest --ignore=tests/integration` green (1213 passed, 5 skipped, post-rebase)
-- [x] 7.2 `make test-schema` green (34 passed) — includes `alembic check` clean on every path
+- [x] 7.1 `pytest --ignore=tests/integration` green (1242 passed, 5 skipped, post-rebase)
+- [x] 7.2 `make test-schema` green (35 passed) — includes `alembic check` clean on every path
 - [x] 7.3 `openspec validate oauth-grant-families --strict`
-- [x] 7.4 Adversarial Codex rounds 1 and 2 addressed (sections 8 and 9); re-run is orchestrator's
+- [x] 7.4 Adversarial Codex rounds 1-3 addressed (sections 8-10); round 3's MAJOR is an accepted, documented limitation
 - [ ] 7.5 Deploy + `make db-check` (orchestrator-run)

--- a/openspec/changes/oauth-grant-families/tasks.md
+++ b/openspec/changes/oauth-grant-families/tasks.md
@@ -1,0 +1,52 @@
+## 1. Shared scope vocabulary (#67, #65 gap 1)
+
+- [x] 1.1 Add `src/oauth/scope.py` with `scope_set`, `client_can_write`, `token_has_write`, `clamp_scope` and `VALID_SCOPES` — dependency-free so every layer can import it without a cycle
+- [x] 1.2 Point `src/oauth/routes.py` at it (`_clamp_scope` is now the shared helper; `authorize_get`'s `client_can_write` comes from it)
+- [x] 1.3 Swap `src/mcp_server/auth.py`'s private membership check for `token_has_write`
+- [x] 1.4 Point `oauth_page`'s `has_write` at `token_has_write` and its per-client `can_write` at `client_can_write`
+
+## 2. Grant families (#64)
+
+- [x] 2.1 Add `OAuthToken.grant_id` (`String(64)`, NOT NULL, `index=True`) to `src/models/db.py`
+- [x] 2.2 Write `alembic/versions/014_oauth_grant_id.py`: add nullable, backfill one id per `(client_id, user_id)` with `IS NOT DISTINCT FROM` for NULL users, verify no NULL remains, `SET NOT NULL`, create `ix_oauth_tokens_grant_id`; guard the backfill on `grant_id IS NULL` so a re-run cannot re-stamp; `SET LOCAL` and `RESET` the timeouts
+- [x] 2.3 Add `src/oauth/grants.py`: `new_grant_id`, `grant_lock_key`, `lock_grant`, `revoke_grant_family`, `set_grant_family_scope`
+- [x] 2.4 Stamp a fresh `grant_id` on both tokens in `_handle_auth_code`
+- [x] 2.5 Inherit `old_token.grant_id` in `_handle_refresh`, and take the family lock before reading the family
+- [x] 2.6 Make `revoke_oauth_token` revoke the whole family (access tokens included)
+- [x] 2.7 Make `update_oauth_token_scope` write the whole family
+- [x] 2.8 Make the RFC 7009 `/revoke` endpoint family-scoped
+
+## 3. The registration is the cap (#67)
+
+- [x] 3.1 `update_oauth_token_scope` refuses `readwrite` when the client is not registered for it, and clamps whatever it does write
+- [x] 3.2 `oauth.html` renders the `readwrite` option only when `client.can_write`
+- [x] 3.3 `_handle_refresh` re-clamps the rotated scope against the client's current registration and returns the clamped value in the token response
+- [x] 3.4 `_handle_auth_code` clamps the code's scope against the client row it already loads, so the exchange is not the one unclamped write path
+
+## 4. Cross-user client reuse (#68)
+
+- [x] 4.1 Add `_client_belongs_to_another_user` and refuse in `authorize_post` before any code is minted; leave `authorize_get` alone
+- [x] 4.2 Re-check in `_handle_auth_code` before the code is marked used, closing the race where two users consent to the same *unbound* client concurrently and only one claim wins
+
+## 5. Panel display (#64 history, #76 OAuth half)
+
+- [x] 5.1 `oauth_page` groups tokens into grants, includes revoked/expired rows, caps history per grant and bounds the per-client scan
+- [x] 5.2 Derive effective status including the owner's `User.is_active`; add the "Owner inactive" badge
+- [x] 5.3 Rewrite `oauth.html` for one block per grant: one "Revoke access" control, one scope select, dimmed history rows, "+ N earlier" line
+
+## 6. Tests
+
+- [x] 6.1 Rewrite `tests/test_oauth_panel_scope_display.py` to exercise the real `oauth_page` (#65 gap 1) and replace the tautological assertion with calls into `token_has_write` (#65 gap 2)
+- [x] 6.2 `tests/_oauth_grant_fakes.py` — statement-interpreting fake session so family writes are observable
+- [x] 6.3 `tests/test_issue_64_grant_families.py` — stamping, inheritance, revocation that survives a refresh, downgrade that does not revert, family isolation, lock ordering, RFC endpoint
+- [x] 6.4 `tests/test_issue_67_panel_scope_clamp.py` — panel refusal, option gating, rotation re-clamp, helper unit tests
+- [x] 6.5 `tests/test_issue_68_cross_user_client.py` — refusal, no rebinding, owner/unbound/single-user paths, deny path
+- [x] 6.6 Seven new cases in `tests/integration/test_schema_check.py` for 014's backfill, NOT NULL, index name, idempotence and downgrade; update the head-revision assertions to `014`
+
+## 7. Gates
+
+- [x] 7.1 `pytest --ignore=tests/integration` green (995 passed, 5 skipped; baseline 940/5)
+- [x] 7.2 `make test-schema` green (20 passed) — includes `alembic check` clean on every path
+- [x] 7.3 `openspec validate oauth-grant-families --strict`
+- [ ] 7.4 Adversarial Codex pass (orchestrator-run)
+- [ ] 7.5 Deploy + `make db-check` (orchestrator-run)

--- a/openspec/changes/oauth-grant-families/tasks.md
+++ b/openspec/changes/oauth-grant-families/tasks.md
@@ -57,10 +57,18 @@
 - [x] 8.8 MINOR — `clamp_scope` fails closed on an empty intersection (section 3 above)
 - [x] 8.9 MINOR — fakes match the literal `pg_advisory_xact_lock` and honour LIMIT/OFFSET; `tests/integration/test_oauth_grants_pg.py` adds real-Postgres coverage of revoke-vs-refresh ordering (deterministically gated, not a `gather` and a hope), concurrent first consent, and client-authenticated `/revoke`
 
+## 9. Adversarial round 2 (Codex: 1 BLOCKER, 2 MAJOR, 1 MINOR)
+
+- [x] 9.0 Rebase onto `origin/main` (three merged slices; `src/mcp_server/auth.py` and `src/services/vault.py` overlapped). The round-2 BLOCKER — an ownerless OAuth token accepted in multi-user mode — is what main's `ownerless_credential` check rejects; pinned in this branch's suite too, end to end through the middleware
+- [x] 9.1 MAJOR — `/revoke` requires `client_id` present **and** equal; absence was a universal bypass because a public client authenticates trivially
+- [x] 9.2 MAJOR — `_token_status` includes `has_vault_scope`, rendering a distinct "No vault scope" state with no scope or revoke control
+- [x] 9.3 MINOR — 014's index check reads `pg_index` (table, `indisvalid`, `indpred`, `indexprs`, exact key attnums); partial / expression / multi-column / wrong-table / INVALID impostors all refused
+- [x] 9.4 MINOR — the fake matches only the exact normalized lock statement and interprets both `expires_at` directions (and the history disjunction as a disjunction); `tests/test_oauth_grant_fakes_fidelity.py` pins both, verified by mutation
+
 ## 7. Gates
 
-- [x] 7.1 `pytest --ignore=tests/integration` green (1063 passed, 5 skipped; baseline 940/5)
-- [x] 7.2 `make test-schema` green (27 passed) — includes `alembic check` clean on every path
+- [x] 7.1 `pytest --ignore=tests/integration` green (1213 passed, 5 skipped, post-rebase)
+- [x] 7.2 `make test-schema` green (34 passed) — includes `alembic check` clean on every path
 - [x] 7.3 `openspec validate oauth-grant-families --strict`
-- [x] 7.4 Adversarial Codex round 1 findings addressed (section 8); re-run is orchestrator's
+- [x] 7.4 Adversarial Codex rounds 1 and 2 addressed (sections 8 and 9); re-run is orchestrator's
 - [ ] 7.5 Deploy + `make db-check` (orchestrator-run)

--- a/src/auth/routes.py
+++ b/src/auth/routes.py
@@ -28,6 +28,7 @@ from src.csrf import generate_csrf_token, verify_csrf
 from src.database import get_session
 from src.limiter import limiter
 from src.models.db import APIKey, NoteMetadata, OAuthClient, OAuthCode, OAuthToken, UsageLog, User
+from src.oauth.grants import USER_BOOTSTRAP_LOCK_KEY
 from src.services.vault import validate_vault_root_path, warm_user_vault_cache
 
 router = APIRouter(tags=["auth"], dependencies=[Depends(verify_csrf)])
@@ -41,7 +42,11 @@ templates = Jinja2Templates(
 # Advisory-lock key for the bootstrap-registration critical section. Any
 # distinct 32-bit int works; this is just a constant the lock function
 # expects. Two concurrent /admin/register POSTs will serialize on this key.
-_BOOTSTRAP_LOCK_KEY = 7283910429
+# Shared with the OAuth token-minting handlers, which take the same key so a
+# mint cannot insert a new ownerless token in the window between this
+# transaction's `WHERE user_id IS NULL` claim and its COMMIT. The value is
+# unchanged; only its definition moved, so a rolling deploy still serializes.
+_BOOTSTRAP_LOCK_KEY = USER_BOOTSTRAP_LOCK_KEY
 
 
 # --- Helpers --------------------------------------------------------------

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -29,6 +29,8 @@ from src.models.db import (
     User,
     UsageLog,
 )
+from src.oauth.grants import revoke_grant_family, set_grant_family_scope
+from src.oauth.scope import clamp_scope, client_can_write, token_has_write
 from src.services.indexer import invalidate_hnsw_index_cache
 from src.services.vault import warm_user_vault_cache
 
@@ -544,6 +546,121 @@ async def delete_key_form(
 # --- OAuth ----------------------------------------------------------------
 
 
+# How many dead (revoked or expired) tokens to render per grant. Revocation
+# history is the point — a Revoke that made the row vanish read as success even
+# when it was a no-op (issue #64) — but a client that refreshes hourly leaves
+# hundreds of rotated-away refresh tokens in a 30-day window, and a page that
+# renders all of them buries the live pair the operator came to look at. Older
+# rows are counted and reported, never silently dropped.
+GRANT_HISTORY_LIMIT = 5
+
+# Upper bound on token rows read per client, so one chatty client cannot make
+# this page unbounded. Deliberately far above `GRANT_HISTORY_LIMIT` times any
+# plausible number of grants: rows past it are not grouped at all, and losing a
+# whole grant would be worse than losing some of its history.
+CLIENT_TOKEN_SCAN_LIMIT = 1000
+
+
+def _token_status(token, now: datetime, owner_active: bool) -> str:
+    """The status of one token row, strictest reason first.
+
+    `owner_active` is the part the panel used to ignore (issue #76):
+    `APIKeyMiddleware` additionally requires the owning `User.is_active` and
+    401s with `reason=inactive_user` otherwise, so a deactivated user's tokens
+    were already dead while this page rendered them green. The error direction
+    matters — this can over-report deadness, never liveness, so no working
+    credential is ever shown as revoked.
+    """
+    if token.revoked:
+        return "revoked"
+    if token.expires_at <= now:
+        return "expired"
+    if not owner_active:
+        return "owner_inactive"
+    return "active"
+
+
+async def _owner_active_map(session: AsyncSession, user_ids: set[int]) -> dict[int, bool]:
+    """`{user_id: is_active}` for the owners of the tokens on this page.
+
+    A `user_id` missing from the result — a deleted user, whose tokens the FK
+    cascade should have taken with it — is read as inactive by the caller,
+    which is the same direction the middleware fails in.
+    """
+    if not user_ids:
+        return {}
+    result = await session.execute(
+        select(User.id, User.is_active).where(User.id.in_(user_ids))
+    )
+    return {row[0]: bool(row[1]) for row in result.all()}
+
+
+def _grant_view(grant_id: str, family: list, now: datetime, active_by_owner: dict[int, bool]) -> dict:
+    """One grant family as the template consumes it.
+
+    `family` is every token row sharing `grant_id`, newest first. A *live*
+    token is one that is neither revoked nor expired; whether its owner is
+    still active changes the badge but not liveness, because reactivating the
+    user brings the same token back rather than minting a new one.
+    """
+    live: list[tuple] = []
+    dead: list[dict] = []
+    for t in family:
+        owner_active = t.user_id is None or active_by_owner.get(t.user_id) is True
+        status = _token_status(t, now, owner_active)
+        row = {
+            "id": t.id,
+            "token_type": t.token_type,
+            "scope": t.scope,
+            "status": status,
+            "expires_at": t.expires_at.isoformat(),
+            "created_at": t.created_at.isoformat(),
+        }
+        if status in ("active", "owner_inactive"):
+            live.append((t, row))
+        else:
+            dead.append(row)
+
+    # Every still-usable token is always rendered; only history is capped.
+    shown = [row for _, row in live] + dead[:GRANT_HISTORY_LIMIT]
+    hidden = max(0, len(dead) - GRANT_HISTORY_LIMIT)
+
+    # One scope control and one "Revoke access" per grant, addressed through a
+    # representative live token. Acting on a single row was the whole defect:
+    # `_handle_refresh` copies the *refresh* token's scope, so a downgrade
+    # applied to the access row silently restored itself on the next rotation,
+    # and a Revoke on the access row bought at most its one-hour lifetime. The
+    # handlers behind these forms resolve the family and write all of it.
+    if live:
+        representative, representative_row = live[0]
+        token_id = representative.id
+        status = representative_row["status"]
+        scope = representative_row["scope"]
+    else:
+        # Nothing left to act on, so no controls are offered. The rows are
+        # still listed: a revocation that leaves a blank space reads as
+        # success even when it did nothing.
+        token_id = None
+        status = "revoked" if all(t.revoked for t in family) else "expired"
+        scope = family[0].scope
+
+    return {
+        "grant_id": grant_id,
+        "token_id": token_id,
+        "scope": scope,
+        # Membership, not equality: "offline_access readwrite" is a write grant
+        # and `== "readwrite"` says it is not. Derived here, from the token's
+        # own scope, through the same helper `src/mcp_server/auth.py` enforces
+        # with — the two agreeing is the property that actually matters (#65).
+        "has_write": token_has_write(scope),
+        "status": status,
+        "created_at": min(t.created_at for t in family).isoformat(),
+        "last_seen_at": max(t.created_at for t in family).isoformat(),
+        "tokens": shown,
+        "hidden_count": hidden,
+    }
+
+
 @router.get("/oauth", response_class=HTMLResponse)
 async def oauth_page(
     request: Request,
@@ -556,46 +673,60 @@ async def oauth_page(
     if uid is not None:
         q = q.where(OAuthClient.user_id == uid)
     result = await session.execute(q)
-    clients = []
-    for c in result.scalars().all():
-        # Tokens inherit their client's scope, but we also scope tokens by
-        # user_id directly for defense in depth: an unbound/legacy client
-        # could have tokens stamped with a user_id that diverges from the
-        # client's. Filter both ways.
+    client_rows = list(result.scalars().all())
+
+    # Tokens inherit their client's scope, but we also scope tokens by
+    # user_id directly for defense in depth: an unbound/legacy client
+    # could have tokens stamped with a user_id that diverges from the
+    # client's. Filter both ways.
+    #
+    # Revoked and expired rows are *included* now. Filtering them out is what
+    # made a per-row Revoke read as success: the row simply disappeared, the
+    # sibling refresh token minted a replacement pair within the hour, and the
+    # page showed a fresh access+refresh pair as if nothing had happened. It
+    # also left the template's `revoked` branches as unreachable dead code.
+    tokens_by_client: dict[str, list] = {}
+    owner_ids: set[int] = set()
+    for c in client_rows:
         token_q = (
             select(OAuthToken)
-            .where(
-                OAuthToken.client_id == c.client_id,
-                OAuthToken.revoked == False,
-                OAuthToken.expires_at > now,
-            )
-            .order_by(OAuthToken.created_at.desc())
+            .where(OAuthToken.client_id == c.client_id)
+            .order_by(OAuthToken.created_at.desc(), OAuthToken.id.desc())
+            .limit(CLIENT_TOKEN_SCAN_LIMIT)
         )
         if uid is not None:
             token_q = token_q.where(OAuthToken.user_id == uid)
-        token_result = await session.execute(token_q)
-        tokens = []
-        for t in token_result.scalars().all():
-            tokens.append({
-                "id": t.id,
-                "token_type": t.token_type,
-                "scope": t.scope,
-                # t.scope is a space-separated set (e.g. "offline_access
-                # readwrite"), not always exactly "read" or "readwrite" -
-                # the template needs membership, not string equality, or
-                # a readwrite token showing an offline_access marker
-                # renders as if it were read-only.
-                "has_write": "readwrite" in t.scope.split(),
-                "revoked": t.revoked,
-                "expired": False,
-                "expires_at": t.expires_at.isoformat(),
-                "created_at": t.created_at.isoformat(),
-            })
+        rows = list((await session.execute(token_q)).scalars().all())
+        tokens_by_client[c.client_id] = rows
+        owner_ids.update(t.user_id for t in rows if t.user_id is not None)
+
+    active_by_owner = await _owner_active_map(session, owner_ids)
+
+    clients = []
+    for c in client_rows:
+        # Group into grant families. `grant_id` is NOT NULL (migration 014) and
+        # is the *only* way a family is ever resolved — the decision in #64 was
+        # explicit that a second "find the family" path is how the bug returns.
+        grouped: dict[str, list] = {}
+        for t in tokens_by_client[c.client_id]:
+            grouped.setdefault(t.grant_id, []).append(t)
+
+        grants = [
+            _grant_view(grant_id, family, now, active_by_owner)
+            for grant_id, family in grouped.items()
+        ]
+        grants.sort(key=lambda g: g["last_seen_at"], reverse=True)
+
         clients.append({
             "client_id": c.client_id,
             "client_name": c.client_name,
             "created_at": c.created_at.isoformat(),
-            "tokens": tokens,
+            # The registered scope caps everything this client's grants may
+            # hold, so the panel must not offer an option above it (issue #67).
+            # Same helper the consent screen and the token endpoint use.
+            "can_write": client_can_write(c.scope),
+            "scope": c.scope,
+            "grants": grants,
         })
     return templates.TemplateResponse(request, "oauth.html", _panel_context(request, user, {
         "active": "oauth", "clients": clients,
@@ -644,8 +775,20 @@ async def revoke_oauth_token(
     session: AsyncSession = Depends(get_session),
     user=Depends(require_user_panel),
 ):
+    """Revoke the whole grant family, not the single row that was clicked.
+
+    Flipping one row was close to a durable no-op (issue #64): the sibling
+    refresh token was untouched, `_handle_refresh` resolves on
+    `token_hash` + `token_type` + `revoked` alone, and the client's ordinary
+    401-then-refresh cycle minted a fresh, identically-scoped pair — within the
+    hour for an access token, automatically, with no sign of it in the panel.
+
+    `token_id` is now a handle on the grant, not the unit of work. Ownership is
+    still asserted on the row the operator named; the family cannot span users
+    (see `src/oauth/grants.py`), so that check covers everything this touches.
+    """
     token = await _assert_oauth_token_owner(session, token_id, user)
-    token.revoked = True
+    await revoke_grant_family(session, token.grant_id)
     await session.commit()
     return RedirectResponse("/admin/oauth", status_code=303)
 
@@ -657,16 +800,44 @@ async def update_oauth_token_scope(
     session: AsyncSession = Depends(get_session),
     user=Depends(require_user_panel),
 ):
+    """Set one scope on every live token in the grant. Never above the client's.
+
+    Two defects meet here. Writing a single row let the change revert on the
+    next rotation, because `_handle_refresh` copies the *refresh* token's scope
+    (issue #64). And nothing clamped the submitted value against
+    `OAuthClient.scope`, so the panel could hand `readwrite` to a client that
+    registered read-only — permanently, since rotation re-minted from the
+    token's own scope forever after (issue #67).
+
+    The registration is a statement about that software, so a request above it
+    is refused outright rather than quietly clamped: an operator who picked
+    `readwrite` should not be told nothing happened when the select snaps back.
+    The clamp still runs afterwards as the belt to that braces — no path may
+    write a scope the client is not registered for.
+    """
     if scope not in ("read", "readwrite"):
         return RedirectResponse("/admin/oauth", status_code=303)
     token = await _assert_oauth_token_owner(session, token_id, user)
-    if not token.revoked:
-        # Preserve the offline_access marker (informational only - see
-        # DEFAULT_CLIENT_SCOPE comment in src/oauth/routes.py) instead of
-        # dropping it whenever an admin flips read/readwrite here.
-        has_offline = "offline_access" in token.scope.split()
-        token.scope = f"{scope} offline_access" if has_offline else scope
-        await session.commit()
+    if token.revoked:
+        return RedirectResponse("/admin/oauth", status_code=303)
+
+    client = (
+        await session.execute(
+            select(OAuthClient).where(OAuthClient.client_id == token.client_id)
+        )
+    ).scalar_one_or_none()
+    if client is None:
+        raise HTTPException(404, "Client not found")
+    if scope == "readwrite" and not client_can_write(client.scope):
+        return RedirectResponse("/admin/oauth", status_code=303)
+
+    # Preserve the offline_access marker (informational only - see
+    # DEFAULT_CLIENT_SCOPE comment in src/oauth/routes.py) instead of
+    # dropping it whenever an admin flips read/readwrite here.
+    has_offline = "offline_access" in token.scope.split()
+    desired = f"{scope} offline_access" if has_offline else scope
+    await set_grant_family_scope(session, token.grant_id, clamp_scope(desired, client.scope))
+    await session.commit()
     return RedirectResponse("/admin/oauth", status_code=303)
 
 

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -34,7 +34,12 @@ from src.oauth.grants import (
     revoke_grant_family,
     set_grant_family_scope,
 )
-from src.oauth.scope import clamp_scope, client_can_write, token_has_write
+from src.oauth.scope import (
+    clamp_scope,
+    client_can_write,
+    has_vault_scope,
+    token_has_write,
+)
 from src.services.indexer import invalidate_hnsw_index_cache
 from src.services.vault import warm_user_vault_cache
 
@@ -583,6 +588,14 @@ def _token_status(token, now: datetime, owner_active: bool) -> str:
         return "revoked"
     if token.expires_at <= now:
         return "expired"
+    if not has_vault_scope(token.scope):
+        # `offline_access` says the grant may carry a refresh token, not that
+        # it may read a note, so `src/mcp_server/auth.py` 401s this token
+        # (`reason=no_vault_scope`). No path can mint one any more, but a
+        # client registered `scope="offline_access"` before that could already
+        # hold one — and the panel showed it "Active" with a working scope
+        # control, which is the same over-reporting of liveness #76 was about.
+        return "no_vault_scope"
     if not owner_active:
         return "owner_inactive"
     return "active"
@@ -627,6 +640,11 @@ def _grant_view(grant_id: str, family: list, now: datetime, active_by_owner: dic
         if status in ("active", "owner_inactive"):
             live.append((t, row))
         else:
+            # `no_vault_scope` counts as dead, deliberately: the middleware
+            # rejects it, so treating it as live would offer a Revoke and a
+            # scope select for a credential that cannot authenticate — and the
+            # scope select would try to write a scope its client is not
+            # registered for, which `update_oauth_token_scope` refuses anyway.
             dead.append(row)
 
     # Every still-usable token is always rendered; only history is capped.
@@ -649,7 +667,12 @@ def _grant_view(grant_id: str, family: list, now: datetime, active_by_owner: dic
         # still listed: a revocation that leaves a blank space reads as
         # success even when it did nothing.
         token_id = None
-        status = "revoked" if all(t.revoked for t in family) else "expired"
+        if all(t.revoked for t in family):
+            status = "revoked"
+        elif not has_vault_scope(family[0].scope):
+            status = "no_vault_scope"
+        else:
+            status = "expired"
         scope = family[0].scope
 
     # A family is normally uniform — every row descends from one consent and

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -728,8 +728,17 @@ async def oauth_page(
             "scope": c.scope,
             "grants": grants,
         })
+
+    # Why the last scope change did nothing, if it did nothing. The select
+    # posts on `onchange`, so a bare redirect reads as the browser undoing the
+    # operator's click. Absent in single-user mode, which has no session.
+    try:
+        flash_error = request.session.pop("flash_oauth_error", None)
+    except (AssertionError, AttributeError):
+        flash_error = None
+
     return templates.TemplateResponse(request, "oauth.html", _panel_context(request, user, {
-        "active": "oauth", "clients": clients,
+        "active": "oauth", "clients": clients, "flash_error": flash_error,
     }))
 
 
@@ -793,9 +802,27 @@ async def revoke_oauth_token(
     return RedirectResponse("/admin/oauth", status_code=303)
 
 
+def _flash_oauth_error(request: Request | None, message: str) -> None:
+    """Say why a scope change did nothing, instead of snapping the select back.
+
+    The select posts on `onchange`, so a silent redirect looks like the browser
+    reverting the operator's click for no reason. Session flashes are absent in
+    single-user mode (no `SessionMiddleware`), which is the same
+    `AssertionError` dance `create_key_form` does — the refusal still holds
+    there, it just goes unexplained.
+    """
+    if request is None:
+        return
+    try:
+        request.session["flash_oauth_error"] = message
+    except (AssertionError, AttributeError):
+        pass
+
+
 @router.post("/oauth/token/{token_id}/scope")
 async def update_oauth_token_scope(
     token_id: int,
+    request: Request = None,
     scope: str = Form(...),
     session: AsyncSession = Depends(get_session),
     user=Depends(require_user_panel),
@@ -829,6 +856,12 @@ async def update_oauth_token_scope(
     if client is None:
         raise HTTPException(404, "Client not found")
     if scope == "readwrite" and not client_can_write(client.scope):
+        _flash_oauth_error(
+            request,
+            f"'{client.client_name}' is registered for '{client.scope}', so its "
+            "grants cannot be raised to readwrite. Re-register the client if it "
+            "genuinely needs write access.",
+        )
         return RedirectResponse("/admin/oauth", status_code=303)
 
     # Preserve the offline_access marker (informational only - see
@@ -836,7 +869,23 @@ async def update_oauth_token_scope(
     # dropping it whenever an admin flips read/readwrite here.
     has_offline = "offline_access" in token.scope.split()
     desired = f"{scope} offline_access" if has_offline else scope
-    await set_grant_family_scope(session, token.grant_id, clamp_scope(desired, client.scope))
+    granted = clamp_scope(desired, client.scope)
+    if not granted:
+        # The registration names no vault scope at all (`offline_access` alone
+        # is not one). `clamp_scope` used to answer `read` here, so this
+        # control could hand a client read access to the whole vault that its
+        # registration never granted. Writing an *empty* scope would be worse
+        # still — `src/mcp_server/auth.py` maps anything without `readwrite`
+        # to `read`, so an empty scope string reads as read access.
+        _flash_oauth_error(
+            request,
+            f"'{client.client_name}' is registered for '{client.scope}', which "
+            "grants no vault access, so its tokens cannot be given a scope. "
+            "Re-register the client with 'read' or 'readwrite'.",
+        )
+        return RedirectResponse("/admin/oauth", status_code=303)
+
+    await set_grant_family_scope(session, token.grant_id, granted)
     await session.commit()
     return RedirectResponse("/admin/oauth", status_code=303)
 

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
-from sqlalchemy import func, select, text
+from sqlalchemy import func, or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.auth.session import _SingleUserSentinel, get_current_user
@@ -29,7 +29,11 @@ from src.models.db import (
     User,
     UsageLog,
 )
-from src.oauth.grants import revoke_grant_family, set_grant_family_scope
+from src.oauth.grants import (
+    live_family_scopes,
+    revoke_grant_family,
+    set_grant_family_scope,
+)
 from src.oauth.scope import clamp_scope, client_can_write, token_has_write
 from src.services.indexer import invalidate_hnsw_index_cache
 from src.services.vault import warm_user_vault_cache
@@ -554,11 +558,15 @@ async def delete_key_form(
 # rows are counted and reported, never silently dropped.
 GRANT_HISTORY_LIMIT = 5
 
-# Upper bound on token rows read per client, so one chatty client cannot make
-# this page unbounded. Deliberately far above `GRANT_HISTORY_LIMIT` times any
-# plausible number of grants: rows past it are not grouped at all, and losing a
-# whole grant would be worse than losing some of its history.
-CLIENT_TOKEN_SCAN_LIMIT = 1000
+# Upper bound on *dead* token rows read per client. Live rows are deliberately
+# unbounded: a single bound over the whole table applied before grants were
+# identified could push a live grant's refresh token off the page entirely,
+# leaving a working credential with no control to revoke it. That is a strictly
+# worse failure than losing some history, and it is reachable — 501 rotations
+# of one chatty grant were enough. Dead rows are fetched newest-first, so what
+# a truncation loses is the oldest history, never a live grant and never a
+# recent revocation.
+CLIENT_DEAD_TOKEN_SCAN_LIMIT = 500
 
 
 def _token_status(token, now: datetime, owner_active: bool) -> str:
@@ -644,15 +652,28 @@ def _grant_view(grant_id: str, family: list, now: datetime, active_by_owner: dic
         status = "revoked" if all(t.revoked for t in family) else "expired"
         scope = family[0].scope
 
+    # A family is normally uniform — every row descends from one consent and
+    # rotation copies the scope — but migration 014's backfill can legitimately
+    # merge two pre-014 sessions of the same client and user, one `read` and
+    # one `readwrite`. Reading the permission off the newest live row alone
+    # would then show "read" while an older live access token still holds
+    # write. `any` is the fail-safe direction: it over-reports capability, so
+    # the operator is never told a grant is narrower than it is.
+    live_write = [token_has_write(t.scope) for t, _ in live]
+    has_write = any(live_write) if live_write else token_has_write(scope)
+    mixed_scope = bool(live_write) and any(live_write) and not all(live_write)
+
     return {
         "grant_id": grant_id,
         "token_id": token_id,
         "scope": scope,
         # Membership, not equality: "offline_access readwrite" is a write grant
-        # and `== "readwrite"` says it is not. Derived here, from the token's
-        # own scope, through the same helper `src/mcp_server/auth.py` enforces
+        # and `== "readwrite"` says it is not. Derived here, from the tokens'
+        # own scopes, through the same helper `src/mcp_server/auth.py` enforces
         # with — the two agreeing is the property that actually matters (#65).
-        "has_write": token_has_write(scope),
+        "has_write": has_write,
+        "mixed_scope": mixed_scope,
+        "live_scopes": sorted({t.scope for t, _ in live}),
         "status": status,
         "created_at": min(t.created_at for t in family).isoformat(),
         "last_seen_at": max(t.created_at for t in family).isoformat(),
@@ -686,17 +707,44 @@ async def oauth_page(
     # page showed a fresh access+refresh pair as if nothing had happened. It
     # also left the template's `revoked` branches as unreachable dead code.
     tokens_by_client: dict[str, list] = {}
+    truncated_clients: set[str] = set()
     owner_ids: set[int] = set()
     for c in client_rows:
-        token_q = (
-            select(OAuthToken)
-            .where(OAuthToken.client_id == c.client_id)
+        def _scoped(query):
+            query = query.where(OAuthToken.client_id == c.client_id)
+            return query if uid is None else query.where(OAuthToken.user_id == uid)
+
+        # Every *live* token, unbounded. A bound here would decide which grants
+        # the operator can act on, and a chatty grant's rotations would decide
+        # it for them.
+        live_q = _scoped(
+            select(OAuthToken).where(
+                OAuthToken.revoked == False,
+                OAuthToken.expires_at > now,
+            )
+        ).order_by(OAuthToken.created_at.desc(), OAuthToken.id.desc())
+        live_rows = list((await session.execute(live_q)).scalars().all())
+
+        # History, newest first and bounded. Losing the tail of this costs an
+        # old row nobody can act on; losing a live row costs a revocation.
+        dead_q = (
+            _scoped(
+                select(OAuthToken).where(
+                    or_(
+                        OAuthToken.revoked == True,
+                        OAuthToken.expires_at <= now,
+                    )
+                )
+            )
             .order_by(OAuthToken.created_at.desc(), OAuthToken.id.desc())
-            .limit(CLIENT_TOKEN_SCAN_LIMIT)
+            .limit(CLIENT_DEAD_TOKEN_SCAN_LIMIT)
         )
-        if uid is not None:
-            token_q = token_q.where(OAuthToken.user_id == uid)
-        rows = list((await session.execute(token_q)).scalars().all())
+        dead_rows = list((await session.execute(dead_q)).scalars().all())
+        if len(dead_rows) == CLIENT_DEAD_TOKEN_SCAN_LIMIT:
+            # Say so rather than printing a total we did not count.
+            truncated_clients.add(c.client_id)
+
+        rows = live_rows + dead_rows
         tokens_by_client[c.client_id] = rows
         owner_ids.update(t.user_id for t in rows if t.user_id is not None)
 
@@ -711,10 +759,15 @@ async def oauth_page(
         for t in tokens_by_client[c.client_id]:
             grouped.setdefault(t.grant_id, []).append(t)
 
-        grants = [
-            _grant_view(grant_id, family, now, active_by_owner)
-            for grant_id, family in grouped.items()
-        ]
+        history_truncated = c.client_id in truncated_clients
+        grants = []
+        for grant_id, family in grouped.items():
+            # `_grant_view` expects the family newest-first; the two queries
+            # were each ordered that way but concatenated live-then-dead.
+            family.sort(key=lambda t: (t.created_at, t.id), reverse=True)
+            view = _grant_view(grant_id, family, now, active_by_owner)
+            view["history_truncated"] = history_truncated
+            grants.append(view)
         grants.sort(key=lambda g: g["last_seen_at"], reverse=True)
 
         clients.append({
@@ -867,7 +920,14 @@ async def update_oauth_token_scope(
     # Preserve the offline_access marker (informational only - see
     # DEFAULT_CLIENT_SCOPE comment in src/oauth/routes.py) instead of
     # dropping it whenever an admin flips read/readwrite here.
-    has_offline = "offline_access" in token.scope.split()
+    #
+    # Read across the whole live family, not just the row the operator clicked:
+    # 014's backfill can merge two pre-014 sessions into one family, and one of
+    # them may carry the marker while the other does not. The write below is
+    # uniform either way, which is the point — a mixed family is exactly the
+    # case where deciding from one row leaves the others disagreeing.
+    live_scopes = await live_family_scopes(session, token.grant_id)
+    has_offline = any("offline_access" in s.split() for s in live_scopes)
     desired = f"{scope} offline_access" if has_offline else scope
     granted = clamp_scope(desired, client.scope)
     if not granted:

--- a/src/control_panel/templates/oauth.html
+++ b/src/control_panel/templates/oauth.html
@@ -66,6 +66,11 @@
                         <span class="badge badge-yellow">Owner inactive</span>
                         {% elif grant.status == 'expired' %}
                         <span class="badge badge-yellow">Expired</span>
+                        {% elif grant.status == 'no_vault_scope' %}
+                        {# `offline_access` alone grants nothing, and the middleware
+                           401s it. Showing "Active" with a working scope control was
+                           the same over-reporting of liveness #76 was about. #}
+                        <span class="badge badge-red" title="This grant carries no vault scope ('read' or 'readwrite'), so it cannot authenticate. Re-register the client with a vault scope and reconnect.">No vault scope</span>
                         {% else %}
                         <span class="badge badge-red">Revoked</span>
                         {% endif %}
@@ -126,7 +131,7 @@
                         {# Revoked and expired rows stay listed, dimmed. Removing them is what
                            made a revocation that did nothing look like one that worked. #}
                         {% for token in grant.tokens %}
-                        <tr {% if token.status in ('revoked', 'expired') %}style="opacity:0.5;"{% endif %}>
+                        <tr {% if token.status in ('revoked', 'expired', 'no_vault_scope') %}style="opacity:0.5;"{% endif %}>
                             <td>
                                 {% if token.token_type == 'access' %}
                                 <span class="badge badge-purple">{{ token.token_type }}</span>
@@ -140,6 +145,8 @@
                                 <span class="badge badge-red">Revoked</span>
                                 {% elif token.status == 'expired' %}
                                 <span class="badge badge-yellow">Expired</span>
+                                {% elif token.status == 'no_vault_scope' %}
+                                <span class="badge badge-red">No vault scope</span>
                                 {% elif token.status == 'owner_inactive' %}
                                 <span class="badge badge-yellow">Owner inactive</span>
                                 {% else %}

--- a/src/control_panel/templates/oauth.html
+++ b/src/control_panel/templates/oauth.html
@@ -30,6 +30,9 @@
                     <div class="mono" style="font-size:10px;color:var(--text-3);margin-top:3px;">{{ client.client_id }}</div>
                 </div>
                 <div style="display:flex;align-items:center;gap:14px;">
+                    {# The registered scope is the ceiling on every grant below. Showing it
+                       explains why the readwrite option is absent for a read-only client. #}
+                    <span class="mono" style="font-size:10px;color:var(--text-3);">registered: {{ client.scope }}</span>
                     <span style="font-size:11px;color:var(--text-3);">Registered <time datetime="{{ client.created_at }}" data-localize="date">{{ client.created_at }}</time></span>
                     <form method="POST" action="/admin/oauth/{{ client.client_id }}/delete" style="display:inline;">
                         {% if csrf_token %}<input type="hidden" name="csrf_token" value="{{ csrf_token }}">{% endif %}
@@ -38,72 +41,113 @@
                 </div>
             </div>
 
-            {% if client.tokens %}
-            <div class="table-scroll">
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Type</th>
-                        <th>Scope</th>
-                        <th>Status</th>
-                        <th>Expires</th>
-                        <th>Created</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for token in client.tokens %}
-                    <tr>
-                        <td>
-                            {% if token.token_type == 'access' %}
-                            <span class="badge badge-purple">{{ token.token_type }}</span>
-                            {% else %}
-                            <span class="badge badge-gray">{{ token.token_type }}</span>
-                            {% endif %}
-                        </td>
-                        <td>
-                            {% if token.revoked %}
-                            <span class="mono" style="font-size:11px;color:var(--text-3);">{{ token.scope }}</span>
-                            {% else %}
-                            <form method="POST" action="/admin/oauth/token/{{ token.id }}/scope" style="display:inline;">
-                                {% if csrf_token %}<input type="hidden" name="csrf_token" value="{{ csrf_token }}">{% endif %}
-                                <select name="scope" onchange="this.form.submit()" class="field-select" style="width:auto;padding:3px 28px 3px 8px;font-size:11px;">
-                                    <option value="read"      {% if not token.has_write %}selected{% endif %}>read</option>
-                                    <option value="readwrite" {% if token.has_write     %}selected{% endif %}>readwrite</option>
-                                </select>
-                            </form>
-                            {% endif %}
-                        </td>
-                        <td>
-                            {% if token.revoked %}
-                            <span class="badge badge-red">Revoked</span>
-                            {% elif token.expired %}
-                            <span class="badge badge-yellow">Expired</span>
-                            {% else %}
-                            <span class="badge badge-green">Active</span>
-                            {% endif %}
-                        </td>
-                        <td class="mono" style="font-size:11px;color:var(--text-3);">
-                            <time datetime="{{ token.expires_at }}" data-localize>{{ token.expires_at }}</time>
-                        </td>
-                        <td class="mono" style="font-size:11px;color:var(--text-3);">
-                            <time datetime="{{ token.created_at }}" data-localize>{{ token.created_at }}</time>
-                        </td>
-                        <td>
-                            {% if not token.revoked and not token.expired %}
-                            <form method="POST" action="/admin/oauth/token/{{ token.id }}/revoke" style="display:inline;">
-                                {% if csrf_token %}<input type="hidden" name="csrf_token" value="{{ csrf_token }}">{% endif %}
-                                <button type="submit" class="btn btn-link" style="font-size:11px;">Revoke</button>
-                            </form>
-                            {% endif %}
-                        </td>
-                    </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
+            {% if client.grants %}
+            {% for grant in client.grants %}
+            {# One block per grant — the unit the user actually approved. A token row is an
+               implementation detail nobody was asked about, and giving each one its own
+               Revoke and its own scope select is what made both controls near no-ops. #}
+            <div style="padding:14px 22px;border-top:1px solid var(--border);">
+                <div style="display:flex;align-items:center;gap:14px;flex-wrap:wrap;">
+                    <div style="display:flex;align-items:center;gap:8px;">
+                        <span style="font-size:12px;color:var(--text-2);">Access</span>
+                        {% if grant.status == 'active' %}
+                        <span class="badge badge-green">Active</span>
+                        {% elif grant.status == 'owner_inactive' %}
+                        {# The middleware also requires the owning User.is_active and 401s
+                           otherwise, so these tokens are already dead server-side. #}
+                        <span class="badge badge-yellow">Owner inactive</span>
+                        {% elif grant.status == 'expired' %}
+                        <span class="badge badge-yellow">Expired</span>
+                        {% else %}
+                        <span class="badge badge-red">Revoked</span>
+                        {% endif %}
+                    </div>
+
+                    <div style="display:flex;align-items:center;gap:8px;">
+                        <span style="font-size:12px;color:var(--text-2);">Scope</span>
+                        {% if grant.token_id %}
+                        <form method="POST" action="/admin/oauth/token/{{ grant.token_id }}/scope" style="display:inline;">
+                            {% if csrf_token %}<input type="hidden" name="csrf_token" value="{{ csrf_token }}">{% endif %}
+                            <select name="scope" onchange="this.form.submit()" class="field-select" style="width:auto;padding:3px 28px 3px 8px;font-size:11px;">
+                                <option value="read"      {% if not grant.has_write %}selected{% endif %}>read</option>
+                                {# Only offered when the client is registered for it. The panel
+                                   must not raise a grant above what the client was registered
+                                   to hold; the handler refuses it regardless. #}
+                                {% if client.can_write %}
+                                <option value="readwrite" {% if grant.has_write     %}selected{% endif %}>readwrite</option>
+                                {% endif %}
+                            </select>
+                        </form>
+                        {% else %}
+                        <span class="mono" style="font-size:11px;color:var(--text-3);">{{ grant.scope }}</span>
+                        {% endif %}
+                    </div>
+
+                    <span style="font-size:11px;color:var(--text-3);">Granted <time datetime="{{ grant.created_at }}" data-localize="date">{{ grant.created_at }}</time></span>
+
+                    <div style="margin-left:auto;">
+                        {% if grant.token_id %}
+                        <form method="POST" action="/admin/oauth/token/{{ grant.token_id }}/revoke" style="display:inline;">
+                            {% if csrf_token %}<input type="hidden" name="csrf_token" value="{{ csrf_token }}">{% endif %}
+                            <button type="submit" class="btn btn-danger" style="font-size:11px;padding:4px 12px;" onclick="return confirm('Revoke this grant? Every access and refresh token issued from it stops working immediately and the app must be reconnected.')">Revoke access</button>
+                        </form>
+                        {% endif %}
+                    </div>
+                </div>
+
+                <div class="table-scroll" style="margin-top:10px;">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Type</th>
+                            <th>Scope</th>
+                            <th>Status</th>
+                            <th>Expires</th>
+                            <th>Created</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {# Revoked and expired rows stay listed, dimmed. Removing them is what
+                           made a revocation that did nothing look like one that worked. #}
+                        {% for token in grant.tokens %}
+                        <tr {% if token.status in ('revoked', 'expired') %}style="opacity:0.5;"{% endif %}>
+                            <td>
+                                {% if token.token_type == 'access' %}
+                                <span class="badge badge-purple">{{ token.token_type }}</span>
+                                {% else %}
+                                <span class="badge badge-gray">{{ token.token_type }}</span>
+                                {% endif %}
+                            </td>
+                            <td class="mono" style="font-size:11px;color:var(--text-3);">{{ token.scope }}</td>
+                            <td>
+                                {% if token.status == 'revoked' %}
+                                <span class="badge badge-red">Revoked</span>
+                                {% elif token.status == 'expired' %}
+                                <span class="badge badge-yellow">Expired</span>
+                                {% elif token.status == 'owner_inactive' %}
+                                <span class="badge badge-yellow">Owner inactive</span>
+                                {% else %}
+                                <span class="badge badge-green">Active</span>
+                                {% endif %}
+                            </td>
+                            <td class="mono" style="font-size:11px;color:var(--text-3);">
+                                <time datetime="{{ token.expires_at }}" data-localize>{{ token.expires_at }}</time>
+                            </td>
+                            <td class="mono" style="font-size:11px;color:var(--text-3);">
+                                <time datetime="{{ token.created_at }}" data-localize>{{ token.created_at }}</time>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                </div>
+                {% if grant.hidden_count %}
+                <div style="padding:6px 2px 0;font-size:11px;color:var(--text-3);">+ {{ grant.hidden_count }} earlier token{{ '' if grant.hidden_count == 1 else 's' }} from this grant, all revoked or expired.</div>
+                {% endif %}
             </div>
+            {% endfor %}
             {% else %}
-            <div style="padding:20px 22px;font-size:13px;color:var(--text-3);">No active tokens for this client.</div>
+            <div style="padding:20px 22px;font-size:13px;color:var(--text-3);">No tokens for this client.</div>
             {% endif %}
         </div>
         {% endfor %}

--- a/src/control_panel/templates/oauth.html
+++ b/src/control_panel/templates/oauth.html
@@ -8,6 +8,14 @@
 
 <div class="page-body">
 
+    {% if flash_error %}
+    {# Why the last scope change did nothing. The select submits on `onchange`,
+       so without this the option simply snaps back and reads as a browser bug. #}
+    <div class="card anim-1" style="margin-bottom:16px;padding:12px 16px;border-left:3px solid var(--error);">
+        <div style="font-size:13px;color:var(--text-2);">{{ flash_error }}</div>
+    </div>
+    {% endif %}
+
     {% if not clients %}
     <div class="card anim-1" style="text-align:center;padding:48px 24px;">
         <svg width="36" height="36" viewBox="0 0 36 36" fill="none" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" style="margin:0 auto 14px;opacity:0.25;">

--- a/src/control_panel/templates/oauth.html
+++ b/src/control_panel/templates/oauth.html
@@ -166,7 +166,10 @@
                 </div>
                 {% if grant.hidden_count %}
                 <div style="padding:6px 2px 0;font-size:11px;color:var(--text-3);">
-                    + {{ grant.hidden_count }} earlier token{{ '' if grant.hidden_count == 1 else 's' }} from this grant, all revoked or expired{% if grant.history_truncated %}, and older ones beyond the history window{% endif %}.
+                    {# "inactive" rather than "revoked or expired": a token can also be
+                       listed here for carrying no vault scope, and naming only two of the
+                       three reasons invites the reader to rule the third one out. #}
+                    + {{ grant.hidden_count }} earlier inactive token{{ '' if grant.hidden_count == 1 else 's' }} from this grant{% if grant.history_truncated %}, and older ones beyond the history window{% endif %}.
                 </div>
                 {% elif grant.history_truncated %}
                 {# Only history is ever truncated — live tokens are read unbounded,

--- a/src/control_panel/templates/oauth.html
+++ b/src/control_panel/templates/oauth.html
@@ -73,6 +73,14 @@
 
                     <div style="display:flex;align-items:center;gap:8px;">
                         <span style="font-size:12px;color:var(--text-2);">Scope</span>
+                        {% if grant.mixed_scope %}
+                        {# Migration 014 can merge two pre-014 sessions of one client
+                           and user into a single family, and they may disagree. The
+                           badge shows the strongest permission any live token holds,
+                           so it never under-reports; saving the select writes one
+                           scope across the whole family and clears this. #}
+                        <span class="badge badge-yellow" title="Live tokens in this grant carry different scopes: {{ grant.live_scopes | join(', ') }}. Saving a scope below applies one value to all of them.">mixed</span>
+                        {% endif %}
                         {% if grant.token_id %}
                         <form method="POST" action="/admin/oauth/token/{{ grant.token_id }}/scope" style="display:inline;">
                             {% if csrf_token %}<input type="hidden" name="csrf_token" value="{{ csrf_token }}">{% endif %}
@@ -150,7 +158,13 @@
                 </table>
                 </div>
                 {% if grant.hidden_count %}
-                <div style="padding:6px 2px 0;font-size:11px;color:var(--text-3);">+ {{ grant.hidden_count }} earlier token{{ '' if grant.hidden_count == 1 else 's' }} from this grant, all revoked or expired.</div>
+                <div style="padding:6px 2px 0;font-size:11px;color:var(--text-3);">
+                    + {{ grant.hidden_count }} earlier token{{ '' if grant.hidden_count == 1 else 's' }} from this grant, all revoked or expired{% if grant.history_truncated %}, and older ones beyond the history window{% endif %}.
+                </div>
+                {% elif grant.history_truncated %}
+                {# Only history is ever truncated — live tokens are read unbounded,
+                   so no grant the operator can act on is ever missing from this page. #}
+                <div style="padding:6px 2px 0;font-size:11px;color:var(--text-3);">Older tokens beyond the history window are not shown.</div>
                 {% endif %}
             </div>
             {% endfor %}

--- a/src/mcp_server/auth.py
+++ b/src/mcp_server/auth.py
@@ -13,7 +13,7 @@ from src.auth.session import UNSET_VAULT_ROOT, current_user_id, current_vault_ro
 from src.config import settings
 from src.database import async_session
 from src.models.db import APIKey, OAuthToken, User
-from src.oauth.scope import token_has_write
+from src.oauth.scope import has_vault_scope, token_has_write
 from src.services.vault import warm_user_vault_cache
 
 logger = logging.getLogger(__name__)
@@ -274,6 +274,27 @@ class APIKeyMiddleware:
                         logger.warning("auth_failure", extra={"reason": "key_expired", "key_id": oauth_token.id})
                         response = JSONResponse(
                             {"error": "Token expired"},
+                            status_code=401,
+                            headers={"WWW-Authenticate": _www_authenticate("invalid_token")},
+                        )
+                        await response(scope, receive, send)
+                        return
+
+                    # A token that names no vault scope grants nothing. Falling
+                    # through to `read` here is the same conflation
+                    # `clamp_scope` used to make: `offline_access` says the
+                    # grant may carry a refresh token, not that it may read a
+                    # note. No path can mint such a token any more, but a
+                    # client registered `scope="offline_access"` before this
+                    # could already hold one, and this is the boundary that
+                    # decides what it may do.
+                    if not has_vault_scope(oauth_token.scope):
+                        logger.warning(
+                            "auth_failure",
+                            extra={"reason": "no_vault_scope", "key_id": oauth_token.id},
+                        )
+                        response = JSONResponse(
+                            {"error": "Invalid or revoked token"},
                             status_code=401,
                             headers={"WWW-Authenticate": _www_authenticate("invalid_token")},
                         )

--- a/src/mcp_server/auth.py
+++ b/src/mcp_server/auth.py
@@ -13,6 +13,7 @@ from src.auth.session import UNSET_VAULT_ROOT, current_user_id, current_vault_ro
 from src.config import settings
 from src.database import async_session
 from src.models.db import APIKey, OAuthToken, User
+from src.oauth.scope import token_has_write
 from src.services.vault import warm_user_vault_cache
 
 logger = logging.getLogger(__name__)
@@ -279,9 +280,12 @@ class APIKeyMiddleware:
                         await response(scope, receive, send)
                         return
 
-                    # Map OAuth scope to permission - scopes are space-separated (OAuth 2.0 convention)
-                    scope_parts = set(oauth_token.scope.split())
-                    permission = "readwrite" if "readwrite" in scope_parts else "read"
+                    # Map OAuth scope to permission. Scopes are space-separated
+                    # sets (OAuth 2.0 convention), so this is a membership test
+                    # -- and it is the *same* helper the control panel uses to
+                    # decide what to display, so the badge and the enforcement
+                    # cannot disagree (issue #65).
+                    permission = "readwrite" if token_has_write(oauth_token.scope) else "read"
 
                     scope["state"] = scope.get("state", {})
                     scope["state"]["api_key_id"] = None

--- a/src/mcp_server/auth.py
+++ b/src/mcp_server/auth.py
@@ -12,7 +12,7 @@ from starlette.types import ASGIApp, Receive, Scope, Send
 from src.auth.session import UNSET_VAULT_ROOT, current_user_id, current_vault_root
 from src.config import settings
 from src.database import async_session
-from src.models.db import APIKey, OAuthToken, User
+from src.models.db import APIKey, OAuthClient, OAuthToken, User
 from src.oauth.scope import has_vault_scope, token_has_write
 from src.services.vault import warm_user_vault_cache
 
@@ -261,6 +261,32 @@ class APIKeyMiddleware:
                             logger.warning(
                                 "auth_failure",
                                 extra={"reason": "inactive_user", "key_id": oauth_token.id},
+                            )
+                            response = JSONResponse(
+                                {"error": "Invalid or revoked token"},
+                                status_code=401,
+                                headers={"WWW-Authenticate": _www_authenticate("invalid_token")},
+                            )
+                            await response(scope, receive, send)
+                            return
+
+                    # The grant's owner must still be the client's owner. A
+                    # cross-user grant can no longer be created, but one made
+                    # before the consent and rotation paths refused it stays
+                    # live for the access token's full hour and is invisible in
+                    # either user's panel. An unbound client (NULL owner) is
+                    # not a conflict — it has simply never been claimed.
+                    if oauth_token.user_id is not None:
+                        result = await session.execute(
+                            select(OAuthClient.user_id).where(
+                                OAuthClient.client_id == oauth_token.client_id
+                            )
+                        )
+                        client_owner = result.scalar_one_or_none()
+                        if client_owner is not None and client_owner != oauth_token.user_id:
+                            logger.warning(
+                                "auth_failure",
+                                extra={"reason": "cross_user_grant", "key_id": oauth_token.id},
                             )
                             response = JSONResponse(
                                 {"error": "Invalid or revoked token"},

--- a/src/models/db.py
+++ b/src/models/db.py
@@ -327,6 +327,14 @@ class OAuthToken(Base):
         String(64), ForeignKey("oauth_clients.client_id", ondelete="CASCADE"), nullable=False
     )
     scope: Mapped[str] = mapped_column(String(50), nullable=False)
+    # The grant family this token belongs to (migration 014, issue #64). Every
+    # row minted from one `/authorize` approval shares it, and every rotation
+    # inherits it, so revocation and scope changes can act on the unit the
+    # operator actually consented to instead of a single row whose sibling
+    # refresh token would immediately undo the change. NOT NULL: the decision
+    # in #64 was explicit that a nullable grant_id with a fallback "find the
+    # family" path is how this bug comes back.
+    grant_id: Mapped[str] = mapped_column(String(64), nullable=False, index=True)
     expires_at: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), nullable=False)
     revoked: Mapped[bool] = mapped_column(Boolean, default=False)
     created_at: Mapped[datetime.datetime] = mapped_column(

--- a/src/oauth/grants.py
+++ b/src/oauth/grants.py
@@ -29,7 +29,7 @@ routes both use it, and #67 warned against the panel reaching into
 import hashlib
 import secrets
 
-from sqlalchemy import text, update
+from sqlalchemy import select, text, update
 
 from src.models.db import OAuthToken
 
@@ -142,6 +142,24 @@ async def revoke_grant_family(session, grant_id: str) -> int:
         .values(revoked=True)
     )
     return result.rowcount or 0
+
+
+async def live_family_scopes(session, grant_id: str) -> list[str]:
+    """The scope strings of every still-live token in a family.
+
+    A family is normally uniform, but 014's backfill can merge two pre-014
+    sessions of the same client and user — one `read`, one `readwrite`, or one
+    carrying `offline_access` and one not. Deciding anything from a single row
+    of such a family gets it wrong for the others, so the callers that write a
+    *uniform* scope read the whole set first.
+    """
+    result = await session.execute(
+        select(OAuthToken.scope).where(
+            OAuthToken.grant_id == grant_id,
+            OAuthToken.revoked == False,  # noqa: E712
+        )
+    )
+    return [row for row in result.scalars().all()]
 
 
 async def set_grant_family_scope(session, grant_id: str, scope: str) -> int:

--- a/src/oauth/grants.py
+++ b/src/oauth/grants.py
@@ -1,0 +1,124 @@
+"""Grant families: the unit an operator actually consents to and revokes.
+
+A `/authorize` approval produces **one grant**. The token endpoint then mints
+an access/refresh pair from it, and every later rotation mints another pair.
+Before issue #64 nothing tied those rows together, so the panel could only
+offer per-row controls -- and a per-row Revoke was close to a no-op, because
+the sibling refresh token minted a fresh, identically-scoped access token on
+the client's next ordinary 401 retry. A per-row scope *downgrade* was worse: it
+silently restored itself within the hour.
+
+`oauth_tokens.grant_id` (migration 014) is that missing identifier. Every row
+minted from one consent shares it, rotation inherits it, and revocation and
+downgrade act on the whole family. There is exactly one way to find a family --
+`grant_id == g` -- because the decision in #64 was explicit that two code paths
+for "find the family" is how this bug comes back.
+
+**Invariant: one `grant_id` belongs to exactly one `(client_id, user_id)`.**
+It is established at every write site (`_handle_auth_code` stamps one id on one
+user's pair; `_handle_refresh` copies both `grant_id` and `user_id` from the
+row it rotates) and by 014's backfill, which groups by exactly those two
+columns. Family operations therefore do *not* re-filter by `user_id`: an
+incomplete revocation is the failure this module exists to prevent, and a
+`user_id` predicate would reintroduce a way for one to happen.
+
+This module is dependency-light on purpose -- the control panel and the OAuth
+routes both use it, and #67 warned against the panel reaching into
+`src/oauth/routes.py`.
+"""
+import hashlib
+import secrets
+
+from sqlalchemy import text, update
+
+from src.models.db import OAuthToken
+
+# 32 URL-safe characters. Opaque: nothing may parse it, and it is never shown
+# to a client -- it exists only to join rows minted from one consent.
+GRANT_ID_BYTES = 24
+
+# Postgres advisory locks are keyed by bigint, so the opaque id is folded to
+# one. A separate namespace key keeps us from colliding with any other advisory
+# lock this application might take later.
+_ADVISORY_NAMESPACE = 0x0A17  # "oauth grant"
+
+
+def new_grant_id() -> str:
+    """A fresh grant identifier for one consent event."""
+    return secrets.token_urlsafe(GRANT_ID_BYTES)
+
+
+def grant_lock_key(grant_id: str) -> int:
+    """Signed 64-bit advisory-lock key for a grant id.
+
+    Derived in Python rather than with Postgres' `hashtext()`, which is
+    undocumented and whose algorithm has changed between majors.
+    """
+    digest = hashlib.sha256(
+        _ADVISORY_NAMESPACE.to_bytes(2, "big") + grant_id.encode()
+    ).digest()
+    return int.from_bytes(digest[:8], "big", signed=True)
+
+
+async def lock_grant(session, grant_id: str) -> None:
+    """Serialize everything that touches one grant family, for this transaction.
+
+    Without this, revocation loses a race it looks like it wins. Under READ
+    COMMITTED an `UPDATE ... WHERE grant_id = :g` takes its snapshot when the
+    statement starts, so rows a concurrent refresh *inserts* afterwards are
+    invisible to it: the panel reports "revoked", every row it saw is revoked,
+    and the brand-new access/refresh pair the client just rotated into survives.
+    Row locks cannot close that -- the offending rows do not exist yet when the
+    lock would be taken. A lock on the *family* does.
+
+    Both sides take this before touching any family row, and nothing else, so
+    the acquisition order is total and there is no cycle to deadlock on. It is
+    a transaction-scoped lock: it releases on COMMIT or ROLLBACK, never leaks,
+    and needs no explicit unlock.
+
+    The caller must issue this as its own statement *before* the statement that
+    reads or writes the family -- that later statement then takes a fresh
+    snapshot, which is precisely what makes a concurrently-inserted row visible.
+    """
+    await session.execute(
+        text("SELECT pg_advisory_xact_lock(:key)"),
+        {"key": grant_lock_key(grant_id)},
+    )
+
+
+async def revoke_grant_family(session, grant_id: str) -> int:
+    """Revoke every still-live token in one grant family. Does not commit.
+
+    Access tokens are included, and that is the point: rotation is allowed to
+    let an old access token run to its natural expiry, but revocation is not.
+    An hour of surviving write access after the operator clicked Revoke is
+    exactly the failure this replaced.
+
+    Returns the number of rows actually flipped, so a caller can tell "already
+    fully revoked" from "revoked N tokens" without a second query.
+    """
+    await lock_grant(session, grant_id)
+    result = await session.execute(
+        update(OAuthToken)
+        .where(OAuthToken.grant_id == grant_id, OAuthToken.revoked == False)  # noqa: E712
+        .values(revoked=True)
+    )
+    return result.rowcount or 0
+
+
+async def set_grant_family_scope(session, grant_id: str, scope: str) -> int:
+    """Write one scope onto every still-live token in a family. Does not commit.
+
+    Revoked rows are left alone so the panel's history keeps showing what each
+    one carried when it died; rewriting them would forge the record.
+
+    The caller is responsible for having clamped `scope` to the client's
+    registration first -- this function is the *write*, not the policy.
+    """
+    await lock_grant(session, grant_id)
+    result = await session.execute(
+        update(OAuthToken)
+        .where(OAuthToken.grant_id == grant_id, OAuthToken.revoked == False)  # noqa: E712
+        .values(scope=scope)
+    )
+    return result.rowcount or 0

--- a/src/oauth/grants.py
+++ b/src/oauth/grants.py
@@ -42,6 +42,20 @@ GRANT_ID_BYTES = 24
 # lock this application might take later.
 _ADVISORY_NAMESPACE = 0x0A17  # "oauth grant"
 
+# The single-user -> multi-user bootstrap claims every ownerless row for the
+# first admin with `UPDATE ... WHERE user_id IS NULL` (`register_submit` in
+# `src/auth/routes.py`), and it already holds this key for that transaction.
+# The token endpoint takes it too, because that UPDATE's snapshot is taken when
+# the statement starts: a mint committing afterwards inserts a *new* NULL-owner
+# token the claim can no longer see, and it survives as a token belonging to
+# nobody. Sharing one key makes the two mutually exclusive.
+#
+# **The value is a wire constant, not an implementation detail.** During a
+# rolling deploy an old process holds it under the literal below while a new
+# one imports it from here; changing it would silently un-serialize exactly the
+# window this exists to close.
+USER_BOOTSTRAP_LOCK_KEY = 7283910429
+
 
 def new_grant_id() -> str:
     """A fresh grant identifier for one consent event."""
@@ -58,6 +72,30 @@ def grant_lock_key(grant_id: str) -> int:
         _ADVISORY_NAMESPACE.to_bytes(2, "big") + grant_id.encode()
     ).digest()
     return int.from_bytes(digest[:8], "big", signed=True)
+
+
+async def lock_user_bootstrap(session) -> None:
+    """Hold off the ownerless-row claim for this transaction, and vice versa.
+
+    Taken by both token-minting handlers and by `register_submit`'s claim, so
+    a token cannot be inserted with `user_id IS NULL` in the window between the
+    claim's UPDATE and its COMMIT. Without it the bootstrap reports success,
+    the claim covers every row it could see, and the pair a client rotated into
+    a moment later belongs to no user at all.
+
+    **Lock order is this lock first, then any per-grant lock.** `_handle_refresh`
+    takes both; the panel's family operations take only the grant lock and
+    never this one; the bootstrap takes only this one. So no path holds a grant
+    lock while asking for this, and there is no cycle.
+
+    Taken unconditionally rather than only under `multi_user_mode`: the flag can
+    change between processes during a deploy, and a global lock on a path that
+    runs once per consent and once per hourly refresh costs nothing.
+    """
+    await session.execute(
+        text("SELECT pg_advisory_xact_lock(:key)"),
+        {"key": USER_BOOTSTRAP_LOCK_KEY},
+    )
 
 
 async def lock_grant(session, grant_id: str) -> None:

--- a/src/oauth/routes.py
+++ b/src/oauth/routes.py
@@ -16,7 +16,12 @@ from src.config import settings
 from src.database import async_session
 from src.limiter import limiter
 from src.models.db import OAuthClient, OAuthCode, OAuthToken
-from src.oauth.grants import lock_grant, new_grant_id, revoke_grant_family
+from src.oauth.grants import (
+    lock_grant,
+    lock_user_bootstrap,
+    new_grant_id,
+    revoke_grant_family,
+)
 from src.oauth.scope import VALID_SCOPES, clamp_scope, has_vault_scope
 # Aliased on import so `authorize_get` can keep its long-standing local name
 # `client_can_write` (the consent template reads that key) without shadowing
@@ -549,6 +554,15 @@ async def _handle_auth_code(form):
         return JSONResponse({"error": "invalid_request"}, status_code=400)
 
     async with async_session() as session:
+        # Serialize against the single-user -> multi-user bootstrap before
+        # anything is read or written. Its claim is
+        # `UPDATE ... WHERE user_id IS NULL`, whose snapshot is taken when the
+        # statement starts, so a mint committing afterwards would insert a pair
+        # the claim can no longer see and those tokens would belong to nobody.
+        # Taken before any per-grant lock, which is the fixed order both token
+        # handlers use — see `src/oauth/grants.py`.
+        await lock_user_bootstrap(session)
+
         # Resolve the authorization code first. Some ChatGPT connector builds
         # omit client_id at the public-client token exchange. PKCE still binds
         # the request to the initiating client, and the code tells us which
@@ -598,6 +612,21 @@ async def _handle_auth_code(form):
         expected_challenge = _base64url_sha256(code_verifier)
         if not secrets.compare_digest(expected_challenge, oauth_code.code_challenge):
             return JSONResponse({"error": "invalid_grant", "error_description": "PKCE verification failed"}, status_code=400)
+
+        # In multi-user mode every token must have an owner. A code stamped
+        # with a NULL `user_id` predates the flag flip (or escaped the
+        # bootstrap's claim), and minting from it produces a credential the
+        # ownership checks cannot reason about — `_assert_oauth_token_owner`,
+        # the panel's per-user filters and the vault-root lookup all key off
+        # `user_id`. Refuse rather than create one.
+        if settings.multi_user_mode and oauth_code.user_id is None:
+            return JSONResponse(
+                {
+                    "error": "invalid_grant",
+                    "error_description": "Authorization code has no owner; re-authorize.",
+                },
+                status_code=400,
+            )
 
         # The client must still belong to the user this code was minted for
         # (issue #68). `authorize_post` refuses a client another user owns, but
@@ -697,7 +726,12 @@ async def _handle_refresh(form):
             # compatibility, a repeated client_id).
             token_hash = _hash(refresh_token)
 
-            # Take the grant-family lock *first*, before any row in the family
+            # Bootstrap lock before the grant lock — the fixed order both token
+            # handlers use, and the reason there is no cycle with the panel
+            # (which takes only the grant lock). See `src/oauth/grants.py`.
+            await lock_user_bootstrap(session)
+
+            # Take the grant-family lock *before* any row in the family
             # is read or written. Rotation inserts two brand-new rows, and a
             # concurrent panel revocation cannot see rows that did not exist
             # when its UPDATE took its snapshot — so without this the operator
@@ -757,6 +791,28 @@ async def _handle_refresh(form):
 
             if old_token.expires_at < datetime.now(timezone.utc):
                 return JSONResponse({"error": "invalid_grant", "error_description": "refresh token expired"}, status_code=400)
+
+            # In multi-user mode a token with no owner cannot be rotated: the
+            # replacement would inherit the NULL and stay outside every
+            # ownership check. Such a row can only be a pre-flag-flip leftover
+            # the bootstrap did not claim.
+            if settings.multi_user_mode and old_token.user_id is None:
+                return JSONResponse(
+                    {
+                        "error": "invalid_grant",
+                        "error_description": "Token has no owner; re-authorize.",
+                    },
+                    status_code=400,
+                )
+
+            # The grant's owner must still be the client's owner (issue #68).
+            # `authorize_post` and `_handle_auth_code` both refuse to create
+            # such a pairing now, but a legacy row — or one created by the
+            # first-claim race before it was closed — would otherwise rotate
+            # forever, keeping a live cross-user grant alive indefinitely and
+            # invisible in either user's panel.
+            if _client_belongs_to_another_user(client, old_token.user_id):
+                return JSONResponse({"error": "invalid_grant"}, status_code=400)
 
             # Re-clamp against the client's *current* registration (issue #67).
             # Rotation used to copy `old_token.scope` verbatim, so any scope a

--- a/src/oauth/routes.py
+++ b/src/oauth/routes.py
@@ -963,16 +963,24 @@ async def revoke_token(request: Request):
                 # is not valid *for the requesting client*, that is not an
                 # error" — an unknown, foreign or unauthenticated token is
                 # indistinguishable from an already-revoked one. So a caller
-                # naming a different client is answered 200 and nothing
-                # happens, rather than being told whose token it is.
+                # who does not identify himself as this token's client is
+                # answered 200 and nothing happens, rather than being told
+                # whose token it is.
                 #
-                # A missing `client_id` is tolerated the same way `/token`
-                # tolerates it (some ChatGPT connector builds omit it): the
-                # client is then identified by the token itself, and a
-                # confidential client still has to present its secret.
+                # `client_id` must be **present and exactly equal**. Treating
+                # its absence as a match was a hole, not a tolerance: a public
+                # client authenticates trivially (no secret to check), so
+                # "omit client_id" was a universal bypass — anyone holding A's
+                # token could end A's whole grant without naming a client at
+                # all, and for a public client without proving anything. Unlike
+                # `/token`, where PKCE still binds the request to the
+                # initiating client and the code identifies it, nothing else
+                # here identifies the caller. There is no ChatGPT-compatibility
+                # cost either: revocation is optional for a client, and RFC
+                # 7009 §2.1 requires it to authenticate when it does revoke.
                 if client is None:
                     return JSONResponse({})
-                if client_id and client_id != oauth_token.client_id:
+                if not client_id or client_id != oauth_token.client_id:
                     return JSONResponse({})
                 if not _client_authenticated(client, client_secret):
                     # The one case that is a real error rather than a no-op:

--- a/src/oauth/routes.py
+++ b/src/oauth/routes.py
@@ -17,7 +17,7 @@ from src.database import async_session
 from src.limiter import limiter
 from src.models.db import OAuthClient, OAuthCode, OAuthToken
 from src.oauth.grants import lock_grant, new_grant_id, revoke_grant_family
-from src.oauth.scope import VALID_SCOPES, clamp_scope
+from src.oauth.scope import VALID_SCOPES, clamp_scope, has_vault_scope
 # Aliased on import so `authorize_get` can keep its long-standing local name
 # `client_can_write` (the consent template reads that key) without shadowing
 # the helper.
@@ -203,6 +203,25 @@ async def register_client(request: Request):
         scope = _validate_scope(raw_scope)
     except ValueError as exc:
         return JSONResponse({"error": "invalid_scope", "error_description": str(exc)}, status_code=400)
+
+    # A registration naming neither `read` nor `readwrite` grants nothing --
+    # `offline_access` says the grant may carry a refresh token, not that it
+    # may read a note. Such a client could be registered and could reach the
+    # consent screen, and every downstream clamp now (correctly) resolves it
+    # to an empty grant, so the whole flow would dead-end at the token
+    # endpoint. Refusing here says so at the only point where the developer
+    # registering the client is still in the loop.
+    if not has_vault_scope(scope):
+        return JSONResponse(
+            {
+                "error": "invalid_scope",
+                "error_description": (
+                    "scope must include 'read' or 'readwrite'; "
+                    "'offline_access' alone grants no access"
+                ),
+            },
+            status_code=400,
+        )
 
     token_endpoint_auth_method = body.get(
         "token_endpoint_auth_method", "client_secret_post"
@@ -446,6 +465,23 @@ async def authorize_post(
         # user's grants are both consequences of letting the reuse happen.
         # Single-user mode never reaches this — `session_user_id` stays None and
         # `client_row.user_id` stays NULL.
+        # An empty clamp means the registration grants no vault access at all
+        # (e.g. `scope="offline_access"`), so there is nothing to consent to.
+        # `clamp_scope` used to answer `read` here, handing such a client the
+        # whole vault read-only — a permission its registration never named.
+        # Refuse instead of minting a code for a grant that means nothing.
+        if not scope:
+            return JSONResponse(
+                {
+                    "error": "invalid_scope",
+                    "error_description": (
+                        "This client is not registered for any vault access. "
+                        "Register it with 'read' or 'readwrite'."
+                    ),
+                },
+                status_code=400,
+            )
+
         if _client_belongs_to_another_user(client_row, session_user_id):
             return JSONResponse(
                 {
@@ -575,16 +611,32 @@ async def _handle_auth_code(form):
         if _client_belongs_to_another_user(client, oauth_code.user_id):
             return JSONResponse({"error": "invalid_grant"}, status_code=400)
 
-        # Mark code as used
-        oauth_code.used = True
-
         # Last clamp before anything is persisted (issue #67). `authorize_post`
         # already clamped what it wrote onto the code, so this is normally a
         # no-op — but it is the only thing standing between a code minted under
-        # one registration and a token minted under a narrower one, and the cost
-        # of a set intersection here is nothing next to a write grant nobody
-        # registered for.
+        # one registration and a token minted under a narrower one, and the
+        # cost is nothing next to a write grant nobody registered for.
+        #
+        # It runs *before* the code is marked used: an empty clamp means the
+        # registration grants no vault access, which is not something a retry
+        # can fix, and burning the code would only make the failure harder to
+        # read. `clamp_scope` answering `read` here is exactly the hole this
+        # closes — a client registered `offline_access` alone would have been
+        # handed a read token over the entire vault.
         granted_scope = _clamp_scope(oauth_code.scope, client.scope)
+        if not granted_scope:
+            return JSONResponse(
+                {
+                    "error": "invalid_scope",
+                    "error_description": (
+                        "This client is not registered for any vault access."
+                    ),
+                },
+                status_code=400,
+            )
+
+        # Mark code as used
+        oauth_code.used = True
 
         # Mint tokens. In multi-user mode the issued tokens inherit the
         # `user_id` stamped on the auth code at /authorize time; in single-
@@ -714,6 +766,20 @@ async def _handle_refresh(form):
             # back. Clamping here also means narrowing a client's registration
             # takes effect on the next refresh instead of never.
             granted_scope = _clamp_scope(old_token.scope, client.scope)
+            if not granted_scope:
+                # The registration grants no vault access any more, so there is
+                # nothing to rotate into. Nothing is committed, so the old
+                # refresh token is left exactly as it was — the thing to fix is
+                # the client's registration, not this token.
+                return JSONResponse(
+                    {
+                        "error": "invalid_scope",
+                        "error_description": (
+                            "This client is not registered for any vault access."
+                        ),
+                    },
+                    status_code=400,
+                )
 
             # Mint new token pair FIRST, then revoke old token — all in one transaction
             new_access = secrets.token_hex(32)

--- a/src/oauth/routes.py
+++ b/src/oauth/routes.py
@@ -16,16 +16,24 @@ from src.config import settings
 from src.database import async_session
 from src.limiter import limiter
 from src.models.db import OAuthClient, OAuthCode, OAuthToken
+from src.oauth.grants import lock_grant, new_grant_id, revoke_grant_family
+from src.oauth.scope import VALID_SCOPES, clamp_scope
+# Aliased on import so `authorize_get` can keep its long-standing local name
+# `client_can_write` (the consent template reads that key) without shadowing
+# the helper.
+from src.oauth.scope import client_can_write as _client_can_write
 
 router = APIRouter(tags=["oauth"])
 templates = Jinja2Templates(
     directory=os.path.join(os.path.dirname(__file__), "..", "control_panel", "templates")
 )
 
-# Valid OAuth scopes. ChatGPT requests ``offline_access`` when the provider
-# advertises refresh-token support. It does not change vault permissions; it
-# only makes the already-issued refresh token explicit in the grant.
-VALID_SCOPES = {"read", "readwrite", "offline_access"}
+# Valid OAuth scopes live in `src/oauth/scope.py` alongside the helpers that
+# interpret them, so the panel and the ASGI auth middleware can import them
+# without reaching into this module (issue #67). ChatGPT requests
+# ``offline_access`` when the provider advertises refresh-token support; it does
+# not change vault permissions, it only makes the already-issued refresh token
+# explicit in the grant.
 DEFAULT_CLIENT_SCOPE = "read readwrite offline_access"
 TOKEN_ENDPOINT_AUTH_METHODS = {"none", "client_secret_post"}
 _PKCE_RE = re.compile(r"^[A-Za-z0-9._~-]{43,128}$")
@@ -81,20 +89,26 @@ def _validate_scope(scope: str) -> str:
     return " ".join(parts & VALID_SCOPES) or "read"
 
 
-def _clamp_scope(requested: str, registered: str) -> str:
-    """Restrict a requested scope to what the client registered for.
+# The clamp now lives in `src/oauth/scope.py` so the control panel can apply
+# the same cap without importing this module. Kept under its historical private
+# name because it is referenced throughout this file and by the #21 regression
+# tests; there is exactly one implementation behind both names.
+_clamp_scope = clamp_scope
 
-    Both inputs are already validated scope strings. The user can only ever
-    be granted the intersection of what they asked for at consent time and
-    what the client is registered to hold. `readwrite` implies `read`, so a
-    client registered for `readwrite` may still be granted plain `read`.
+
+def _client_belongs_to_another_user(client_row, session_user_id: int | None) -> bool:
+    """Is this client owned by a *different* user than the one consenting?
+
+    Both `None` cases mean "no conflict", and they mean it for different
+    reasons: an unbound client (`user_id IS NULL`) is about to be claimed by
+    its first authorizer, and a `None` session identity only happens in
+    single-user mode, where there are no other users to conflict with.
     """
-    requested_parts = set(requested.split())
-    registered_parts = set(registered.split())
-    if "readwrite" in registered_parts:
-        registered_parts.add("read")
-    granted = requested_parts & registered_parts
-    return " ".join(sorted(granted)) or "read"
+    return (
+        session_user_id is not None
+        and client_row.user_id is not None
+        and client_row.user_id != session_user_id
+    )
 
 
 def _state_serializer() -> URLSafeTimedSerializer:
@@ -298,7 +312,7 @@ async def authorize_get(
 
     # The registered scope caps what the user can grant; surface it so the
     # consent screen only offers access levels the client can actually hold.
-    client_can_write = "readwrite" in client.scope.split()
+    client_can_write = _client_can_write(client.scope)
 
     scope_parts = scope.split()
     offline_access_requested = "offline_access" in scope_parts
@@ -419,6 +433,32 @@ async def authorize_post(
             url = _append_query(redirect_uri, error="access_denied", state=client_state)
             return RedirectResponse(url, status_code=302)
 
+        # Refuse cross-user reuse of a client somebody else already owns
+        # (issue #68). A client binds to its *first* authorizing user below and
+        # never rebinds, so without this a second user's approval mints live
+        # tokens under a client they do not own: `oauth_page` filters clients by
+        # `OAuthClient.user_id`, so their own grant is invisible and unrevokable
+        # in their panel, while the owner's "Delete this client and revoke all
+        # its tokens" cascades through it and silently kills their session.
+        #
+        # Fail closed at the source rather than unioning the panel listing: an
+        # unlistable live grant and a delete button that reaches into another
+        # user's grants are both consequences of letting the reuse happen.
+        # Single-user mode never reaches this — `session_user_id` stays None and
+        # `client_row.user_id` stays NULL.
+        if _client_belongs_to_another_user(client_row, session_user_id):
+            return JSONResponse(
+                {
+                    "error": "access_denied",
+                    "error_description": (
+                        "This OAuth client is registered to a different user. "
+                        "Register the connector again from your own account "
+                        "instead of reusing an existing client_id."
+                    ),
+                },
+                status_code=403,
+            )
+
         code = secrets.token_hex(32)
 
         # Bind the OAuth client to its first-authorizing user. RFC 7591
@@ -523,8 +563,28 @@ async def _handle_auth_code(form):
         if not secrets.compare_digest(expected_challenge, oauth_code.code_challenge):
             return JSONResponse({"error": "invalid_grant", "error_description": "PKCE verification failed"}, status_code=400)
 
+        # The client must still belong to the user this code was minted for
+        # (issue #68). `authorize_post` refuses a client another user owns, but
+        # it claims an *unbound* client in the same transaction as the code —
+        # so two users consenting to the same unbound client at the same moment
+        # both get a code and only one claim wins. Re-checking here means the
+        # loser's code cannot be exchanged for tokens under a client they do not
+        # own. A code minted in single-user mode carries a NULL `user_id` and is
+        # unaffected, including on a database whose clients were later claimed
+        # by the multi-user bootstrap.
+        if _client_belongs_to_another_user(client, oauth_code.user_id):
+            return JSONResponse({"error": "invalid_grant"}, status_code=400)
+
         # Mark code as used
         oauth_code.used = True
+
+        # Last clamp before anything is persisted (issue #67). `authorize_post`
+        # already clamped what it wrote onto the code, so this is normally a
+        # no-op — but it is the only thing standing between a code minted under
+        # one registration and a token minted under a narrower one, and the cost
+        # of a set intersection here is nothing next to a write grant nobody
+        # registered for.
+        granted_scope = _clamp_scope(oauth_code.scope, client.scope)
 
         # Mint tokens. In multi-user mode the issued tokens inherit the
         # `user_id` stamped on the auth code at /authorize time; in single-
@@ -532,11 +592,21 @@ async def _handle_auth_code(form):
         access_token = secrets.token_hex(32)
         refresh_token = secrets.token_hex(32)
 
+        # One consent event, one grant family (issue #64). The authorization
+        # code is consumed into exactly one grant — it is single-use and this
+        # transaction just marked it used — so minting the id here, rather than
+        # at /authorize, keeps `oauth_codes` unchanged and still gives both
+        # tokens the same family. Every later rotation inherits it, which is
+        # what lets the panel revoke or downgrade the pair as one unit instead
+        # of a row whose sibling immediately undoes the change.
+        grant_id = new_grant_id()
+
         session.add(OAuthToken(
             token_hash=_hash(access_token),
             token_type="access",
             client_id=client_id,
-            scope=oauth_code.scope,
+            scope=granted_scope,
+            grant_id=grant_id,
             expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
             user_id=oauth_code.user_id,
         ))
@@ -544,7 +614,8 @@ async def _handle_auth_code(form):
             token_hash=_hash(refresh_token),
             token_type="refresh",
             client_id=client_id,
-            scope=oauth_code.scope,
+            scope=granted_scope,
+            grant_id=grant_id,
             expires_at=datetime.now(timezone.utc) + timedelta(days=30),
             user_id=oauth_code.user_id,
         ))
@@ -555,7 +626,7 @@ async def _handle_auth_code(form):
         "token_type": "Bearer",
         "expires_in": 3600,
         "refresh_token": refresh_token,
-        "scope": oauth_code.scope,
+        "scope": granted_scope,
     })
 
 
@@ -573,6 +644,32 @@ async def _handle_refresh(form):
             # clients can refresh without a client secret (or, for ChatGPT
             # compatibility, a repeated client_id).
             token_hash = _hash(refresh_token)
+
+            # Take the grant-family lock *first*, before any row in the family
+            # is read or written. Rotation inserts two brand-new rows, and a
+            # concurrent panel revocation cannot see rows that did not exist
+            # when its UPDATE took its snapshot — so without this the operator
+            # revokes every row there is and the client keeps the pair it
+            # rotated into a moment later. Locking the family, not the row,
+            # is what closes that: see `src/oauth/grants.py`.
+            #
+            # The lookup that finds the family deliberately does not filter on
+            # `revoked` — a revoked token still names its family, and the
+            # authoritative locking select below is what decides whether this
+            # refresh is allowed. Ordering matters more than precision here:
+            # both sides take this one lock before any row lock, so the
+            # acquisition order is total and cannot deadlock.
+            grant_query = select(OAuthToken.grant_id).where(
+                OAuthToken.token_hash == token_hash,
+                OAuthToken.token_type == "refresh",
+            )
+            if client_id:
+                grant_query = grant_query.where(OAuthToken.client_id == client_id)
+            grant_id = (await session.execute(grant_query)).scalar_one_or_none()
+            if grant_id is None:
+                return JSONResponse({"error": "invalid_grant"}, status_code=400)
+            await lock_grant(session, grant_id)
+
             token_query = select(OAuthToken).where(
                 OAuthToken.token_hash == token_hash,
                 OAuthToken.token_type == "refresh",
@@ -609,6 +706,15 @@ async def _handle_refresh(form):
             if old_token.expires_at < datetime.now(timezone.utc):
                 return JSONResponse({"error": "invalid_grant", "error_description": "refresh token expired"}, status_code=400)
 
+            # Re-clamp against the client's *current* registration (issue #67).
+            # Rotation used to copy `old_token.scope` verbatim, so any scope a
+            # token had acquired above what its client was registered for
+            # survived every rotation indefinitely — the panel could grant
+            # `readwrite` to a client registered `read` and nothing ever took it
+            # back. Clamping here also means narrowing a client's registration
+            # takes effect on the next refresh instead of never.
+            granted_scope = _clamp_scope(old_token.scope, client.scope)
+
             # Mint new token pair FIRST, then revoke old token — all in one transaction
             new_access = secrets.token_hex(32)
             new_refresh = secrets.token_hex(32)
@@ -617,7 +723,11 @@ async def _handle_refresh(form):
                 token_hash=_hash(new_access),
                 token_type="access",
                 client_id=client_id,
-                scope=old_token.scope,
+                scope=granted_scope,
+                # Rotation stays inside the family it rotated (issue #64), so a
+                # revocation or downgrade applied to the grant still covers the
+                # pair the client is about to start using.
+                grant_id=old_token.grant_id,
                 expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
                 user_id=old_token.user_id,
             ))
@@ -625,7 +735,8 @@ async def _handle_refresh(form):
                 token_hash=_hash(new_refresh),
                 token_type="refresh",
                 client_id=client_id,
-                scope=old_token.scope,
+                scope=granted_scope,
+                grant_id=old_token.grant_id,
                 expires_at=datetime.now(timezone.utc) + timedelta(days=30),
                 user_id=old_token.user_id,
             ))
@@ -643,7 +754,11 @@ async def _handle_refresh(form):
         "token_type": "Bearer",
         "expires_in": 3600,
         "refresh_token": new_refresh,
-        "scope": old_token.scope,
+        # The clamped scope, not the old token's — RFC 6749 §5.1 requires the
+        # response to state the granted scope whenever it differs from what was
+        # asked for, and a client told `readwrite` while holding `read` would
+        # keep retrying writes that 403.
+        "scope": granted_scope,
     })
 
 
@@ -664,7 +779,20 @@ async def revoke_token(request: Request):
             )
             oauth_token = result.scalar_one_or_none()
             if oauth_token:
-                oauth_token.revoked = True
+                # Revoke the whole grant family, not just the row presented.
+                #
+                # RFC 7009 §2.1 explicitly permits this ("the authorization
+                # server ... MAY revoke the respective refresh token as well"),
+                # and it is the only behaviour that means anything here: a
+                # client presenting its access token and being told "revoked"
+                # while its refresh token quietly mints a replacement pair is
+                # the same near-no-op the panel had (issue #64). Presenting the
+                # refresh token was already the working case; now both are.
+                #
+                # Nothing is leaked by the widening — the caller already holds a
+                # credential from this family, and RFC 7009 requires a 200
+                # either way, so the response says no more than it did before.
+                await revoke_grant_family(session, oauth_token.grant_id)
                 await session.commit()
 
     # RFC 7009: always return 200

--- a/src/oauth/routes.py
+++ b/src/oauth/routes.py
@@ -10,6 +10,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from sqlalchemy import select
+from sqlalchemy import update as sa_update
 
 from src.auth.session import get_active_session_user
 from src.config import settings
@@ -99,6 +100,43 @@ def _validate_scope(scope: str) -> str:
 # name because it is referenced throughout this file and by the #21 regression
 # tests; there is exactly one implementation behind both names.
 _clamp_scope = clamp_scope
+
+
+def _client_authenticated(client, client_secret) -> bool:
+    """Does `client_secret` satisfy this client's registered auth method?
+
+    One definition for all three endpoints that authenticate a client
+    (`/token` for both grant types, and `/revoke`). A public PKCE client
+    registers `token_endpoint_auth_method = "none"` and carries no secret, so
+    it authenticates trivially — for those, possession of the token *is* the
+    credential, which is the model RFC 6749 §2.1 describes and the reason the
+    revocation endpoint can still act on a public client's request.
+
+    Any method other than the two we register is a refusal, not a fallback.
+    """
+    auth_method = getattr(client, "token_endpoint_auth_method", "client_secret_post")
+    if auth_method == "client_secret_post":
+        return bool(
+            client_secret
+            and client.client_secret_hash
+            and secrets.compare_digest(client.client_secret_hash, _hash(client_secret))
+        )
+    return auth_method == "none"
+
+
+def _cross_user_client_error() -> JSONResponse:
+    """The refusal both consent paths give for someone else's client."""
+    return JSONResponse(
+        {
+            "error": "access_denied",
+            "error_description": (
+                "This OAuth client is registered to a different user. "
+                "Register the connector again from your own account "
+                "instead of reusing an existing client_id."
+            ),
+        },
+        status_code=403,
+    )
 
 
 def _client_belongs_to_another_user(client_row, session_user_id: int | None) -> bool:
@@ -488,17 +526,7 @@ async def authorize_post(
             )
 
         if _client_belongs_to_another_user(client_row, session_user_id):
-            return JSONResponse(
-                {
-                    "error": "access_denied",
-                    "error_description": (
-                        "This OAuth client is registered to a different user. "
-                        "Register the connector again from your own account "
-                        "instead of reusing an existing client_id."
-                    ),
-                },
-                status_code=403,
-            )
+            return _cross_user_client_error()
 
         code = secrets.token_hex(32)
 
@@ -506,8 +534,40 @@ async def authorize_post(
         # dynamic registration is unauthenticated, so we can't bind at
         # registration time — first /authorize wins. Subsequent authorizes
         # for the same client leave `user_id` alone.
+        #
+        # Conditional, because `client_row.user_id is None` was read from this
+        # transaction's snapshot: two users consenting to the same unbound
+        # client at once both saw NULL, and an unconditional ORM assignment let
+        # the second one overwrite the first one's claim. `WHERE user_id IS
+        # NULL ... RETURNING` makes the database arbitrate — under READ
+        # COMMITTED the loser blocks on the row lock, re-evaluates the
+        # predicate against the winner's committed row, and matches nothing.
         if session_user_id is not None and client_row.user_id is None:
-            client_row.user_id = session_user_id
+            claimed = (
+                await session.execute(
+                    sa_update(OAuthClient)
+                    .where(
+                        OAuthClient.client_id == client_id,
+                        OAuthClient.user_id.is_(None),
+                    )
+                    .values(user_id=session_user_id)
+                    .returning(OAuthClient.client_id)
+                )
+            ).scalar_one_or_none()
+            if claimed is None:
+                # Somebody else got there first. Re-read in a fresh statement
+                # (a new snapshot, so the winner's commit is visible) and
+                # refuse unless the winner happens to be this same user, which
+                # is the ordinary case of one person opening two tabs.
+                owner = (
+                    await session.execute(
+                        select(OAuthClient.user_id).where(
+                            OAuthClient.client_id == client_id
+                        )
+                    )
+                ).scalar_one_or_none()
+                if owner != session_user_id:
+                    return _cross_user_client_error()
 
         oauth_code = OAuthCode(
             code_hash=_hash(code),
@@ -587,15 +647,7 @@ async def _handle_auth_code(form):
         if not client:
             return JSONResponse({"error": "invalid_client"}, status_code=401)
 
-        auth_method = getattr(
-            client, "token_endpoint_auth_method", "client_secret_post"
-        )
-        if auth_method == "client_secret_post":
-            if not client_secret or not client.client_secret_hash or not secrets.compare_digest(
-                client.client_secret_hash, _hash(client_secret)
-            ):
-                return JSONResponse({"error": "invalid_client"}, status_code=401)
-        elif auth_method != "none":
+        if not _client_authenticated(client, client_secret):
             return JSONResponse({"error": "invalid_client"}, status_code=401)
 
         client_id = oauth_code.client_id
@@ -776,15 +828,7 @@ async def _handle_refresh(form):
             if not client:
                 return JSONResponse({"error": "invalid_client"}, status_code=401)
 
-            auth_method = getattr(
-                client, "token_endpoint_auth_method", "client_secret_post"
-            )
-            if auth_method == "client_secret_post":
-                if not client_secret or not client.client_secret_hash or not secrets.compare_digest(
-                    client.client_secret_hash, _hash(client_secret)
-                ):
-                    return JSONResponse({"error": "invalid_client"}, status_code=401)
-            elif auth_method != "none":
+            if not _client_authenticated(client, client_secret):
                 return JSONResponse({"error": "invalid_client"}, status_code=401)
 
             client_id = old_token.client_id
@@ -892,6 +936,8 @@ async def _handle_refresh(form):
 async def revoke_token(request: Request):
     form = await request.form()
     token = form.get("token")
+    client_id = form.get("client_id")
+    client_secret = form.get("client_secret")
 
     if token:
         token_hash = _hash(token)
@@ -901,6 +947,38 @@ async def revoke_token(request: Request):
             )
             oauth_token = result.scalar_one_or_none()
             if oauth_token:
+                # RFC 7009 §2.1: the client authenticates. This endpoint used
+                # to do neither authentication nor an ownership check, so any
+                # holder of any token value — a leaked one, one belonging to a
+                # different client — could revoke a whole grant. Widening
+                # revocation to the family (below) made that worse, not better.
+                result = await session.execute(
+                    select(OAuthClient).where(
+                        OAuthClient.client_id == oauth_token.client_id
+                    )
+                )
+                client = result.scalar_one_or_none()
+
+                # §2.2: "If the server responds with HTTP 200 for a token that
+                # is not valid *for the requesting client*, that is not an
+                # error" — an unknown, foreign or unauthenticated token is
+                # indistinguishable from an already-revoked one. So a caller
+                # naming a different client is answered 200 and nothing
+                # happens, rather than being told whose token it is.
+                #
+                # A missing `client_id` is tolerated the same way `/token`
+                # tolerates it (some ChatGPT connector builds omit it): the
+                # client is then identified by the token itself, and a
+                # confidential client still has to present its secret.
+                if client is None:
+                    return JSONResponse({})
+                if client_id and client_id != oauth_token.client_id:
+                    return JSONResponse({})
+                if not _client_authenticated(client, client_secret):
+                    # The one case that is a real error rather than a no-op:
+                    # the right client was named and failed to authenticate.
+                    return JSONResponse({"error": "invalid_client"}, status_code=401)
+
                 # Revoke the whole grant family, not just the row presented.
                 #
                 # RFC 7009 §2.1 explicitly permits this ("the authorization
@@ -911,9 +989,9 @@ async def revoke_token(request: Request):
                 # the same near-no-op the panel had (issue #64). Presenting the
                 # refresh token was already the working case; now both are.
                 #
-                # Nothing is leaked by the widening — the caller already holds a
-                # credential from this family, and RFC 7009 requires a 200
-                # either way, so the response says no more than it did before.
+                # The family cannot span clients or users (see
+                # `src/oauth/grants.py`), so an authenticated client revoking
+                # its own token reaches nothing that is not its own.
                 await revoke_grant_family(session, oauth_token.grant_id)
                 await session.commit()
 

--- a/src/oauth/scope.py
+++ b/src/oauth/scope.py
@@ -30,6 +30,14 @@ built on it.
 VALID_SCOPES = frozenset({"read", "readwrite", "offline_access"})
 
 WRITE_SCOPE = "readwrite"
+READ_SCOPE = "read"
+
+# The scopes that actually grant access to the vault, strongest first.
+# ``offline_access`` is deliberately absent: it says the grant may carry a
+# refresh token, not that it may read a single note. Treating it as a vault
+# scope is what let a client registered for ``offline_access`` alone end up
+# with read access nobody granted.
+VAULT_SCOPES = (WRITE_SCOPE, READ_SCOPE)
 
 
 def scope_set(scope: str | None) -> set[str]:
@@ -58,21 +66,61 @@ def token_has_write(token_scope: str | None) -> bool:
     return WRITE_SCOPE in scope_set(token_scope)
 
 
+def vault_level(scope: str | None) -> str | None:
+    """The vault permission a scope string carries: ``readwrite``, ``read``, or None.
+
+    None means *no vault access at all*. That is a real state, not a
+    degenerate one: a DCR client may register ``scope="offline_access"``, and
+    a scope string that names only ``offline_access`` grants nothing.
+    """
+    parts = scope_set(scope)
+    for name in VAULT_SCOPES:
+        if name in parts:
+            return name
+    return None
+
+
+def has_vault_scope(scope: str | None) -> bool:
+    """Does this scope string grant *any* access to the vault?"""
+    return vault_level(scope) is not None
+
+
 def clamp_scope(requested: str, registered: str) -> str:
     """Restrict a requested scope to what the client registered for.
 
-    Both inputs are already validated scope strings. The user can only ever
-    be granted the intersection of what they asked for and what the client is
-    registered to hold. ``readwrite`` implies ``read``, so a client registered
-    for ``readwrite`` may still be granted plain ``read``.
+    The granted vault permission is the **weaker** of what was asked for and
+    what the client is registered to hold — ``readwrite`` outranks ``read``,
+    so a client registered read-only that asks for ``readwrite`` gets ``read``
+    (issue #21), and a client registered ``readwrite`` that asks for ``read``
+    gets ``read``. ``offline_access`` rides along only when both sides carry
+    it; it is a marker, never a permission.
+
+    **An empty result means "grant nothing", and every caller MUST refuse
+    rather than write it.** This used to fall back to ``"read"`` whenever the
+    intersection came out empty, which quietly conflated two different things:
+    the legitimate readwrite→read downgrade above, and a client that is
+    registered for *no vault scope at all*. A DCR registration of
+    ``scope="offline_access"`` therefore received read access to the whole
+    vault that its registration never granted. The downgrade is now expressed
+    directly, so the fallback can be what it should always have been —
+    nothing.
 
     The result is sorted and joined, so it is a canonical rendering of the
-    granted set -- callers must never compare it with ``==`` against a
+    granted set; callers must never compare it with ``==`` against a
     hand-written ordering.
     """
-    requested_parts = scope_set(requested)
-    registered_parts = scope_set(registered)
-    if WRITE_SCOPE in registered_parts:
-        registered_parts.add("read")
-    granted = requested_parts & registered_parts
-    return " ".join(sorted(granted)) or "read"
+    requested_level = vault_level(requested)
+    registered_level = vault_level(registered)
+    if requested_level is None or registered_level is None:
+        return ""
+
+    # The weaker of the two. `read` beats `readwrite` here precisely because
+    # "weaker" is what a clamp means.
+    granted = {
+        READ_SCOPE
+        if READ_SCOPE in (requested_level, registered_level)
+        else WRITE_SCOPE
+    }
+    if "offline_access" in scope_set(requested) & scope_set(registered):
+        granted.add("offline_access")
+    return " ".join(sorted(granted))

--- a/src/oauth/scope.py
+++ b/src/oauth/scope.py
@@ -1,0 +1,78 @@
+"""One place that decides what an OAuth scope string means.
+
+Three surfaces used to answer "does this grant write?" independently:
+
+- ``src/oauth/routes.py`` gated the consent screen's Read+Write radio on
+  ``"readwrite" in client.scope.split()`` and clamped the posted form value
+  with a private ``_clamp_scope``;
+- ``src/mcp_server/auth.py`` mapped a token scope to a permission with its own
+  ``"readwrite" in scope_parts``;
+- ``src/control_panel/routes.py`` computed ``has_write`` with a third copy, and
+  ``update_oauth_token_scope`` did not consult the client's registration at
+  all -- so the panel could raise a token above what its client was ever
+  registered for, permanently (issue #67).
+
+They agreed by coincidence, which is not a property anything could test. This
+module is deliberately dependency-free (no ``src.config``, no ORM) so *every*
+layer -- the OAuth routes, the ASGI auth middleware and the control panel --
+can import it without an import cycle, which is what issue #67 warned about
+when it said not to reach into ``src/oauth/routes.py`` from the panel.
+
+Scope strings are **space-separated sets**, not enum values. ``"offline_access
+readwrite"`` is a readwrite grant; string equality against ``"readwrite"``
+says it is not. Membership is the only correct test, and every helper here is
+built on it.
+"""
+
+# Every scope token the server understands. ``offline_access`` does not change
+# vault permissions -- it only makes the already-issued refresh token explicit
+# in the grant (see DEFAULT_CLIENT_SCOPE in src/oauth/routes.py).
+VALID_SCOPES = frozenset({"read", "readwrite", "offline_access"})
+
+WRITE_SCOPE = "readwrite"
+
+
+def scope_set(scope: str | None) -> set[str]:
+    """The set of scope tokens in a scope string. ``None`` is the empty set."""
+    return set((scope or "").split())
+
+
+def client_can_write(client_scope: str | None) -> bool:
+    """Is this *client* registered to hold a write grant?
+
+    The registered scope is the cap: RFC 7591 registration is a statement
+    about what that software may ever hold, and no consent screen, no token
+    endpoint and no panel control may raise a grant above it.
+    """
+    return WRITE_SCOPE in scope_set(client_scope)
+
+
+def token_has_write(token_scope: str | None) -> bool:
+    """Does this *token* actually carry write permission?
+
+    Membership, not equality -- ``"offline_access readwrite"`` is a write
+    grant. This is the single definition behind the panel's ``has_write``
+    display flag and the middleware's ``permission`` mapping, so the two
+    cannot drift apart.
+    """
+    return WRITE_SCOPE in scope_set(token_scope)
+
+
+def clamp_scope(requested: str, registered: str) -> str:
+    """Restrict a requested scope to what the client registered for.
+
+    Both inputs are already validated scope strings. The user can only ever
+    be granted the intersection of what they asked for and what the client is
+    registered to hold. ``readwrite`` implies ``read``, so a client registered
+    for ``readwrite`` may still be granted plain ``read``.
+
+    The result is sorted and joined, so it is a canonical rendering of the
+    granted set -- callers must never compare it with ``==`` against a
+    hand-written ordering.
+    """
+    requested_parts = scope_set(requested)
+    registered_parts = scope_set(registered)
+    if WRITE_SCOPE in registered_parts:
+        registered_parts.add("read")
+    granted = requested_parts & registered_parts
+    return " ".join(sorted(granted)) or "read"

--- a/src/services/indexer.py
+++ b/src/services/indexer.py
@@ -720,7 +720,47 @@ async def rebuild_tsvectors(session, user_id: int | None = None) -> int:
 
 
 async def cleanup_expired_tokens():
-    """Delete expired/revoked OAuth codes and tokens older than 7 days."""
+    """Delete OAuth codes and tokens that are more than 7 days dead.
+
+    The token half used to read ``expires_at < cutoff OR revoked``, and that
+    second disjunct carried **no age condition at all** despite this
+    docstring's "older than 7 days" — every revoked token was deleted on the
+    next pass, i.e. within `INDEX_INTERVAL_SECONDS` (5 minutes by default).
+
+    That is wrong now that the panel lists revoked tokens as a grant's
+    revocation history (issue #64). Filtering revoked rows *out of the page*
+    is what made a Revoke that did nothing read as success — the row simply
+    disappeared. Deleting them out of the table five minutes later reproduces
+    the same blank space, just with a delay.
+
+    **The 7-day window is measured from `expires_at`, not `created_at`, and
+    that choice is load-bearing.** Revocation time is not stored anywhere, so
+    the window has to be derived from a column we do have:
+
+    * A token can only be revoked while it exists, so its revocation time R
+      satisfies ``R <= expires_at`` for every revocation the panel or the token
+      endpoint performs. Deleting only when ``expires_at < now - 7d`` therefore
+      *guarantees* ``R < now - 7d`` — every revoked row is visible for at least
+      seven days after it was revoked.
+    * `created_at` gives no such guarantee and gets it backwards: a refresh
+      token minted 30 days ago and revoked one minute ago is already 30 days
+      past `created_at`, so it would be purged immediately — precisely the case
+      the operator most needs to see.
+
+    Age-gating the revoked branch makes it a strict subset of the expiry
+    branch, so the correct implementation is the single predicate below rather
+    than a redundant `or_`. Revoked tokens are still deleted; they are deleted
+    seven days after they would have expired anyway, which is the same
+    retention their unrevoked siblings get. The auth-code half is unchanged: a
+    used code is spent immediately and has no history value.
+
+    Edge case, stated rather than hidden: a family revocation also flips
+    `revoked` on tokens that had *already* expired, so for those R can exceed
+    `expires_at`. Such a row is deleted on the ordinary expiry schedule and can
+    therefore disappear sooner than seven days after that flip — but it was
+    already dead and already displayed as "Expired" before the revocation
+    touched it, so no revocation the operator performed becomes invisible.
+    """
     cutoff = datetime.now(timezone.utc) - timedelta(days=7)
 
     async with async_session() as session:
@@ -735,14 +775,12 @@ async def cleanup_expired_tokens():
         )
         codes_deleted = result.rowcount
 
-        # Clean up expired/revoked tokens
+        # Clean up tokens more than 7 days past their expiry — revoked ones
+        # included, and on the same schedule. See the docstring: an unqualified
+        # `OR revoked` deleted a revocation's evidence within five minutes of
+        # the operator creating it.
         result = await session.execute(
-            delete(OAuthToken).where(
-                or_(
-                    OAuthToken.expires_at < cutoff,
-                    OAuthToken.revoked == True,
-                )
-            )
+            delete(OAuthToken).where(OAuthToken.expires_at < cutoff)
         )
         tokens_deleted = result.rowcount
 

--- a/tests/_oauth_grant_fakes.py
+++ b/tests/_oauth_grant_fakes.py
@@ -21,6 +21,7 @@ import datetime
 from sqlalchemy.sql.dml import Update
 
 from src.models.db import OAuthClient, OAuthToken, User
+from src.oauth.grants import USER_BOOTSTRAP_LOCK_KEY
 
 UTC = datetime.timezone.utc
 
@@ -156,6 +157,31 @@ def _params(stmt) -> dict:
         return {}
 
 
+def _is_advisory_lock(stmt) -> bool:
+    """Is this the textual `pg_advisory_xact_lock` statement, specifically?"""
+    return "pg_advisory_xact_lock" in str(stmt)
+
+
+def _window_value(clause):
+    return None if clause is None else clause.value
+
+
+def _apply_window(stmt, rows: list) -> list:
+    """Honour LIMIT/OFFSET, so a fake cannot hide a truncation bug.
+
+    The panel's per-client scan is bounded, and a bound applied at the wrong
+    point can push a live grant off the page entirely with no control to
+    revoke it. A fake that ignored LIMIT would render that page complete.
+    """
+    offset = _window_value(getattr(stmt, "_offset_clause", None))
+    limit = _window_value(getattr(stmt, "_limit_clause", None))
+    if offset:
+        rows = rows[offset:]
+    if limit is not None:
+        rows = rows[:limit]
+    return rows
+
+
 class FakeSession:
     """Interprets the handful of statement shapes the OAuth surfaces issue.
 
@@ -172,7 +198,15 @@ class FakeSession:
         self.rolled_back = 0
         self.deleted: list = []
         self.added: list = []
-        self.locked_grants: list[int] = []
+        # Every advisory lock the handler took, in acquisition order. Order is
+        # itself the property under test -- the bootstrap lock must precede the
+        # grant lock, and both must precede any family read or write.
+        self.advisory_locks: list[int] = []
+
+    @property
+    def locked_grants(self) -> list[int]:
+        """Advisory locks other than the constant bootstrap key."""
+        return [key for key in self.advisory_locks if key != USER_BOOTSTRAP_LOCK_KEY]
 
     # -- async session surface ---------------------------------------------
 
@@ -198,12 +232,18 @@ class FakeSession:
         self.deleted.append(obj)
 
     async def execute(self, stmt, params=None):
-        # `lock_grant` issues a textual `pg_advisory_xact_lock`. Recording it
-        # is how the tests prove the family lock is actually taken before the
-        # family is written -- the ordering that stops a concurrent refresh
-        # from surviving a revocation.
-        if params is not None and "key" in params:
-            self.locked_grants.append(params["key"])
+        # `lock_grant` and `lock_user_bootstrap` issue a textual
+        # `pg_advisory_xact_lock`. Recording it is how the tests prove the
+        # locks are actually taken, and in which order -- the ordering that
+        # stops a concurrent refresh from surviving a revocation, and a
+        # concurrent mint from escaping the bootstrap's claim.
+        #
+        # Matched on the *statement text*, not merely on the presence of a
+        # `key` parameter: a handler that passed `{"key": ...}` to some other
+        # query would otherwise be recorded as holding a lock it never took.
+        if _is_advisory_lock(stmt):
+            assert params and "key" in params, "advisory lock issued without a key"
+            self.advisory_locks.append(params["key"])
             return _Result([])
 
         if isinstance(stmt, Update):
@@ -223,6 +263,7 @@ class FakeSession:
         if entity is OAuthToken:
             rows = self._filter_tokens(stmt, bound)
             rows.sort(key=lambda t: (t.created_at, t.id), reverse=True)
+            rows = _apply_window(stmt, rows)
             # `select(OAuthToken.grant_id)` (the refresh handler's family
             # lookup) wants the column, not the row.
             if getattr(stmt.column_descriptions[0].get("expr", None), "key", None) == "grant_id":
@@ -313,3 +354,41 @@ class FakeRequest:
                 "server": ("testserver", 443),
             }
         )
+
+
+class SeqSession:
+    """Returns canned rows in call order -- enough for `_handle_auth_code`.
+
+    Advisory locks are recorded rather than consumed from the result sequence,
+    so a handler that starts taking one does not silently shift every
+    subsequent canned row by one.
+    """
+
+    def __init__(self, results=()):
+        self._results = iter(results)
+        self.added: list = []
+        self.committed = False
+        self.advisory_locks: list[int] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def execute(self, stmt, params=None, *_a, **_kw):
+        if _is_advisory_lock(stmt):
+            assert params and "key" in params, "advisory lock issued without a key"
+            self.advisory_locks.append(params["key"])
+            return _Result([])
+        value = next(self._results)
+        return _Result([value] if value is not None else [])
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+    async def rollback(self):
+        pass

--- a/tests/_oauth_grant_fakes.py
+++ b/tests/_oauth_grant_fakes.py
@@ -1,0 +1,315 @@
+"""In-memory doubles for the OAuth grant-family tests (#64/#65/#67/#68/#76).
+
+Not a test module -- the leading underscore keeps pytest from collecting it.
+
+The point of these fakes is that the *production* handlers run: `oauth_page`
+really groups rows into families and derives `has_write`, `revoke_oauth_token`
+really issues the family UPDATE, `_handle_refresh` really re-clamps. Only the
+database is replaced. A fixture that hand-builds the template context instead
+is what left issue #65 gap 1 open -- it asserted the template consumes
+`has_write` and never that the route derives it.
+
+`FakeSession` therefore interprets real SQLAlchemy statements rather than
+handing back canned results in call order: it dispatches on the entity the
+statement selects, and applies `update()` statements to the in-memory rows so a
+family write is observable exactly the way it would be in Postgres.
+"""
+from __future__ import annotations
+
+import datetime
+
+from sqlalchemy.sql.dml import Update
+
+from src.models.db import OAuthClient, OAuthToken, User
+
+UTC = datetime.timezone.utc
+
+
+def utcnow() -> datetime.datetime:
+    return datetime.datetime.now(UTC)
+
+
+def in_hours(hours: float) -> datetime.datetime:
+    return utcnow() + datetime.timedelta(hours=hours)
+
+
+class FakeToken:
+    """An `OAuthToken` row, with only the attributes the handlers read."""
+
+    _next_id = 1
+
+    def __init__(
+        self,
+        *,
+        grant_id: str,
+        token_type: str = "access",
+        scope: str = "read",
+        client_id: str = "client123",
+        user_id: int | None = None,
+        revoked: bool = False,
+        expires_at: datetime.datetime | None = None,
+        created_at: datetime.datetime | None = None,
+        token_hash: str | None = None,
+        id: int | None = None,
+    ):
+        if id is None:
+            id = FakeToken._next_id
+            FakeToken._next_id += 1
+        self.id = id
+        self.grant_id = grant_id
+        self.token_type = token_type
+        self.scope = scope
+        self.client_id = client_id
+        self.user_id = user_id
+        self.revoked = revoked
+        self.expires_at = expires_at or in_hours(1)
+        self.created_at = created_at or utcnow()
+        self.token_hash = token_hash
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return (
+            f"FakeToken(id={self.id}, type={self.token_type!r}, "
+            f"grant={self.grant_id!r}, scope={self.scope!r}, revoked={self.revoked})"
+        )
+
+
+class FakeClient:
+    def __init__(
+        self,
+        *,
+        client_id: str = "client123",
+        client_name: str = "Claude",
+        scope: str = "read readwrite offline_access",
+        user_id: int | None = None,
+        redirect_uris: list[str] | None = None,
+        created_at: datetime.datetime | None = None,
+        client_secret_hash: str | None = None,
+        token_endpoint_auth_method: str = "none",
+    ):
+        self.client_id = client_id
+        self.client_name = client_name
+        self.scope = scope
+        self.user_id = user_id
+        self.redirect_uris = redirect_uris or ["https://example.test/cb"]
+        self.created_at = created_at or utcnow()
+        self.client_secret_hash = client_secret_hash
+        self.token_endpoint_auth_method = token_endpoint_auth_method
+
+
+class FakeUser:
+    def __init__(self, *, id: int, is_active: bool = True, is_admin: bool = False):
+        self.id = id
+        self.is_active = is_active
+        self.is_admin = is_admin
+        self.username = f"user{id}"
+
+
+class SingleUserSentinel:
+    """Mirrors `src.auth.session._SingleUserSentinel` for the panel handlers."""
+
+    id = None
+    is_admin = True
+    username = "admin"
+
+
+class _Scalars:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return list(self._rows)
+
+
+class _Result:
+    def __init__(self, rows, tuples=None, rowcount=0):
+        self._rows = list(rows)
+        self._tuples = tuples
+        self.rowcount = rowcount
+
+    def scalars(self):
+        return _Scalars(self._rows)
+
+    def all(self):
+        return list(self._tuples if self._tuples is not None else self._rows)
+
+    def scalar_one_or_none(self):
+        if not self._rows:
+            return None
+        return self._rows[0]
+
+    def scalar(self):
+        return self.scalar_one_or_none()
+
+
+def _entity(stmt):
+    try:
+        descriptions = stmt.column_descriptions
+    except Exception:  # pragma: no cover - non-ORM statement (e.g. text())
+        return None
+    return descriptions[0]["entity"] if descriptions else None
+
+
+def _params(stmt) -> dict:
+    try:
+        return dict(stmt.compile().params)
+    except Exception:  # pragma: no cover
+        return {}
+
+
+class FakeSession:
+    """Interprets the handful of statement shapes the OAuth surfaces issue.
+
+    Deliberately narrow: anything it does not recognise raises, so a handler
+    that starts issuing a *different* query fails the test loudly instead of
+    silently receiving an empty result and appearing to work.
+    """
+
+    def __init__(self, *, clients=(), tokens=(), users=()):
+        self.clients = list(clients)
+        self.tokens = list(tokens)
+        self.users = list(users)
+        self.committed = 0
+        self.rolled_back = 0
+        self.deleted: list = []
+        self.added: list = []
+        self.locked_grants: list[int] = []
+
+    # -- async session surface ---------------------------------------------
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed += 1
+
+    async def rollback(self):
+        self.rolled_back += 1
+
+    async def close(self):
+        pass
+
+    async def delete(self, obj):
+        self.deleted.append(obj)
+
+    async def execute(self, stmt, params=None):
+        # `lock_grant` issues a textual `pg_advisory_xact_lock`. Recording it
+        # is how the tests prove the family lock is actually taken before the
+        # family is written -- the ordering that stops a concurrent refresh
+        # from surviving a revocation.
+        if params is not None and "key" in params:
+            self.locked_grants.append(params["key"])
+            return _Result([])
+
+        if isinstance(stmt, Update):
+            return self._apply_update(stmt)
+
+        entity = _entity(stmt)
+        bound = _params(stmt)
+
+        if entity is OAuthClient:
+            rows = list(self.clients)
+            if "client_id_1" in bound:
+                rows = [c for c in rows if c.client_id == bound["client_id_1"]]
+            if "user_id_1" in bound:
+                rows = [c for c in rows if c.user_id == bound["user_id_1"]]
+            return _Result(rows)
+
+        if entity is OAuthToken:
+            rows = self._filter_tokens(stmt, bound)
+            rows.sort(key=lambda t: (t.created_at, t.id), reverse=True)
+            # `select(OAuthToken.grant_id)` (the refresh handler's family
+            # lookup) wants the column, not the row.
+            if getattr(stmt.column_descriptions[0].get("expr", None), "key", None) == "grant_id":
+                return _Result([t.grant_id for t in rows])
+            return _Result(rows)
+
+        if entity is User:
+            wanted = bound.get("id_1")
+            rows = self.users
+            if isinstance(wanted, (list, tuple, set)):
+                rows = [u for u in rows if u.id in wanted]
+            return _Result(rows, tuples=[(u.id, u.is_active) for u in rows])
+
+        raise AssertionError(f"FakeSession got an unexpected statement: {stmt}")
+
+    # -- predicate interpretation ------------------------------------------
+
+    # Every `oauth_tokens` predicate the OAuth surfaces use, and how to read it
+    # off a compiled statement. Selects and updates go through the same code so
+    # a family UPDATE that quietly narrows itself (say, to `token_type =
+    # 'access'`) is *observed* by the fake instead of being flattened into the
+    # correct behaviour -- which is the difference between a test that pins
+    # "revocation covers the family" and one that cannot fail.
+    _TOKEN_PREDICATES = (
+        ("id_1", "id"),
+        ("client_id_1", "client_id"),
+        ("user_id_1", "user_id"),
+        ("token_hash_1", "token_hash"),
+        ("token_type_1", "token_type"),
+        ("grant_id_1", "grant_id"),
+        ("scope_1", "scope"),
+    )
+
+    def _filter_tokens(self, stmt, bound: dict) -> list:
+        rows = list(self.tokens)
+        rendered = str(stmt)
+        # `revoked == False` / `== True` compile to SQL literals rather than
+        # bind params, so they have to be read off the rendered statement.
+        if "oauth_tokens.revoked = false" in rendered:
+            rows = [t for t in rows if not t.revoked]
+        if "oauth_tokens.revoked = true" in rendered:
+            rows = [t for t in rows if t.revoked]
+        for param, attribute in self._TOKEN_PREDICATES:
+            if param in bound:
+                rows = [t for t in rows if getattr(t, attribute) == bound[param]]
+        return rows
+
+    def _apply_update(self, stmt):
+        if stmt.table.name != "oauth_tokens":
+            raise AssertionError(f"unexpected UPDATE target: {stmt.table.name}")
+        values = {col.key: bind.value for col, bind in stmt._values.items()}
+        bound = _params(stmt)
+        if "grant_id_1" not in bound:
+            raise AssertionError("family UPDATE must be keyed on grant_id")
+        # The SET clause's own bind params share the column names, so they must
+        # not be mistaken for WHERE predicates.
+        where_bound = {k: v for k, v in bound.items() if k.endswith("_1")}
+        targets = self._filter_tokens(stmt, where_bound)
+        for token in targets:
+            for key, value in values.items():
+                setattr(token, key, value)
+        return _Result([], rowcount=len(targets))
+
+
+class FakeRequest:
+    """Enough of a Starlette request for `_panel_context` / TemplateResponse.
+
+    A real `starlette.requests.Request` over a minimal scope: `request.session`
+    raises without SessionMiddleware, which `generate_csrf_token` already
+    handles by returning "" (single-user mode has no CSRF token).
+    """
+
+    def __new__(cls, path: str = "/admin/oauth"):
+        from starlette.requests import Request
+
+        return Request(
+            {
+                "type": "http",
+                "http_version": "1.1",
+                "method": "GET",
+                "scheme": "https",
+                "path": path,
+                "raw_path": path.encode(),
+                "query_string": b"",
+                "root_path": "",
+                "headers": [],
+                "client": ("127.0.0.1", 12345),
+                "server": ("testserver", 443),
+            }
+        )

--- a/tests/_oauth_grant_fakes.py
+++ b/tests/_oauth_grant_fakes.py
@@ -168,9 +168,22 @@ def _single_column(stmt) -> str | None:
     return getattr(descriptions[0].get("expr"), "key", None)
 
 
+# The one statement `lock_grant` / `lock_user_bootstrap` issue, whitespace
+# normalized. Matching the *whole* statement rather than searching for the
+# function name is the point: a substring test counts a decoy — the name
+# appearing in a SQL comment, in a CTE that also does something else, or in a
+# `text()` a future caller writes — as a lock that was never taken, so a test
+# asserting "the lock came first" would pass on a handler that never locked.
+ADVISORY_LOCK_SQL = "SELECT pg_advisory_xact_lock(:key)"
+
+
+def _normalized_sql(stmt) -> str:
+    return " ".join(str(stmt).split())
+
+
 def _is_advisory_lock(stmt) -> bool:
-    """Is this the textual `pg_advisory_xact_lock` statement, specifically?"""
-    return "pg_advisory_xact_lock" in str(stmt)
+    """Is this *exactly* the advisory-lock statement, and nothing else?"""
+    return _normalized_sql(stmt) == ADVISORY_LOCK_SQL
 
 
 def _window_value(clause):
@@ -310,15 +323,67 @@ class FakeSession:
         ("scope_1", "scope"),
     )
 
+    def _matches_bound_params(self, token, bound: dict) -> bool:
+        """The equality predicates, for a row already past a compound clause."""
+        return all(
+            getattr(token, attribute) == bound[param]
+            for param, attribute in self._TOKEN_PREDICATES
+            if param in bound
+        )
+
     def _filter_tokens(self, stmt, bound: dict) -> list:
         rows = list(self.tokens)
-        rendered = str(stmt)
+        rendered = _normalized_sql(stmt)
+        cutoff = bound.get("expires_at_1")
+
+        # `oauth_page`'s history query is a *disjunction* —
+        # `revoked OR expires_at <= now` — and evaluating its two halves as
+        # separate ANDed filters (which is what a per-predicate loop does)
+        # would drop every revoked-but-unexpired row, i.e. exactly the
+        # revocation the operator just performed. Recognise the group and
+        # evaluate it as one.
+        # No surrounding parens in the pattern: SQLAlchemy adds them only when
+        # the disjunction is ANDed with something else (as `oauth_page` does,
+        # with `client_id`), and omits them when it is the whole WHERE clause.
+        dead_group = (
+            "oauth_tokens.revoked = true OR oauth_tokens.expires_at <= "
+            ":expires_at_1"
+        )
+        if dead_group in rendered:
+            assert cutoff is not None
+            return [
+                t for t in rows
+                if (t.revoked or t.expires_at <= cutoff)
+                and self._matches_bound_params(t, bound)
+            ]
+
         # `revoked == False` / `== True` compile to SQL literals rather than
         # bind params, so they have to be read off the rendered statement.
         if "oauth_tokens.revoked = false" in rendered:
             rows = [t for t in rows if not t.revoked]
         if "oauth_tokens.revoked = true" in rendered:
             rows = [t for t in rows if t.revoked]
+
+        # Both expiry directions. `oauth_page` splits its listing with
+        # `expires_at > now` and `expires_at <= now`, and a fake that ignored
+        # them returned every row to both queries — so the split the panel
+        # depends on (live rows unbounded, history capped) was never exercised,
+        # and an expired token would have rendered as live.
+        if cutoff is not None:
+            for operator, keep in (
+                (">=", lambda t: t.expires_at >= cutoff),
+                ("<=", lambda t: t.expires_at <= cutoff),
+                (">", lambda t: t.expires_at > cutoff),
+                ("<", lambda t: t.expires_at < cutoff),
+            ):
+                if f"oauth_tokens.expires_at {operator} :expires_at_1" in rendered:
+                    rows = [t for t in rows if keep(t)]
+                    break
+            else:  # pragma: no cover - a shape the fake does not model
+                raise AssertionError(
+                    f"unrecognised expires_at comparison in: {rendered}"
+                )
+
         for param, attribute in self._TOKEN_PREDICATES:
             if param in bound:
                 rows = [t for t in rows if getattr(t, attribute) == bound[param]]

--- a/tests/_oauth_grant_fakes.py
+++ b/tests/_oauth_grant_fakes.py
@@ -157,6 +157,17 @@ def _params(stmt) -> dict:
         return {}
 
 
+def _single_column(stmt) -> str | None:
+    """The attribute name when a select names exactly one ORM column."""
+    try:
+        descriptions = stmt.column_descriptions
+    except Exception:  # pragma: no cover
+        return None
+    if len(descriptions) != 1:
+        return None
+    return getattr(descriptions[0].get("expr"), "key", None)
+
+
 def _is_advisory_lock(stmt) -> bool:
     """Is this the textual `pg_advisory_xact_lock` statement, specifically?"""
     return "pg_advisory_xact_lock" in str(stmt)
@@ -264,10 +275,12 @@ class FakeSession:
             rows = self._filter_tokens(stmt, bound)
             rows.sort(key=lambda t: (t.created_at, t.id), reverse=True)
             rows = _apply_window(stmt, rows)
-            # `select(OAuthToken.grant_id)` (the refresh handler's family
-            # lookup) wants the column, not the row.
-            if getattr(stmt.column_descriptions[0].get("expr", None), "key", None) == "grant_id":
-                return _Result([t.grant_id for t in rows])
+            # A single-column select (`select(OAuthToken.grant_id)` for the
+            # refresh handler's family lookup, `select(OAuthToken.scope)` for
+            # the panel's uniform-scope write) wants the column, not the row.
+            column = _single_column(stmt)
+            if column is not None:
+                return _Result([getattr(t, column) for t in rows])
             return _Result(rows)
 
         if entity is User:

--- a/tests/integration/test_oauth_grants_pg.py
+++ b/tests/integration/test_oauth_grants_pg.py
@@ -1,0 +1,508 @@
+"""Real-Postgres gate for the OAuth grant-family concurrency properties.
+
+Three of these have no meaningful fake-session equivalent, because what they
+assert *is* the database's behaviour:
+
+* **Revocation vs rotation.** The failure is a snapshot artefact — an
+  `UPDATE ... WHERE grant_id = :g` cannot see rows a concurrent refresh
+  inserts after its statement began, so the panel reports "revoked" while the
+  client keeps the pair it just rotated into. A fake has no snapshot to be
+  wrong about; only two real transactions racing on a real lock manager show
+  whether the advisory lock actually orders them.
+* **Concurrent first consent.** `UPDATE oauth_clients SET user_id = :u WHERE
+  user_id IS NULL RETURNING client_id` is only an arbitrator because Postgres
+  blocks the loser on the row lock and re-evaluates the predicate. In a fake
+  the two writes simply happen in program order.
+* **Client-authenticated revocation** is included because it is cheap here and
+  exercises the same rows end to end.
+
+Skipped unless `PGVECTOR_TEST_ADMIN_URL` names a throwaway Postgres *server*
+(the module creates and drops its own database):
+
+    docker run --rm -d --name pgvector-test -e POSTGRES_PASSWORD=test \\
+        -p 55432:5432 pgvector/pgvector:pg16
+    PGVECTOR_TEST_ADMIN_URL=postgresql+asyncpg://postgres:test@localhost:55432/postgres \\
+        pytest -q tests/integration/test_oauth_grants_pg.py
+    docker rm -f pgvector-test
+"""
+import asyncio
+import os
+import secrets
+import subprocess
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from urllib.parse import unquote, urlsplit, urlunsplit
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete as sa_delete
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from src.models.db import OAuthClient, OAuthCode, OAuthToken, UsageLog, User
+from src.oauth import routes as oauth
+
+PGVECTOR_TEST_ADMIN_URL = os.environ.get("PGVECTOR_TEST_ADMIN_URL")
+FORBIDDEN_DB_NAMES = {"obsidian_mcp"}
+ROOT = Path(__file__).resolve().parent.parent.parent
+
+pytestmark = [
+    pytest.mark.asyncio(loop_scope="module"),
+    pytest.mark.skipif(
+        not PGVECTOR_TEST_ADMIN_URL,
+        reason="PGVECTOR_TEST_ADMIN_URL not set",
+    ),
+]
+
+REDIRECT_URI = "https://client.example.com/callback"
+VERIFIER = "v" * 64
+SECRET = "s" * 64
+FUTURE = datetime(2099, 1, 1, tzinfo=timezone.utc)
+
+
+# ── throwaway database harness (same shape as test_transfer_pg.py) ──────────
+
+
+def _with_database(url: str, dbname: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit(parts._replace(path=f"/{dbname}"))
+
+
+def _asyncpg_dsn(url: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit(parts._replace(scheme=parts.scheme.split("+", 1)[0]))
+
+
+async def _run_maintenance(admin_url: str, statement: str) -> None:
+    import asyncpg
+
+    conn = await asyncpg.connect(_asyncpg_dsn(admin_url))
+    try:
+        await conn.execute(statement)
+    finally:
+        await conn.close()
+
+
+@pytest.fixture(scope="module")
+def migrated_database():
+    admin_db = unquote(urlsplit(PGVECTOR_TEST_ADMIN_URL).path).lstrip("/").casefold()
+    if admin_db in FORBIDDEN_DB_NAMES:
+        pytest.fail(
+            "PGVECTOR_TEST_ADMIN_URL points at the production database name; "
+            "this fixture creates and drops databases."
+        )
+    dbname = f"test_grants_{uuid.uuid4().hex}"
+    try:
+        asyncio.run(
+            _run_maintenance(PGVECTOR_TEST_ADMIN_URL, f'CREATE DATABASE "{dbname}"')
+        )
+        url = _with_database(PGVECTOR_TEST_ADMIN_URL, dbname)
+        result = subprocess.run(
+            [sys.executable, "-m", "alembic", "upgrade", "head"],
+            cwd=ROOT,
+            env={
+                **os.environ,
+                "DATABASE_URL": url,
+                "SECRET_KEY": os.environ.get("SECRET_KEY") or "test-migration-key",
+            },
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        assert result.returncode == 0, (
+            f"alembic upgrade head failed\n{result.stdout}\n{result.stderr}"
+        )
+        yield url
+    finally:
+        try:
+            asyncio.run(
+                _run_maintenance(
+                    PGVECTOR_TEST_ADMIN_URL,
+                    f'DROP DATABASE IF EXISTS "{dbname}" (FORCE)',
+                )
+            )
+        except Exception as e:  # pragma: no cover - cleanup best effort
+            print(f"warning: could not drop throwaway database {dbname}: {e}")
+
+
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
+async def engine(migrated_database):
+    eng = create_async_engine(migrated_database)
+    yield eng
+    await eng.dispose()
+
+
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
+async def sessionmaker(engine):
+    return async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+
+@pytest_asyncio.fixture(loop_scope="module")
+async def clean(sessionmaker, monkeypatch_module):
+    """Empty the tables this module writes to, and point the handlers here."""
+    async with sessionmaker() as session:
+        await session.execute(sa_delete(UsageLog))
+        await session.execute(sa_delete(OAuthToken))
+        await session.execute(sa_delete(OAuthCode))
+        await session.execute(sa_delete(OAuthClient))
+        await session.execute(sa_delete(User))
+        await session.commit()
+    # The token endpoint opens its own sessions through this module global.
+    monkeypatch_module.setattr(oauth, "async_session", sessionmaker)
+    yield sessionmaker
+
+
+@pytest.fixture(scope="module")
+def monkeypatch_module():
+    mp = pytest.MonkeyPatch()
+    yield mp
+    mp.undo()
+
+
+# ── seeding ────────────────────────────────────────────────────────────────
+
+
+async def seed_client(sessionmaker, *, confidential=False, user_id=None, client_id="c1"):
+    async with sessionmaker() as session:
+        session.add(
+            OAuthClient(
+                client_id=client_id,
+                client_secret_hash=oauth._hash(SECRET) if confidential else None,
+                token_endpoint_auth_method=(
+                    "client_secret_post" if confidential else "none"
+                ),
+                client_name="Test Client",
+                redirect_uris=[REDIRECT_URI],
+                scope="read readwrite offline_access",
+                user_id=user_id,
+            )
+        )
+        await session.commit()
+
+
+async def seed_grant(sessionmaker, *, client_id="c1", grant_id="g1", scope="readwrite"):
+    """One consent's worth of rows; returns the raw refresh-token value."""
+    refresh_value = secrets.token_hex(32)
+    async with sessionmaker() as session:
+        session.add(
+            OAuthToken(
+                token_hash=oauth._hash(secrets.token_hex(32)),
+                token_type="access",
+                client_id=client_id,
+                scope=scope,
+                grant_id=grant_id,
+                expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            )
+        )
+        session.add(
+            OAuthToken(
+                token_hash=oauth._hash(refresh_value),
+                token_type="refresh",
+                client_id=client_id,
+                scope=scope,
+                grant_id=grant_id,
+                expires_at=datetime.now(timezone.utc) + timedelta(days=30),
+            )
+        )
+        await session.commit()
+    return refresh_value
+
+
+async def live_count(sessionmaker, grant_id="g1") -> int:
+    async with sessionmaker() as session:
+        rows = (
+            await session.execute(
+                select(OAuthToken).where(
+                    OAuthToken.grant_id == grant_id,
+                    OAuthToken.revoked == False,  # noqa: E712
+                )
+            )
+        ).scalars().all()
+        return len(rows)
+
+
+# ── revocation vs rotation ────────────────────────────────────────────────
+
+
+async def _panel_revoke(sessionmaker, grant_id="g1"):
+    from src.oauth.grants import revoke_grant_family
+
+    async with sessionmaker() as session:
+        await revoke_grant_family(session, grant_id)
+        await session.commit()
+
+
+class _GatedSession:
+    """A real `AsyncSession` whose COMMIT waits for the test to say go.
+
+    Racing the two handlers with `asyncio.gather` and hoping for the bad
+    interleaving is not a test — measured, it reproduced the failure on the
+    first (cold-pool) attempt and not on the next seven, so a regression would
+    have been caught about one run in eight. This pins the interleaving
+    instead: the refresh reads its rows and inserts the new pair, then parks in
+    `commit()` while the revocation runs. That is exactly the window an
+    unlocked `UPDATE ... WHERE grant_id = :g` cannot see into.
+
+    The wait has a deadline because the *correct* implementation deliberately
+    deadlocks this construction: the refresh holds the advisory lock for its
+    whole transaction, so the revocation blocks in `lock_grant` and can never
+    open the gate. Timing out and letting the refresh commit is what lets the
+    same test assert the fixed behaviour rather than merely hanging.
+    """
+
+    def __init__(self, inner, gate, deadline):
+        self._inner = inner
+        self._gate = gate
+        self._deadline = deadline
+
+    def __getattr__(self, name):
+        return getattr(self._inner, name)
+
+    async def __aenter__(self):
+        await self._inner.__aenter__()
+        return self
+
+    async def __aexit__(self, *exc):
+        return await self._inner.__aexit__(*exc)
+
+    async def commit(self):
+        try:
+            await asyncio.wait_for(self._gate.wait(), timeout=self._deadline)
+        except asyncio.TimeoutError:
+            pass
+        return await self._inner.commit()
+
+
+async def test_a_revocation_reaches_a_pair_a_refresh_inserted_but_had_not_committed(
+    clean,
+):
+    """The failure the grant lock exists to prevent, pinned deterministically.
+
+    Under READ COMMITTED an `UPDATE ... WHERE grant_id = :g` takes its snapshot
+    when the statement starts, so rows a concurrent refresh has inserted but
+    not yet committed are invisible to it — and rows it inserted *after* that
+    snapshot stay invisible even once committed. The panel therefore revokes
+    every row it can see, reports success, and the client keeps the brand-new
+    pair it rotated into. Holding an advisory lock on the family across both
+    transactions is what removes the window: the revocation waits, then issues
+    its UPDATE on a fresh snapshot that includes the new rows.
+    """
+    sessionmaker = clean
+    await seed_client(sessionmaker)
+    refresh_value = await seed_grant(sessionmaker)
+
+    gate = asyncio.Event()
+
+    def _gated():
+        return _GatedSession(sessionmaker(), gate, deadline=1.0)
+
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(oauth, "async_session", _gated)
+        refresh_task = asyncio.create_task(
+            oauth._handle_refresh({"refresh_token": refresh_value, "client_id": "c1"})
+        )
+        # Let the refresh get as far as its (gated) commit.
+        await asyncio.sleep(0.15)
+
+        revoke_task = asyncio.create_task(_panel_revoke(sessionmaker))
+        # Give the revocation its chance to run to completion first. With the
+        # lock it cannot; without it, it finishes here and misses the new pair.
+        await asyncio.sleep(0.15)
+        gate.set()
+
+        response = await refresh_task
+        await revoke_task
+    finally:
+        monkeypatch.undo()
+
+    assert response.status_code == 200, "the refresh itself must still succeed"
+    assert await live_count(sessionmaker) == 0, (
+        "a token the refresh inserted survived a completed revocation"
+    )
+
+
+@pytest.mark.parametrize("attempt", range(4))
+async def test_a_revocation_leaves_no_live_token_racing_a_refresh(clean, attempt):
+    """The same invariant under ordinary scheduling, as a smoke check.
+
+    Whichever wins, the family must end with zero usable tokens: revoke first
+    and the refresh finds a revoked row and mints nothing; refresh first and
+    the revocation's UPDATE runs on a snapshot that includes its rows.
+    """
+    sessionmaker = clean
+    await seed_client(sessionmaker)
+    refresh_value = await seed_grant(sessionmaker)
+
+    results = await asyncio.gather(
+        oauth._handle_refresh({"refresh_token": refresh_value, "client_id": "c1"}),
+        _panel_revoke(sessionmaker),
+        return_exceptions=True,
+    )
+    for r in results:
+        assert not isinstance(r, BaseException), r
+
+    assert await live_count(sessionmaker) == 0, (
+        "a token survived a completed revocation"
+    )
+
+
+async def test_a_refresh_after_a_revocation_is_rejected(clean):
+    sessionmaker = clean
+    await seed_client(sessionmaker)
+    refresh_value = await seed_grant(sessionmaker)
+
+    await _panel_revoke(sessionmaker)
+    response = await oauth._handle_refresh(
+        {"refresh_token": refresh_value, "client_id": "c1"}
+    )
+
+    assert response.status_code == 400
+    assert await live_count(sessionmaker) == 0
+
+
+async def test_an_uncontended_refresh_still_rotates(clean):
+    """The lock must not make the ordinary path fail or hang."""
+    sessionmaker = clean
+    await seed_client(sessionmaker)
+    refresh_value = await seed_grant(sessionmaker)
+
+    response = await oauth._handle_refresh(
+        {"refresh_token": refresh_value, "client_id": "c1"}
+    )
+
+    assert response.status_code == 200
+    # Old access token + the new pair; the old refresh token is revoked.
+    assert await live_count(sessionmaker) == 3
+
+
+# ── concurrent first consent ──────────────────────────────────────────────
+
+
+class _Req:
+    def __init__(self, signed):
+        self.cookies = {"oauth_state": signed}
+        self.session = {}
+
+
+async def _consent(user_id, monkeypatch):
+    server_state = "csrfstatetoken1234567890"
+    signed = oauth._state_serializer().dumps(server_state)
+
+    class _U:
+        id = user_id
+
+    async def _resolve(_request, _session):
+        return _U()
+
+    monkeypatch.setattr(oauth, "get_active_session_user", _resolve)
+    return await oauth.authorize_post(
+        _Req(signed),
+        action="approve",
+        client_id="c1",
+        redirect_uri=REDIRECT_URI,
+        code_challenge="A" * 43,
+        code_challenge_method="S256",
+        scope="read",
+        state=server_state,
+        client_state="echo",
+    )
+
+
+async def test_two_users_consenting_at_once_produce_exactly_one_owner(
+    clean, monkeypatch_module
+):
+    """The conditional claim makes Postgres the arbitrator.
+
+    The unconditional ORM assignment it replaces let the loser overwrite the
+    winner's `user_id`, silently re-binding a client another user had just
+    claimed and minting a code under it.
+    """
+    sessionmaker = clean
+    monkeypatch_module.setattr(oauth.settings, "multi_user_mode", True, raising=False)
+    async with sessionmaker() as session:
+        for uid, name in ((1, "alice"), (2, "bob")):
+            session.add(
+                User(
+                    id=uid,
+                    username=name,
+                    password_hash="x",
+                    is_admin=False,
+                    is_active=True,
+                    session_version=1,
+                )
+            )
+        await session.commit()
+    await seed_client(sessionmaker, user_id=None)
+
+    # Two consents for the same unbound client, from two different users.
+    results = await asyncio.gather(
+        _consent(1, monkeypatch_module),
+        _consent(2, monkeypatch_module),
+        return_exceptions=True,
+    )
+    for r in results:
+        assert not isinstance(r, BaseException), r
+
+    statuses = sorted(getattr(r, "status_code", 0) for r in results)
+    assert statuses == [302, 403], statuses
+
+    async with sessionmaker() as session:
+        owner = (
+            await session.execute(
+                select(OAuthClient.user_id).where(OAuthClient.client_id == "c1")
+            )
+        ).scalar_one()
+        codes = (await session.execute(select(OAuthCode))).scalars().all()
+
+    assert owner in (1, 2)
+    assert len(codes) == 1, "only the winner may mint a code"
+    assert codes[0].user_id == owner
+
+    monkeypatch_module.setattr(
+        oauth.settings, "multi_user_mode", False, raising=False
+    )
+
+
+# ── client-authenticated revocation ───────────────────────────────────────
+
+
+class _FormReq:
+    def __init__(self, form):
+        self._form = form
+
+    async def form(self):
+        return self._form
+
+
+async def test_confidential_client_needs_its_secret_to_revoke(clean):
+    sessionmaker = clean
+    await seed_client(sessionmaker, confidential=True)
+    refresh_value = await seed_grant(sessionmaker)
+
+    denied = await oauth.revoke_token.__wrapped__(
+        _FormReq({"token": refresh_value, "client_id": "c1"})
+    )
+    assert denied.status_code == 401
+    assert await live_count(sessionmaker) == 2
+
+    allowed = await oauth.revoke_token.__wrapped__(
+        _FormReq({"token": refresh_value, "client_id": "c1", "client_secret": SECRET})
+    )
+    assert allowed.status_code == 200
+    assert await live_count(sessionmaker) == 0
+
+
+async def test_naming_another_client_is_a_200_that_does_nothing(clean):
+    sessionmaker = clean
+    await seed_client(sessionmaker)
+    refresh_value = await seed_grant(sessionmaker)
+
+    response = await oauth.revoke_token.__wrapped__(
+        _FormReq({"token": refresh_value, "client_id": "not-this-one"})
+    )
+
+    assert response.status_code == 200
+    assert await live_count(sessionmaker) == 2

--- a/tests/integration/test_oauth_grants_pg.py
+++ b/tests/integration/test_oauth_grants_pg.py
@@ -506,3 +506,30 @@ async def test_naming_another_client_is_a_200_that_does_nothing(clean):
 
     assert response.status_code == 200
     assert await live_count(sessionmaker) == 2
+
+
+async def test_omitting_client_id_revokes_nothing_even_for_a_public_client(clean):
+    """Absence is not a match, over real rows.
+
+    A public client carries no secret, so `_client_authenticated` passes
+    trivially. Had a missing `client_id` also counted as naming the right
+    client, posting somebody else's token value with no client field at all
+    would have ended their 30-day grant while proving nothing — and unlike
+    `/token`, no PKCE verifier binds this request to anyone.
+    """
+    sessionmaker = clean
+    await seed_client(sessionmaker)  # public: token_endpoint_auth_method='none'
+    refresh_value = await seed_grant(sessionmaker)
+
+    response = await oauth.revoke_token.__wrapped__(_FormReq({"token": refresh_value}))
+
+    assert response.status_code == 200, "still a uniform 200 (RFC 7009 §2.2)"
+    assert await live_count(sessionmaker) == 2, "nothing may be revoked"
+
+    # Naming the client is all it takes for the same public client to succeed,
+    # so the refusal above is about identification, not about public clients.
+    allowed = await oauth.revoke_token.__wrapped__(
+        _FormReq({"token": refresh_value, "client_id": "c1"})
+    )
+    assert allowed.status_code == 200
+    assert await live_count(sessionmaker) == 0

--- a/tests/integration/test_schema_check.py
+++ b/tests/integration/test_schema_check.py
@@ -1030,19 +1030,88 @@ def test_a_pre_existing_column_of_the_wrong_type_is_refused():
         assert column_shape(url, "oauth_tokens", "grant_id")[1] == "text"
 
 
-def test_a_squatting_index_name_is_refused():
-    """`CREATE INDEX IF NOT EXISTS` would silently keep the wrong index.
+# Every shape a `CREATE INDEX IF NOT EXISTS` would happily keep while
+# `alembic check` — which compares index *names* — reports the index installed.
+# "Which column is it on?" accepts most of these: a partial index covers a
+# subset of rows, an expression index cannot serve an equality lookup on the
+# column, a multi-column index leads with the wrong key, and an INVALID
+# leftover from a failed CREATE INDEX CONCURRENTLY is not usable at all.
+INDEX_IMPOSTORS = (
+    (
+        "wrong column",
+        "CREATE INDEX ix_oauth_tokens_grant_id ON oauth_tokens (token_type)",
+        "key columns are attnums",
+    ),
+    (
+        "partial",
+        "CREATE INDEX ix_oauth_tokens_grant_id ON oauth_tokens (grant_id) "
+        "WHERE token_type = 'access'",
+        "partial index",
+    ),
+    (
+        "expression",
+        "CREATE INDEX ix_oauth_tokens_grant_id ON oauth_tokens (lower(grant_id))",
+        "indexes an expression",
+    ),
+    (
+        "multi-column, right column second",
+        "CREATE INDEX ix_oauth_tokens_grant_id ON oauth_tokens (token_type, grant_id)",
+        "key columns are attnums",
+    ),
+    (
+        "multi-column, right column first",
+        "CREATE INDEX ix_oauth_tokens_grant_id ON oauth_tokens (grant_id, token_type)",
+        "key columns are attnums",
+    ),
+    (
+        "on another table",
+        "CREATE INDEX ix_oauth_tokens_grant_id ON oauth_codes (client_id)",
+        "indexes table",
+    ),
+)
 
-    `alembic check` compares index *names*, so an index of our name on another
-    column leaves the check permanently dirty while looking installed.
-    """
-    with throwaway_db("schema_grant_index_squat", revision="012") as url:
+
+@pytest.mark.parametrize(
+    "label, ddl, message",
+    INDEX_IMPOSTORS,
+    ids=[case[0] for case in INDEX_IMPOSTORS],
+)
+def test_a_squatting_index_name_is_refused(label, ddl, message):
+    """Anything under our name that is not exactly our index is refused."""
+    with throwaway_db(f"schema_grant_index_{abs(hash(label)) % 10**8}", revision="012") as url:
         seed_pre_014_tokens(url)
         add_bare_grant_id_column(url)
         sql(url, "UPDATE oauth_tokens SET grant_id = 'g-' || id::text")
+        sql(url, ddl)
+
+        result = _harness.run_alembic(
+            url, "upgrade", "head", dimensions=DIM, check=False
+        )
+
+        assert result.returncode != 0, label
+        combined = result.stdout + result.stderr
+        assert "ix_oauth_tokens_grant_id already exists" in combined, label
+        assert message in combined, combined[-2000:]
+        assert alembic_version(url) == "012"
+
+
+def test_an_invalid_index_of_our_name_is_refused():
+    """A failed `CREATE INDEX CONCURRENTLY` leaves an INVALID index behind.
+
+    It has the right name, the right table and the right key column, and it
+    cannot serve a single lookup. Only `pg_index.indisvalid` distinguishes it.
+    """
+    with throwaway_db("schema_grant_index_invalid", revision="012") as url:
+        seed_pre_014_tokens(url)
+        add_bare_grant_id_column(url)
+        sql(url, "UPDATE oauth_tokens SET grant_id = 'g-' || id::text")
+        sql(url, "CREATE INDEX ix_oauth_tokens_grant_id ON oauth_tokens (grant_id)")
+        # Postgres offers no supported way to invalidate an index, so mark it
+        # directly — the catalog state is what the migration reads.
         sql(
             url,
-            "CREATE INDEX ix_oauth_tokens_grant_id ON oauth_tokens (token_type)",
+            "UPDATE pg_index SET indisvalid = false WHERE indexrelid = "
+            "'ix_oauth_tokens_grant_id'::regclass",
         )
 
         result = _harness.run_alembic(
@@ -1050,8 +1119,26 @@ def test_a_squatting_index_name_is_refused():
         )
 
         assert result.returncode != 0
-        assert "already exists on column" in result.stdout + result.stderr
+        assert "INVALID" in result.stdout + result.stderr
         assert alembic_version(url) == "012"
+
+
+def test_the_genuine_index_is_accepted():
+    """The whole point of the checks above is not to reject our own index."""
+    with throwaway_db("schema_grant_index_ok", revision="012") as url:
+        seed_pre_014_tokens(url)
+        add_bare_grant_id_column(url)
+        sql(
+            url,
+            "UPDATE oauth_tokens SET grant_id = "
+            "  'hand-' || client_id || '-' || coalesce(user_id::text, 'null')",
+        )
+        sql(url, "CREATE INDEX ix_oauth_tokens_grant_id ON oauth_tokens (grant_id)")
+
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+
+        assert alembic_version(url) == "014"
+        assert_reconciled(url, marker_expected=False)
 
 
 def test_a_complete_pre_existing_column_is_accepted():

--- a/tests/integration/test_schema_check.py
+++ b/tests/integration/test_schema_check.py
@@ -907,3 +907,185 @@ def test_downgrade_014_removes_the_column_and_upgrade_rebuilds_it():
         _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
         assert len(set(grant_ids(url).values())) == EXPECTED_FAMILIES
         assert_reconciled(url, marker_expected=False)
+
+
+# --------------------------------------------------------------------------
+# 014 refuses a pre-existing column it cannot verify
+# --------------------------------------------------------------------------
+#
+# The backfill is a *partition* only because 014 created the column, so every
+# row is NULL and the grouping covers all of them. On a column somebody else
+# added, `WHERE grant_id IS NULL` becomes a patch: a NULL row beside a stamped
+# sibling gets a fresh id, one grant becomes two, and revoking either leaves
+# the other alive — the exact defect 014 exists to remove, reintroduced by the
+# migration. There is no safe repair, so it refuses, in 013's spirit.
+
+
+def add_bare_grant_id_column(url, coltype="varchar(64)"):
+    sql(url, f"ALTER TABLE oauth_tokens ADD COLUMN grant_id {coltype}")
+
+
+def test_partially_stamped_column_is_refused_not_backfilled():
+    """The case that would split a live pair across two families."""
+    with throwaway_db("schema_grant_partial", revision="012") as url:
+        seed_pre_014_tokens(url)
+        add_bare_grant_id_column(url)
+        # Alice's access token is stamped; its refresh sibling is not.
+        sql(
+            url,
+            "UPDATE oauth_tokens SET grant_id = 'preexisting-1' WHERE token_hash = $1",
+            "a" * 64,
+        )
+
+        result = _harness.run_alembic(
+            url, "upgrade", "head", dimensions=DIM, check=False
+        )
+
+        assert result.returncode != 0
+        combined = result.stdout + result.stderr
+        assert "are NULL" in combined
+        assert "splitting one grant into two" in combined
+
+        # Nothing changed: still at 012, the stamped row keeps its value, the
+        # siblings are still NULL, and no index was created.
+        assert alembic_version(url) == "012"
+        ids = grant_ids(url)
+        assert ids["a" * 64] == "preexisting-1"
+        assert ids["b" * 64] is None
+        assert column_shape(url, "oauth_tokens", "grant_id")[0] is False
+        assert fetchval(
+            url,
+            "SELECT indexdef FROM pg_indexes WHERE tablename = 'oauth_tokens' "
+            "AND indexname = 'ix_oauth_tokens_grant_id'",
+        ) is None
+
+
+def test_a_pre_existing_grant_spanning_two_users_is_refused():
+    """Adopting it would let one user's Revoke reach another user's grant.
+
+    Every family operation resolves a family as `grant_id == g`, with no
+    `user_id` predicate — deliberately, because a `user_id` predicate is how
+    incomplete revocation comes back. That is only safe while the invariant
+    holds, so a migration must never import values that break it.
+    """
+    with throwaway_db("schema_grant_cross_user", revision="012") as url:
+        seed_pre_014_tokens(url)
+        add_bare_grant_id_column(url)
+        # One id shared by alice's row and bob's row on the same client.
+        sql(url, "UPDATE oauth_tokens SET grant_id = 'shared'")
+
+        result = _harness.run_alembic(
+            url, "upgrade", "head", dimensions=DIM, check=False
+        )
+
+        assert result.returncode != 0
+        combined = result.stdout + result.stderr
+        assert "'shared'" in combined
+        assert "more than one" in combined
+
+        assert alembic_version(url) == "012"
+        assert set(grant_ids(url).values()) == {"shared"}
+
+
+def test_a_pre_existing_grant_mixing_null_and_real_owners_is_refused():
+    """`count(DISTINCT user_id)` skips NULLs, so this needs its own disjunct."""
+    with throwaway_db("schema_grant_null_owner_mix", revision="012") as url:
+        seed_pre_014_tokens(url)
+        add_bare_grant_id_column(url)
+        # Alice's client-b row and the single-user (NULL owner) client-b row.
+        sql(
+            url,
+            "UPDATE oauth_tokens SET grant_id = 'mixed' WHERE token_hash = ANY($1)",
+            ["e" * 64, "f" * 64],
+        )
+        sql(
+            url,
+            "UPDATE oauth_tokens SET grant_id = 'rest' WHERE grant_id IS NULL",
+        )
+
+        result = _harness.run_alembic(
+            url, "upgrade", "head", dimensions=DIM, check=False
+        )
+
+        assert result.returncode != 0
+        assert "'mixed'" in result.stdout + result.stderr
+        assert alembic_version(url) == "012"
+
+
+def test_a_pre_existing_column_of_the_wrong_type_is_refused():
+    """014 completes a column it can verify; it does not adopt a stranger."""
+    with throwaway_db("schema_grant_wrong_type", revision="012") as url:
+        seed_pre_014_tokens(url)
+        add_bare_grant_id_column(url, coltype="text")
+        sql(url, "UPDATE oauth_tokens SET grant_id = 'g-' || id::text")
+
+        result = _harness.run_alembic(
+            url, "upgrade", "head", dimensions=DIM, check=False
+        )
+
+        assert result.returncode != 0
+        combined = result.stdout + result.stderr
+        assert "already exists as text" in combined
+        assert alembic_version(url) == "012"
+        assert column_shape(url, "oauth_tokens", "grant_id")[1] == "text"
+
+
+def test_a_squatting_index_name_is_refused():
+    """`CREATE INDEX IF NOT EXISTS` would silently keep the wrong index.
+
+    `alembic check` compares index *names*, so an index of our name on another
+    column leaves the check permanently dirty while looking installed.
+    """
+    with throwaway_db("schema_grant_index_squat", revision="012") as url:
+        seed_pre_014_tokens(url)
+        add_bare_grant_id_column(url)
+        sql(url, "UPDATE oauth_tokens SET grant_id = 'g-' || id::text")
+        sql(
+            url,
+            "CREATE INDEX ix_oauth_tokens_grant_id ON oauth_tokens (token_type)",
+        )
+
+        result = _harness.run_alembic(
+            url, "upgrade", "head", dimensions=DIM, check=False
+        )
+
+        assert result.returncode != 0
+        assert "already exists on column" in result.stdout + result.stderr
+        assert alembic_version(url) == "012"
+
+
+def test_a_complete_pre_existing_column_is_accepted():
+    """The benign case: someone applied 014's shape by hand, consistently.
+
+    Nothing has to be guessed here — every row has an id and no id spans two
+    owners — so the migration completes rather than refusing, and leaves the
+    existing values alone.
+    """
+    with throwaway_db("schema_grant_preexisting_ok", revision="012") as url:
+        seed_pre_014_tokens(url)
+        add_bare_grant_id_column(url)
+        # One id per (client_id, user_id), exactly what 014 would have derived.
+        sql(
+            url,
+            "UPDATE oauth_tokens SET grant_id = "
+            "  'hand-' || client_id || '-' || coalesce(user_id::text, 'null')",
+        )
+        before = grant_ids(url)
+
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+
+        assert alembic_version(url) == "014"
+        assert grant_ids(url) == before, "existing ids must be left alone"
+        assert column_shape(url, "oauth_tokens", "grant_id")[0] is True
+        assert_reconciled(url, marker_expected=False)
+
+
+def test_an_empty_table_with_a_nullable_column_completes():
+    """Nothing to guess, so nothing to refuse."""
+    with throwaway_db("schema_grant_empty_preexisting", revision="012") as url:
+        add_bare_grant_id_column(url)
+
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+
+        assert alembic_version(url) == "014"
+        assert column_shape(url, "oauth_tokens", "grant_id")[0] is True

--- a/tests/integration/test_schema_check.py
+++ b/tests/integration/test_schema_check.py
@@ -1066,7 +1066,7 @@ INDEX_IMPOSTORS = (
     (
         "on another table",
         "CREATE INDEX ix_oauth_tokens_grant_id ON oauth_codes (client_id)",
-        "indexes table",
+        "indexes another relation",
     ),
 )
 
@@ -1121,6 +1121,54 @@ def test_an_invalid_index_of_our_name_is_refused():
         assert result.returncode != 0
         assert "INVALID" in result.stdout + result.stderr
         assert alembic_version(url) == "012"
+
+
+def test_an_index_of_our_name_in_another_schema_is_ignored():
+    """Namespace, not bare name: a shadow schema is not our schema.
+
+    `CREATE INDEX` places an index in its table's schema, so
+    `shadow.ix_oauth_tokens_grant_id` cannot collide with anything 014 creates
+    and says nothing about `oauth_tokens`. A lookup matching `relname` across
+    every schema found it anyway and refused a database that was perfectly
+    fine — the migration would have been unrunnable until an unrelated object
+    somebody else owns was dropped.
+    """
+    with throwaway_db("schema_grant_index_shadow", revision="012") as url:
+        seed_pre_014_tokens(url)
+        # The index check only runs on the pre-existing-column path, so the
+        # column has to be there for this case to reach it at all.
+        add_bare_grant_id_column(url)
+        sql(
+            url,
+            "UPDATE oauth_tokens SET grant_id = "
+            "  'hand-' || client_id || '-' || coalesce(user_id::text, 'null')",
+        )
+        sql(url, "CREATE SCHEMA shadow")
+        sql(url, "CREATE TABLE shadow.decoy (grant_id text, token_type text)")
+        # Same name, same column name, different schema — and partial, so the
+        # old bare-name lookup would have rejected it as an impostor rather
+        # than merely mis-identifying it.
+        sql(
+            url,
+            "CREATE INDEX ix_oauth_tokens_grant_id ON shadow.decoy (grant_id) "
+            "WHERE token_type = 'access'",
+        )
+
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+
+        assert alembic_version(url) == "014"
+        assert_reconciled(url, marker_expected=False)
+        # Ours was created in the table's own schema, and the decoy is untouched.
+        assert fetchval(
+            url,
+            "SELECT count(*) FROM pg_indexes WHERE indexname = "
+            "'ix_oauth_tokens_grant_id'",
+        ) == 2
+        assert fetchval(
+            url,
+            "SELECT indexdef FROM pg_indexes WHERE indexname = "
+            "'ix_oauth_tokens_grant_id' AND schemaname = 'public'",
+        ) is not None
 
 
 def test_the_genuine_index_is_accepted():

--- a/tests/integration/test_schema_check.py
+++ b/tests/integration/test_schema_check.py
@@ -341,7 +341,7 @@ def insert_null_rows(url: str):
 def test_fresh_database_is_clean_and_enforced():
     """(a) An empty database migrated to head needs no further operations."""
     with throwaway_db("schema_fresh") as url:
-        assert alembic_version(url) == "013"
+        assert alembic_version(url) == "014"
         # No marker: 010 created this constraint and 013 recognised it as
         # already correct. That distinction is what downgrade() reads.
         assert_reconciled(url, marker_expected=False)
@@ -678,7 +678,7 @@ def test_rerunning_013_changes_nothing():
         assert alembic_version(url) == "012"
         _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
 
-        assert alembic_version(url) == "013"
+        assert alembic_version(url) == "014"
         assert (constraint_row(url), not_null_flags(url)) == before
         assert_reconciled(url, marker_expected=False)
 
@@ -709,3 +709,201 @@ def test_downgrade_drops_the_constraint_013_created():
         assert alembic_version(url) == "012"
         assert constraint_row(url) is None
         assert all(not_null_flags(url).values())
+
+
+# --------------------------------------------------------------------------
+# migration 014: oauth_tokens.grant_id (issue #64)
+# --------------------------------------------------------------------------
+#
+# `alembic check` sees the column, its nullability and its index, so
+# `assert_reconciled` above already covers the declarative half on every path.
+# What it cannot see is the *backfill*, and the backfill is where a migration
+# could invent a grant — splitting one family into two, so a revocation misses
+# half of it — or destroy one, by merging two users into a single family, so
+# revoking one user's grant kills another's. Those are the cases here.
+
+
+def insert_user(url, user_id: int, username: str):
+    sql(
+        url,
+        "INSERT INTO users (id, username, password_hash, is_admin, is_active, "
+        "session_version) VALUES ($1, $2, 'x', false, true, 1)",
+        user_id,
+        username,
+    )
+
+
+def insert_token(
+    url,
+    token_hash,
+    client_id,
+    *,
+    user_id=None,
+    token_type="access",
+    revoked=False,
+    scope="read",
+):
+    sql(
+        url,
+        "INSERT INTO oauth_tokens (token_hash, token_type, client_id, scope, "
+        "user_id, expires_at, revoked) VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        token_hash,
+        token_type,
+        client_id,
+        scope,
+        user_id,
+        FUTURE,
+        revoked,
+    )
+
+
+def grant_ids(url) -> dict[str, str]:
+    rows = fetch(url, "SELECT token_hash, grant_id FROM oauth_tokens")
+    return {row["token_hash"]: row["grant_id"] for row in rows}
+
+
+def seed_pre_014_tokens(url):
+    """Two users, two clients, revoked and live rows, and a NULL-user row."""
+    insert_user(url, 1, "alice")
+    insert_user(url, 2, "bob")
+    insert_client(url, "client-a", "none", None)
+    insert_client(url, "client-b", "none", None)
+
+    # Alice's grant on client-a: a live pair plus a rotated-away refresh token.
+    insert_token(url, "a" * 64, "client-a", user_id=1, token_type="access")
+    insert_token(url, "b" * 64, "client-a", user_id=1, token_type="refresh")
+    insert_token(url, "c" * 64, "client-a", user_id=1, token_type="refresh", revoked=True)
+    # Bob authorized the same client — a different grant entirely.
+    insert_token(url, "d" * 64, "client-a", user_id=2, token_type="access")
+    # Alice on a second client.
+    insert_token(url, "e" * 64, "client-b", user_id=1, token_type="access")
+    # Single-user-mode row: user_id IS NULL. `NULL = NULL` is NULL, so an `=`
+    # join in the backfill would leave this one unmatched and the SET NOT NULL
+    # would fail — which is why it uses IS NOT DISTINCT FROM.
+    insert_token(url, "f" * 64, "client-b", user_id=None, token_type="access")
+
+
+EXPECTED_FAMILIES = 4  # (a,alice) (a,bob) (b,alice) (b,NULL)
+
+
+def test_grant_id_is_not_null_and_indexed_on_a_fresh_database():
+    with throwaway_db("schema_grant_fresh") as url:
+        attnotnull, coltype, _ = column_shape(url, "oauth_tokens", "grant_id")
+        assert attnotnull is True, (
+            "grant_id must be NOT NULL — the decision in #64 was explicit that "
+            "a nullable grant_id with a fallback 'find the family' path is how "
+            "the bug comes back"
+        )
+        assert coltype == "character varying(64)"
+        # The name is what autogenerate expects for `index=True`; anything else
+        # leaves `alembic check` permanently dirty.
+        assert fetchval(
+            url,
+            "SELECT indexdef FROM pg_indexes WHERE tablename = 'oauth_tokens' "
+            "AND indexname = 'ix_oauth_tokens_grant_id'",
+        ) is not None
+
+
+def test_backfill_gives_one_grant_per_client_and_user():
+    """The decided approximation, stated precisely.
+
+    Pre-014 rows carry no family, so one is assigned per distinct
+    `(client_id, user_id)`. Concurrent sessions of the same connector collapse
+    into one family — over-revoking, never under-revoking — and every grant
+    issued after the migration is exact.
+    """
+    with throwaway_db("schema_grant_backfill", revision="012") as url:
+        seed_pre_014_tokens(url)
+
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+
+        ids = grant_ids(url)
+        assert all(ids.values()), "no row may be left without a family"
+
+        alice_client_a = {ids["a" * 64], ids["b" * 64], ids["c" * 64]}
+        assert len(alice_client_a) == 1, (
+            "one user's rows on one client are one family — including the "
+            "revoked one, which is what lets the panel show revocation history"
+        )
+        assert len(set(ids.values())) == EXPECTED_FAMILIES
+
+
+def test_backfill_never_merges_two_users_into_one_family():
+    """The invariant every family operation leans on.
+
+    `src/oauth/grants.py` resolves a family as `grant_id == g` and deliberately
+    does *not* re-filter by `user_id` — a user predicate there would give
+    incomplete revocation a way back in. That is only safe because a family
+    cannot span users, which is what this asserts.
+    """
+    with throwaway_db("schema_grant_no_merge", revision="012") as url:
+        seed_pre_014_tokens(url)
+
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+
+        rows = fetch(
+            url,
+            "SELECT grant_id, count(DISTINCT coalesce(user_id, -1)) AS users "
+            "FROM oauth_tokens GROUP BY grant_id",
+        )
+        assert rows
+        assert all(row["users"] == 1 for row in rows), rows
+
+
+def test_backfill_does_not_split_a_users_rows_across_families():
+    """The other direction: a split family is a revocation that misses half."""
+    with throwaway_db("schema_grant_no_split", revision="012") as url:
+        seed_pre_014_tokens(url)
+
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+
+        rows = fetch(
+            url,
+            "SELECT client_id, coalesce(user_id, -1) AS uid, "
+            "       count(DISTINCT grant_id) AS families "
+            "FROM oauth_tokens GROUP BY client_id, user_id",
+        )
+        assert rows
+        assert all(row["families"] == 1 for row in rows), rows
+
+
+def test_rerunning_014_does_not_re_stamp_existing_grants():
+    """Idempotence that actually re-executes the body.
+
+    A second `upgrade head` is a no-op at the alembic level. Stamping back to
+    013 forces 014 to run again against a database that already satisfies it —
+    and re-partitioning live grants there would silently break every revocation
+    and downgrade issued before the re-run.
+    """
+    with throwaway_db("schema_grant_idempotent", revision="012") as url:
+        seed_pre_014_tokens(url)
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+        before = grant_ids(url)
+
+        _harness.run_alembic(url, "stamp", "013", dimensions=DIM)
+        assert alembic_version(url) == "013"
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+
+        assert alembic_version(url) == "014"
+        assert grant_ids(url) == before
+        assert column_shape(url, "oauth_tokens", "grant_id")[0] is True
+
+
+def test_downgrade_014_removes_the_column_and_upgrade_rebuilds_it():
+    with throwaway_db("schema_grant_downgrade", revision="012") as url:
+        seed_pre_014_tokens(url)
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+
+        _harness.run_alembic(url, "downgrade", "013", dimensions=DIM)
+        assert alembic_version(url) == "013"
+        assert column_shape(url, "oauth_tokens", "grant_id") is None
+        assert fetchval(
+            url,
+            "SELECT indexdef FROM pg_indexes WHERE tablename = 'oauth_tokens' "
+            "AND indexname = 'ix_oauth_tokens_grant_id'",
+        ) is None
+
+        # Re-upgrading re-derives the same approximation from (client_id, user_id).
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+        assert len(set(grant_ids(url).values())) == EXPECTED_FAMILIES
+        assert_reconciled(url, marker_expected=False)

--- a/tests/test_chatgpt_oauth.py
+++ b/tests/test_chatgpt_oauth.py
@@ -41,7 +41,12 @@ class _Session:
     async def __aexit__(self, *_exc):
         return False
 
-    async def execute(self, _query):
+    async def execute(self, query, params=None):
+        # The token handlers now take a transaction-scoped advisory lock before
+        # they read anything (see src/oauth/grants.py). It consumes no canned
+        # result, so skip it rather than letting it shift the sequence.
+        if "pg_advisory_xact_lock" in str(query):
+            return _Result(None)
         return _Result(next(self.results))
 
     def add(self, value):

--- a/tests/test_issue_21_registered_scope_enforced.py
+++ b/tests/test_issue_21_registered_scope_enforced.py
@@ -169,5 +169,10 @@ def test_clamp_scope_helper():
     assert routes._clamp_scope("readwrite", "readwrite") == "readwrite"
     # readwrite registration implies read availability
     assert routes._clamp_scope("read", "readwrite") == "read"
-    # empty intersection falls back to safe default
-    assert routes._clamp_scope("", "read") == "read"
+    # No vault scope on either side is a *refusal*, not a fallback to `read`.
+    # The old `or "read"` conflated the legitimate readwrite->read downgrade
+    # above with "this client is registered for nothing", so a DCR client
+    # registered `scope="offline_access"` was handed read access to the whole
+    # vault. Every caller now turns an empty result into an error.
+    assert routes._clamp_scope("", "read") == ""
+    assert routes._clamp_scope("read", "offline_access") == ""

--- a/tests/test_issue_4_authorize_post_redirect_validation.py
+++ b/tests/test_issue_4_authorize_post_redirect_validation.py
@@ -38,6 +38,7 @@ try:
 
     import pytest
     from fastapi.responses import JSONResponse, RedirectResponse
+    from sqlalchemy.sql.dml import Update
 
     from src.oauth import routes
 finally:
@@ -79,7 +80,19 @@ class _FakeSession:
     async def __aexit__(self, *exc):
         return False
 
-    async def execute(self, _stmt):
+    async def execute(self, stmt, *_a, **_kw):
+        # The first-authorizer claim is a conditional `UPDATE oauth_clients ...
+        # WHERE user_id IS NULL RETURNING client_id` rather than an ORM
+        # attribute assignment, so two concurrent consents for the same unbound
+        # client are arbitrated by the database instead of by whichever
+        # transaction's snapshot was read last. Interpreting it here keeps the
+        # fake honest: the claim applies only when the row really is unowned,
+        # and returns nothing when it is not.
+        if isinstance(stmt, Update):
+            if self._client is not None and self._client.user_id is None:
+                self._client.user_id = dict(stmt.compile().params).get("user_id")
+                return _FakeResult(self._client.client_id)
+            return _FakeResult(None)
         return _FakeResult(self._client)
 
     def add(self, obj):

--- a/tests/test_issue_64_grant_families.py
+++ b/tests/test_issue_64_grant_families.py
@@ -30,6 +30,7 @@ from src.oauth import routes as oauth
 from src.oauth.grants import grant_lock_key, new_grant_id
 
 from _oauth_grant_fakes import (
+    SeqSession,
     FakeClient,
     FakeSession,
     FakeToken,
@@ -82,36 +83,6 @@ def live_family(grant_id="g1", scope="offline_access readwrite", user_id=None):
 # --- the identifier is stamped at issue and inherited by rotation ---------
 
 
-class _SeqSession:
-    """Returns canned rows in call order -- enough for `_handle_auth_code`."""
-
-    def __init__(self, results):
-        self._results = iter(results)
-        self.added = []
-        self.committed = False
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *_exc):
-        return False
-
-    async def execute(self, _stmt, *_a, **_kw):
-        value = next(self._results)
-
-        class _R:
-            def scalar_one_or_none(self_inner):
-                return value
-
-        return _R()
-
-    def add(self, obj):
-        self.added.append(obj)
-
-    async def commit(self):
-        self.committed = True
-
-
 def test_auth_code_exchange_puts_both_tokens_in_one_grant(monkeypatch):
     """One consent event, one family. Not two, and not none."""
     from datetime import datetime, timedelta, timezone
@@ -137,7 +108,7 @@ def test_auth_code_exchange_puts_both_tokens_in_one_grant(monkeypatch):
         expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
         used=False,
     )
-    session = _SeqSession([code, client])
+    session = SeqSession([code, client])
     monkeypatch.setattr(oauth, "async_session", lambda: session)
 
     response = asyncio.run(

--- a/tests/test_issue_64_grant_families.py
+++ b/tests/test_issue_64_grant_families.py
@@ -282,7 +282,11 @@ def test_rfc_revocation_endpoint_kills_the_whole_family(monkeypatch):
     monkeypatch.setattr(oauth, "async_session", lambda: session)
 
     response = asyncio.run(
-        oauth.revoke_token.__wrapped__(_FormRequest({"token": "access-secret"}))
+        oauth.revoke_token.__wrapped__(
+            # `client_id` must be present and match — its absence is not a
+            # match. See tests/test_issue_64_revocation_endpoint_auth.py.
+            _FormRequest({"token": "access-secret", "client_id": "client123"})
+        )
     )
 
     assert response.status_code == 200

--- a/tests/test_issue_64_grant_families.py
+++ b/tests/test_issue_64_grant_families.py
@@ -1,0 +1,448 @@
+"""Issue #64: revocation and downgrade must act on the grant, not one row.
+
+Before `oauth_tokens.grant_id` (migration 014) nothing tied an access token to
+the refresh token minted beside it, so the panel could only offer per-row
+controls -- and both of them were near no-ops:
+
+* **Revoke** flipped one row. `_handle_refresh` resolves purely on
+  `token_hash` + `token_type` + `revoked`, so the untouched sibling refresh
+  token minted a fresh, identically-scoped pair on the client's next ordinary
+  401 retry. Access tokens live one hour, so per-row Revoke on an access token
+  bought at most that hour and then restored the identical capability.
+* **Downgrade** wrote one row's scope, and `_handle_refresh` copies the
+  *refresh* token's scope -- so a downgrade applied to the access row silently
+  restored itself on the next rotation. That is worse than the display bug #62
+  fixed: it hands back write access the owner believed they had removed.
+
+Every test here is written against the specific claims an adversarial reviewer
+was told to look for: a revocation that does not stick after a refresh, a
+downgrade that reverts, and a family write that reaches a grant it should not.
+"""
+import asyncio
+import json
+
+import pytest
+from fastapi.responses import RedirectResponse
+
+from src.control_panel import routes as panel
+from src.models.db import OAuthToken
+from src.oauth import routes as oauth
+from src.oauth.grants import grant_lock_key, new_grant_id
+
+from _oauth_grant_fakes import (
+    FakeClient,
+    FakeSession,
+    FakeToken,
+    SingleUserSentinel,
+    in_hours,
+)
+
+
+REFRESH_SECRET = "r" * 64
+OTHER_REFRESH_SECRET = "s" * 64
+
+
+def refresh(session, monkeypatch, token=REFRESH_SECRET, client_id=None):
+    monkeypatch.setattr(oauth, "async_session", lambda: session)
+    form = {"refresh_token": token}
+    if client_id:
+        form["client_id"] = client_id
+    return asyncio.run(oauth._handle_refresh(form))
+
+
+def body(response) -> dict:
+    return json.loads(response.body)
+
+
+def minted(session) -> list[OAuthToken]:
+    return [obj for obj in session.added if isinstance(obj, OAuthToken)]
+
+
+def live_family(grant_id="g1", scope="offline_access readwrite", user_id=None):
+    """The two rows one consent produces."""
+    return [
+        FakeToken(
+            grant_id=grant_id,
+            token_type="access",
+            scope=scope,
+            user_id=user_id,
+            expires_at=in_hours(1),
+        ),
+        FakeToken(
+            grant_id=grant_id,
+            token_type="refresh",
+            scope=scope,
+            user_id=user_id,
+            expires_at=in_hours(720),
+            token_hash=oauth._hash(REFRESH_SECRET),
+        ),
+    ]
+
+
+# --- the identifier is stamped at issue and inherited by rotation ---------
+
+
+class _SeqSession:
+    """Returns canned rows in call order -- enough for `_handle_auth_code`."""
+
+    def __init__(self, results):
+        self._results = iter(results)
+        self.added = []
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def execute(self, _stmt, *_a, **_kw):
+        value = next(self._results)
+
+        class _R:
+            def scalar_one_or_none(self_inner):
+                return value
+
+        return _R()
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+
+def test_auth_code_exchange_puts_both_tokens_in_one_grant(monkeypatch):
+    """One consent event, one family. Not two, and not none."""
+    from datetime import datetime, timedelta, timezone
+
+    from src.models.db import OAuthClient, OAuthCode
+
+    verifier = "v" * 64
+    client = OAuthClient(
+        client_id="client123",
+        client_secret_hash=None,
+        token_endpoint_auth_method="none",
+        client_name="Claude",
+        redirect_uris=["https://example.test/cb"],
+        scope="read readwrite offline_access",
+    )
+    code = OAuthCode(
+        code_hash=oauth._hash("the-code"),
+        client_id=client.client_id,
+        redirect_uri=client.redirect_uris[0],
+        scope="offline_access readwrite",
+        code_challenge=oauth._base64url_sha256(verifier),
+        code_challenge_method="S256",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        used=False,
+    )
+    session = _SeqSession([code, client])
+    monkeypatch.setattr(oauth, "async_session", lambda: session)
+
+    response = asyncio.run(
+        oauth._handle_auth_code(
+            {
+                "code": "the-code",
+                "code_verifier": verifier,
+                "redirect_uri": client.redirect_uris[0],
+            }
+        )
+    )
+
+    assert response.status_code == 200
+    pair = minted(session)
+    assert len(pair) == 2
+    assert {t.token_type for t in pair} == {"access", "refresh"}
+    grants = {t.grant_id for t in pair}
+    assert len(grants) == 1, "the pair must share one grant_id"
+    assert grants != {None} and all(t.grant_id for t in pair)
+
+
+def test_rotation_stays_inside_the_grant_it_rotated(monkeypatch):
+    session = FakeSession(clients=[FakeClient()], tokens=live_family())
+    response = refresh(session, monkeypatch)
+
+    assert response.status_code == 200
+    pair = minted(session)
+    assert len(pair) == 2
+    assert {t.grant_id for t in pair} == {"g1"}
+
+
+def test_grant_ids_are_opaque_and_distinct():
+    assert new_grant_id() != new_grant_id()
+    assert len(new_grant_id()) >= 22
+
+
+# --- revocation sticks, including across a refresh -----------------------
+
+
+def revoke_via_panel(session, token_id):
+    return asyncio.run(
+        panel.revoke_oauth_token(
+            token_id=token_id,
+            session=session,
+            user=SingleUserSentinel(),
+        )
+    )
+
+
+def test_revoking_the_access_row_kills_the_refresh_token_too():
+    """The headline defect. One click, both rows, no survivor to rotate with."""
+    family = live_family()
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+
+    response = revoke_via_panel(session, family[0].id)  # the *access* row
+
+    assert isinstance(response, RedirectResponse)
+    assert all(t.revoked for t in family)
+    assert session.committed == 1
+
+
+def test_a_revoked_grant_cannot_be_refreshed(monkeypatch):
+    """The property an auditor was told to attack: revocation after refresh.
+
+    Revoking used to leave `_handle_refresh` a live refresh token to work
+    with, so the client's next 401 retry silently restored the grant.
+    """
+    family = live_family()
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+    revoke_via_panel(session, family[0].id)
+
+    response = refresh(session, monkeypatch)
+
+    assert response.status_code == 400
+    assert body(response)["error"] == "invalid_grant"
+    assert minted(session) == []
+
+
+def test_revocation_reaches_a_pair_minted_by_an_earlier_rotation(monkeypatch):
+    """Rotation leaves the previous access token live; revocation must not.
+
+    `_handle_refresh` deliberately lets the old access token run to its natural
+    expiry -- fine for rotation, wrong for revocation. Every row in the family
+    that is still usable has to die.
+    """
+    family = live_family()
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+    refresh(session, monkeypatch)
+
+    # Model what the commit would have persisted: the rotated-in pair joins the
+    # family, and the old refresh token is revoked.
+    rotated = [
+        FakeToken(
+            grant_id=t.grant_id,
+            token_type=t.token_type,
+            scope=t.scope,
+            user_id=t.user_id,
+            expires_at=in_hours(1 if t.token_type == "access" else 720),
+        )
+        for t in minted(session)
+    ]
+    session.tokens.extend(rotated)
+
+    revoke_via_panel(session, family[0].id)
+
+    assert all(t.revoked for t in session.tokens), session.tokens
+
+
+def test_revocation_does_not_touch_a_different_grant():
+    """A second concurrent session of the same client is its own family."""
+    keep = FakeToken(grant_id="g2", token_type="access", scope="readwrite")
+    family = live_family()
+    session = FakeSession(clients=[FakeClient()], tokens=family + [keep])
+
+    revoke_via_panel(session, family[1].id)
+
+    assert all(t.revoked for t in family)
+    assert keep.revoked is False
+
+
+def test_revocation_takes_the_family_lock_before_writing():
+    """Ordering, not politeness.
+
+    An `UPDATE ... WHERE grant_id = :g` takes its snapshot when the statement
+    starts, so rows a concurrent refresh *inserts* afterwards are invisible to
+    it. Locking the family first is the only thing that makes the revocation
+    cover the pair the client rotated into a moment later.
+    """
+    family = live_family()
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+
+    revoke_via_panel(session, family[0].id)
+
+    assert session.locked_grants == [grant_lock_key("g1")]
+
+
+def test_refresh_takes_the_same_lock_before_reading_the_family(monkeypatch):
+    session = FakeSession(clients=[FakeClient()], tokens=live_family())
+    refresh(session, monkeypatch)
+
+    assert session.locked_grants == [grant_lock_key("g1")]
+
+
+def test_grant_lock_key_is_stable_and_grant_specific():
+    assert grant_lock_key("g1") == grant_lock_key("g1")
+    assert grant_lock_key("g1") != grant_lock_key("g2")
+    assert -(2 ** 63) <= grant_lock_key("g1") < 2 ** 63
+
+
+# --- the RFC 7009 endpoint is grant-scoped too ---------------------------
+
+
+class _FormRequest:
+    def __init__(self, form):
+        self._form = form
+
+    async def form(self):
+        return self._form
+
+
+def test_rfc_revocation_endpoint_kills_the_whole_family(monkeypatch):
+    """Otherwise `/revoke` on an access token is the same near no-op.
+
+    RFC 7009 §2.1 explicitly permits revoking the associated refresh token,
+    and anything narrower means a client told "revoked" keeps rotating.
+    """
+    family = live_family()
+    access = family[0]
+    access.token_hash = oauth._hash("access-secret")
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+    monkeypatch.setattr(oauth, "async_session", lambda: session)
+
+    response = asyncio.run(
+        oauth.revoke_token.__wrapped__(_FormRequest({"token": "access-secret"}))
+    )
+
+    assert response.status_code == 200
+    assert all(t.revoked for t in family)
+
+
+# --- a downgrade applies to the family and survives rotation -------------
+
+
+def downgrade_via_panel(session, token_id, scope="read"):
+    return asyncio.run(
+        panel.update_oauth_token_scope(
+            token_id=token_id,
+            scope=scope,
+            session=session,
+            user=SingleUserSentinel(),
+        )
+    )
+
+
+def test_downgrading_the_access_row_also_downgrades_the_refresh_row():
+    family = live_family(scope="offline_access readwrite")
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+
+    downgrade_via_panel(session, family[0].id)  # the *access* row
+
+    for token in family:
+        assert "readwrite" not in token.scope.split(), token
+        assert "read" in token.scope.split()
+
+
+def test_a_downgrade_does_not_revert_on_the_next_refresh(monkeypatch):
+    """The exact scenario in the issue, end to end.
+
+    Owner flips the access row to `read`; the connector refreshes within the
+    hour; the new pair must not come back `readwrite`.
+    """
+    family = live_family(scope="offline_access readwrite")
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+
+    downgrade_via_panel(session, family[0].id)
+    response = refresh(session, monkeypatch)
+
+    assert response.status_code == 200
+    assert "readwrite" not in body(response)["scope"].split()
+    for token in minted(session):
+        assert "readwrite" not in token.scope.split(), token
+
+
+def test_downgrading_the_refresh_row_also_downgrades_the_live_access_token():
+    """The issue's converse: the existing access token stayed write-capable."""
+    family = live_family(scope="offline_access readwrite")
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+
+    downgrade_via_panel(session, family[1].id)  # the *refresh* row
+
+    assert "readwrite" not in family[0].scope.split()
+
+
+def test_a_downgrade_does_not_reach_another_grant():
+    other = FakeToken(grant_id="g2", token_type="access", scope="readwrite")
+    family = live_family(scope="offline_access readwrite")
+    session = FakeSession(clients=[FakeClient()], tokens=family + [other])
+
+    downgrade_via_panel(session, family[0].id)
+
+    assert other.scope == "readwrite"
+
+
+def test_a_revoked_row_keeps_the_scope_it_died_with():
+    """History must record what the token carried, not what replaced it."""
+    dead = FakeToken(grant_id="g1", token_type="access", scope="readwrite", revoked=True)
+    family = live_family(scope="offline_access readwrite")
+    session = FakeSession(clients=[FakeClient()], tokens=[dead] + family)
+
+    downgrade_via_panel(session, family[0].id)
+
+    assert dead.scope == "readwrite"
+
+
+def test_upgrading_is_also_family_wide():
+    """Not only downgrades -- the control writes one scope for the grant."""
+    family = live_family(scope="offline_access read")
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+
+    downgrade_via_panel(session, family[0].id, scope="readwrite")
+
+    for token in family:
+        assert "readwrite" in token.scope.split()
+
+
+def test_an_unknown_scope_value_writes_nothing():
+    family = live_family(scope="offline_access readwrite")
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+
+    downgrade_via_panel(session, family[0].id, scope="admin")
+
+    assert session.committed == 0
+    for token in family:
+        assert "readwrite" in token.scope.split()
+
+
+@pytest.mark.parametrize("handler", ["revoke", "scope"])
+def test_family_writes_refuse_a_token_owned_by_another_user(handler):
+    """`_assert_oauth_token_owner` still guards the handle, not just the row."""
+    from fastapi import HTTPException
+
+    family = live_family(user_id=1)
+    session = FakeSession(clients=[FakeClient(user_id=1)], tokens=family)
+
+    class _OtherUser:
+        id = 2
+        is_admin = False
+        username = "mallory"
+
+    with pytest.raises(HTTPException) as exc:
+        if handler == "revoke":
+            asyncio.run(
+                panel.revoke_oauth_token(
+                    token_id=family[0].id, session=session, user=_OtherUser()
+                )
+            )
+        else:
+            asyncio.run(
+                panel.update_oauth_token_scope(
+                    token_id=family[0].id,
+                    scope="readwrite",
+                    session=session,
+                    user=_OtherUser(),
+                )
+            )
+
+    assert exc.value.status_code == 403
+    assert not any(t.revoked for t in family)

--- a/tests/test_issue_64_ownerless_token_mint.py
+++ b/tests/test_issue_64_ownerless_token_mint.py
@@ -1,0 +1,249 @@
+"""No token may be minted without an owner while multi-user mode is on.
+
+`register_submit` turns a single-user deployment into a multi-user one by
+claiming every ownerless row for the first admin:
+``UPDATE oauth_tokens SET user_id = <admin> WHERE user_id IS NULL``. Under READ
+COMMITTED that statement's snapshot is taken when it starts, so a token
+exchange or a refresh that commits *afterwards* inserts rows the claim can no
+longer see. They survive as tokens belonging to nobody — outside
+`_assert_oauth_token_owner`, outside the panel's per-user filters, and outside
+the vault-root lookup.
+
+Two things close it, and both are pinned here:
+
+* both mint handlers take the **same** transaction-scoped advisory lock the
+  bootstrap already holds for its claim, so a mint and the claim cannot
+  interleave at all; and
+* with `multi_user_mode` on, a mint whose `user_id` would be NULL is refused
+  outright, so even a row that somehow escaped the claim cannot be rotated into
+  a fresh ownerless pair.
+
+The lock order (bootstrap key first, then the per-grant key) is asserted
+because it is what keeps the panel's family operations — which take only the
+grant lock — from closing a cycle with the token endpoint.
+"""
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.models.db import OAuthClient, OAuthCode, OAuthToken
+from src.oauth import routes as oauth
+from src.oauth.grants import USER_BOOTSTRAP_LOCK_KEY, grant_lock_key
+
+from _oauth_grant_fakes import FakeClient, FakeSession, FakeToken, SeqSession, in_hours
+
+REGISTERED_URI = "https://client.example.com/callback"
+VERIFIER = "v" * 64
+REFRESH_SECRET = "r" * 64
+
+
+def body(response) -> dict:
+    return json.loads(response.body)
+
+
+def minted(session) -> list:
+    return [obj for obj in session.added if isinstance(obj, OAuthToken)]
+
+
+def _exchange(monkeypatch, *, code_user_id, client_user_id=None, multi_user=True):
+    client = OAuthClient(
+        client_id="client123",
+        client_secret_hash=None,
+        token_endpoint_auth_method="none",
+        client_name="Claude",
+        redirect_uris=[REGISTERED_URI],
+        scope="read readwrite offline_access",
+        user_id=client_user_id,
+    )
+    code = OAuthCode(
+        code_hash=oauth._hash("the-code"),
+        client_id=client.client_id,
+        redirect_uri=REGISTERED_URI,
+        scope="read",
+        code_challenge=oauth._base64url_sha256(VERIFIER),
+        code_challenge_method="S256",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        used=False,
+        user_id=code_user_id,
+    )
+    session = SeqSession([code, client])
+    monkeypatch.setattr(oauth, "async_session", lambda: session)
+    monkeypatch.setattr(oauth.settings, "multi_user_mode", multi_user, raising=False)
+    response = asyncio.run(
+        oauth._handle_auth_code(
+            {
+                "code": "the-code",
+                "code_verifier": VERIFIER,
+                "redirect_uri": REGISTERED_URI,
+            }
+        )
+    )
+    return response, session, code
+
+
+def _refresh(monkeypatch, *, token_user_id, client_user_id=None, multi_user=True):
+    token = FakeToken(
+        grant_id="g1",
+        token_type="refresh",
+        scope="read",
+        user_id=token_user_id,
+        expires_at=in_hours(720),
+        token_hash=oauth._hash(REFRESH_SECRET),
+    )
+    session = FakeSession(
+        clients=[FakeClient(user_id=client_user_id)], tokens=[token]
+    )
+    monkeypatch.setattr(oauth, "async_session", lambda: session)
+    monkeypatch.setattr(oauth.settings, "multi_user_mode", multi_user, raising=False)
+    response = asyncio.run(oauth._handle_refresh({"refresh_token": REFRESH_SECRET}))
+    return response, session, token
+
+
+# --- the refusal ----------------------------------------------------------
+
+
+def test_code_with_no_owner_mints_nothing_in_multi_user_mode(monkeypatch):
+    response, session, code = _exchange(monkeypatch, code_user_id=None)
+
+    assert response.status_code == 400
+    assert body(response)["error"] == "invalid_grant"
+    assert minted(session) == []
+    assert code.used is False
+
+
+def test_refresh_of_an_ownerless_token_mints_nothing_in_multi_user_mode(monkeypatch):
+    """Otherwise the rotation launders one ownerless row into a fresh pair."""
+    response, session, token = _refresh(monkeypatch, token_user_id=None)
+
+    assert response.status_code == 400
+    assert body(response)["error"] == "invalid_grant"
+    assert minted(session) == []
+    assert token.revoked is False
+
+
+def test_single_user_mode_still_mints_ownerless_tokens(monkeypatch):
+    """`user_id IS NULL` *is* the single-user identity; it must keep working."""
+    response, session, _ = _exchange(monkeypatch, code_user_id=None, multi_user=False)
+
+    assert response.status_code == 200
+    assert len(minted(session)) == 2
+    assert all(t.user_id is None for t in minted(session))
+
+
+def test_single_user_mode_still_refreshes_ownerless_tokens(monkeypatch):
+    response, session, _ = _refresh(monkeypatch, token_user_id=None, multi_user=False)
+
+    assert response.status_code == 200
+    assert len(minted(session)) == 2
+
+
+def test_an_owned_code_still_mints_in_multi_user_mode(monkeypatch):
+    response, session, _ = _exchange(monkeypatch, code_user_id=4, client_user_id=4)
+
+    assert response.status_code == 200
+    assert [t.user_id for t in minted(session)] == [4, 4]
+
+
+# --- the cross-user rotation the audit found -----------------------------
+
+
+def test_refresh_refuses_a_grant_whose_owner_is_not_the_clients(monkeypatch):
+    """A legacy or race-created cross-user grant must not rotate forever.
+
+    `authorize_post` and `_handle_auth_code` both refuse to *create* this
+    pairing now, but nothing stopped an existing one from re-minting itself
+    indefinitely — live, and invisible in either user's panel.
+    """
+    response, session, token = _refresh(
+        monkeypatch, token_user_id=2, client_user_id=1
+    )
+
+    assert response.status_code == 400
+    assert body(response)["error"] == "invalid_grant"
+    assert minted(session) == []
+    assert token.revoked is False
+
+
+def test_refresh_allows_a_grant_owned_by_the_clients_owner(monkeypatch):
+    response, session, _ = _refresh(monkeypatch, token_user_id=1, client_user_id=1)
+
+    assert response.status_code == 200
+    assert len(minted(session)) == 2
+
+
+def test_refresh_allows_an_unbound_client(monkeypatch):
+    """An unclaimed client is not evidence of a conflict."""
+    response, session, _ = _refresh(monkeypatch, token_user_id=1, client_user_id=None)
+
+    assert response.status_code == 200
+    assert len(minted(session)) == 2
+
+
+# --- lock acquisition and its order --------------------------------------
+
+
+def test_code_exchange_takes_the_bootstrap_lock(monkeypatch):
+    _, session, _ = _exchange(monkeypatch, code_user_id=4, client_user_id=4)
+
+    assert session.advisory_locks == [USER_BOOTSTRAP_LOCK_KEY]
+
+
+def test_refresh_takes_the_bootstrap_lock_before_the_grant_lock(monkeypatch):
+    """Order is the property, not mere presence.
+
+    The panel's family operations take only the grant lock. If the token
+    endpoint took the grant lock first and then asked for the bootstrap key,
+    a bootstrap holding that key and waiting on the family would close a
+    cycle. One fixed order on the only path that takes both removes it.
+    """
+    _, session, _ = _refresh(monkeypatch, token_user_id=1, client_user_id=1)
+
+    assert session.advisory_locks == [USER_BOOTSTRAP_LOCK_KEY, grant_lock_key("g1")]
+
+
+def test_the_bootstrap_key_is_the_one_the_claim_already_holds():
+    """A different key would silently un-serialize the window it exists to close.
+
+    `register_submit` has held this literal since before the token endpoint
+    took it; during a rolling deploy an old process still uses the literal
+    while a new one imports the constant.
+    """
+    from src.auth import routes as auth_routes
+
+    assert auth_routes._BOOTSTRAP_LOCK_KEY == USER_BOOTSTRAP_LOCK_KEY
+    assert USER_BOOTSTRAP_LOCK_KEY == 7283910429
+
+
+def test_the_panel_never_takes_the_bootstrap_lock():
+    """The other half of "no cycle": the family paths take one lock only."""
+    from src.control_panel import routes as panel
+
+    family = [
+        FakeToken(grant_id="g1", token_type="access"),
+        FakeToken(grant_id="g1", token_type="refresh"),
+    ]
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+
+    asyncio.run(
+        panel.revoke_oauth_token(
+            token_id=family[0].id,
+            session=session,
+            user=type("U", (), {"id": None, "is_admin": True, "username": "admin"})(),
+        )
+    )
+
+    assert USER_BOOTSTRAP_LOCK_KEY not in session.advisory_locks
+    assert session.advisory_locks == [grant_lock_key("g1")]
+
+
+@pytest.mark.parametrize("handler", ["exchange", "refresh"])
+def test_the_lock_is_taken_before_anything_is_written(monkeypatch, handler):
+    if handler == "exchange":
+        _, session, _ = _exchange(monkeypatch, code_user_id=4, client_user_id=4)
+    else:
+        _, session, _ = _refresh(monkeypatch, token_user_id=1, client_user_id=1)
+
+    assert session.advisory_locks, "no lock taken at all"
+    assert session.advisory_locks[0] == USER_BOOTSTRAP_LOCK_KEY

--- a/tests/test_issue_64_ownerless_token_mint.py
+++ b/tests/test_issue_64_ownerless_token_mint.py
@@ -21,6 +21,12 @@ Two things close it, and both are pinned here:
 The lock order (bootstrap key first, then the per-grant key) is asserted
 because it is what keeps the panel's family operations — which take only the
 grant lock — from closing a cycle with the token endpoint.
+
+The last section covers the *other* end: a token that already exists with no
+owner must not authenticate. That gate lives in `APIKeyMiddleware`
+(`reason=ownerless_credential`) and is pinned here too, because the mint-side
+refusals above are only half of the property — they stop new ones, not the
+ones a configuration cycle left behind.
 """
 import asyncio
 import json
@@ -247,3 +253,185 @@ def test_the_lock_is_taken_before_anything_is_written(monkeypatch, handler):
 
     assert session.advisory_locks, "no lock taken at all"
     assert session.advisory_locks[0] == USER_BOOTSTRAP_LOCK_KEY
+
+
+# --- the other end: an existing ownerless token must not authenticate -----
+
+
+class _EmptyResult:
+    rowcount = 0
+
+
+class _RowsResult:
+    def __init__(self, rows):
+        self._rows = list(rows)
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return list(self._rows)
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return [self._value]
+
+
+class _MiddlewareSession:
+    """Answers the statements `APIKeyMiddleware` issues on the OAuth branch."""
+
+    def __init__(self, token, *, client_owner=None, user_active=True):
+        self.token = token
+        self.client_owner = client_owner
+        self.user_active = user_active
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def commit(self):
+        pass
+
+    async def execute(self, stmt, *_a, **_kw):
+        sql = str(stmt)
+        if sql.startswith("UPDATE"):
+            return _EmptyResult()
+        if "FROM oauth_tokens" in sql:
+            return _RowsResult([self.token])
+        if "FROM oauth_clients" in sql:
+            return _ScalarResult(self.client_owner)
+        if "vault_path" in sql:
+            return _RowsResult([])
+        return _ScalarResult(self.user_active)
+
+
+def _drive_middleware(token, *, multi_user, client_owner=None):
+    """Run the real middleware over one bearer token; return (sent, called)."""
+    import src.mcp_server.auth as mcp_auth
+
+    sent = []
+    called = []
+
+    async def _send(message):
+        sent.append(message)
+
+    async def _receive():  # pragma: no cover - never awaited
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def _downstream(scope, receive, send):
+        called.append(True)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    async def run():
+        mp = pytest.MonkeyPatch()
+        try:
+            mp.setattr(
+                mcp_auth,
+                "async_session",
+                lambda: _MiddlewareSession(token, client_owner=client_owner),
+            )
+            mp.setattr(mcp_auth.settings, "multi_user_mode", multi_user, raising=False)
+            app = mcp_auth.APIKeyMiddleware(_downstream)
+            await app(
+                {
+                    "type": "http",
+                    "method": "POST",
+                    "path": "/mcp/",
+                    "headers": [(b"authorization", b"Bearer live-token")],
+                },
+                _receive,
+                _send,
+            )
+        finally:
+            mp.undo()
+
+    asyncio.run(run())
+    return sent, called
+
+
+def _live_token(user_id, *, client_id="client123", scope="readwrite"):
+    return OAuthToken(
+        id=91,
+        token_hash=oauth._hash("live-token"),
+        token_type="access",
+        client_id=client_id,
+        scope=scope,
+        grant_id="g1",
+        user_id=user_id,
+        revoked=False,
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+
+def test_an_ownerless_token_is_refused_by_the_middleware_in_multi_user_mode():
+    """The Codex BLOCKER, pinned end to end.
+
+    A token minted while multi-user mode was off keeps `user_id IS NULL`, and
+    the bootstrap backfill only claims NULL rows while `users` is empty — so
+    flipping the flag after users exist never adopts it. Every layer then read
+    that token as the single-user identity and handed it the global vault. Here
+    the client is bound to user A, which is exactly the shape that makes the
+    token's NULL owner indefensible.
+    """
+    sent, called = _drive_middleware(
+        _live_token(None), multi_user=True, client_owner=1
+    )
+
+    assert sent, "the middleware sent nothing at all"
+    assert sent[0]["status"] == 401
+    assert called == [], "the downstream app must never run"
+    assert b"Invalid or revoked token" in sent[1]["body"]
+
+
+def test_the_same_token_is_accepted_in_single_user_mode():
+    """`user_id IS NULL` *is* the identity there; the refusal must be scoped."""
+    sent, called = _drive_middleware(
+        _live_token(None), multi_user=False, client_owner=None
+    )
+
+    assert sent[0]["status"] == 200
+    assert called == [True]
+
+
+def test_an_owned_token_still_authenticates_in_multi_user_mode():
+    sent, called = _drive_middleware(_live_token(1), multi_user=True, client_owner=1)
+
+    assert sent[0]["status"] == 200
+    assert called == [True]
+
+
+def test_an_owned_token_under_another_users_client_is_refused():
+    """The cross-user grant check, at the boundary rather than at mint."""
+    sent, called = _drive_middleware(_live_token(2), multi_user=True, client_owner=1)
+
+    assert sent[0]["status"] == 401
+    assert called == []
+
+
+def test_a_token_with_no_vault_scope_is_refused():
+    """`offline_access` alone authenticates nowhere."""
+    sent, called = _drive_middleware(
+        _live_token(1, scope="offline_access"), multi_user=True, client_owner=1
+    )
+
+    assert sent[0]["status"] == 401
+    assert called == []

--- a/tests/test_issue_64_panel_grant_listing.py
+++ b/tests/test_issue_64_panel_grant_listing.py
@@ -1,0 +1,297 @@
+"""The OAuth page must never hide a live grant, or under-report its scope.
+
+Two failures the adversarial pass found, both in `oauth_page`'s listing:
+
+* **A bound applied before grants were identified.** One `LIMIT` over all of a
+  client's tokens, newest first, meant a chatty grant's rotations could push
+  another grant's live refresh token off the page — a working credential with
+  no control to revoke it. Live rows are now read unbounded and only *history*
+  is capped.
+* **Scope read from the newest live row alone.** Migration 014's backfill
+  groups by `(client_id, user_id)`, so two pre-014 sessions of the same
+  connector legitimately merge into one family — and they can disagree, one
+  `read` and one `readwrite`. The page showed "read" while an older live access
+  token still held write.
+"""
+import asyncio
+import re
+
+import pytest
+
+from src.control_panel import routes as panel
+
+from _oauth_grant_fakes import (
+    FakeClient,
+    FakeRequest,
+    FakeSession,
+    FakeToken,
+    SingleUserSentinel,
+    in_hours,
+    utcnow,
+)
+
+import datetime
+
+
+def render(clients, tokens, users=(), user=None) -> str:
+    session = FakeSession(clients=clients, tokens=tokens, users=users)
+    response = asyncio.run(
+        panel.oauth_page(
+            request=FakeRequest(),
+            session=session,
+            user=user or SingleUserSentinel(),
+        )
+    )
+    return response.body.decode()
+
+
+def grants_of(clients, tokens, users=()):
+    """The route's own per-grant view dicts, before the template sees them."""
+    session = FakeSession(clients=clients, tokens=tokens, users=users)
+    captured = {}
+    real = panel.templates.TemplateResponse
+
+    def _capture(request, name, context, *a, **kw):
+        captured.update(context)
+        return real(request, name, context, *a, **kw)
+
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(panel.templates, "TemplateResponse", _capture)
+        asyncio.run(
+            panel.oauth_page(
+                request=FakeRequest(), session=session, user=SingleUserSentinel()
+            )
+        )
+    finally:
+        monkeypatch.undo()
+    return {g["grant_id"]: g for g in captured["clients"][0]["grants"]}
+
+
+def aged(minutes: int) -> datetime.datetime:
+    """A `created_at` `minutes` in the past — newer rows sort first."""
+    return utcnow() - datetime.timedelta(minutes=minutes)
+
+
+# --- a live grant is never pushed off the page ---------------------------
+
+
+def test_a_chatty_grants_history_cannot_hide_another_grants_live_token():
+    """The exact shape of the finding: 501 rotations on one grant.
+
+    Under a single `LIMIT 1000` over all of a client's tokens ordered newest
+    first, a grant whose live pair is *older* than a thousand rotated-away rows
+    disappeared — no row, no Revoke button, no way to end it from the UI, while
+    the credential kept working for its full 30 days.
+    """
+    noisy = []
+    for i in range(1200):
+        noisy.append(
+            FakeToken(
+                grant_id="chatty",
+                token_type="refresh",
+                revoked=True,
+                created_at=aged(i + 1),
+                expires_at=in_hours(720),
+            )
+        )
+    quiet = [
+        FakeToken(
+            grant_id="quiet",
+            token_type="access",
+            created_at=aged(5000),
+            expires_at=in_hours(1),
+        ),
+        FakeToken(
+            grant_id="quiet",
+            token_type="refresh",
+            created_at=aged(5000),
+            expires_at=in_hours(720),
+        ),
+    ]
+
+    grants = grants_of([FakeClient()], noisy + quiet)
+
+    assert "quiet" in grants, "a live grant was dropped from the listing"
+    assert grants["quiet"]["token_id"] is not None, "no control to revoke it"
+    assert grants["quiet"]["status"] == "active"
+
+
+def test_the_live_query_is_unbounded_and_only_history_is_capped():
+    """Stated as a property of the source, so the bound cannot creep back."""
+    import inspect
+
+    source = inspect.getsource(panel.oauth_page)
+    assert "CLIENT_DEAD_TOKEN_SCAN_LIMIT" in source
+    live_half, dead_half = source.split("dead_q", 1)
+    assert ".limit(" not in live_half, "the live query must not be bounded"
+
+
+def test_history_truncation_is_declared_rather_than_miscounted():
+    """A count taken from a truncated window would understate silently."""
+    dead = [
+        FakeToken(
+            grant_id="g1",
+            token_type="refresh",
+            revoked=True,
+            created_at=aged(i + 1),
+        )
+        for i in range(panel.CLIENT_DEAD_TOKEN_SCAN_LIMIT + 50)
+    ]
+    live = [FakeToken(grant_id="g1", token_type="access", created_at=aged(0))]
+
+    grants = grants_of([FakeClient()], dead + live)
+
+    assert grants["g1"]["history_truncated"] is True
+    html = render([FakeClient()], dead + live)
+    assert "beyond the history window" in html
+
+
+def test_a_small_client_is_not_marked_truncated():
+    live = [FakeToken(grant_id="g1", token_type="access")]
+    dead = [FakeToken(grant_id="g1", token_type="refresh", revoked=True)]
+
+    grants = grants_of([FakeClient()], live + dead)
+
+    assert grants["g1"]["history_truncated"] is False
+
+
+def test_a_fully_revoked_grant_is_still_listed():
+    """History is what makes a revocation visibly durable (issue #64)."""
+    dead = [
+        FakeToken(grant_id="g1", token_type="access", revoked=True),
+        FakeToken(grant_id="g1", token_type="refresh", revoked=True),
+    ]
+
+    grants = grants_of([FakeClient()], dead)
+
+    assert grants["g1"]["status"] == "revoked"
+    assert grants["g1"]["token_id"] is None
+
+
+# --- a mixed-scope family reports its strongest live permission ----------
+
+
+def mixed_family():
+    """What 014 produces from two pre-014 sessions of one client and user."""
+    return [
+        # Newest live row is read-only...
+        FakeToken(
+            grant_id="g1",
+            token_type="refresh",
+            scope="offline_access read",
+            created_at=aged(1),
+            expires_at=in_hours(720),
+        ),
+        # ...while an older live access token still carries write.
+        FakeToken(
+            grant_id="g1",
+            token_type="access",
+            scope="offline_access readwrite",
+            created_at=aged(10),
+            expires_at=in_hours(1),
+        ),
+    ]
+
+
+def test_a_mixed_family_reports_write_not_the_newest_rows_scope():
+    """`any`, not "the first one" — over-reporting capability is the safe side."""
+    grants = grants_of([FakeClient()], mixed_family())
+
+    assert grants["g1"]["has_write"] is True
+    assert grants["g1"]["mixed_scope"] is True
+    assert set(grants["g1"]["live_scopes"]) == {
+        "offline_access read",
+        "offline_access readwrite",
+    }
+
+
+def test_a_mixed_family_is_marked_in_the_rendered_page():
+    html = render([FakeClient()], mixed_family())
+
+    assert ">mixed<" in html
+    # And the select reflects the strongest live permission.
+    m = re.search(r'<option value="readwrite"\s*[^>]*>', html)
+    assert m and "selected" in m.group(0)
+
+
+def test_a_uniform_family_is_not_marked_mixed():
+    family = [
+        FakeToken(grant_id="g1", token_type="access", scope="readwrite"),
+        FakeToken(grant_id="g1", token_type="refresh", scope="readwrite"),
+    ]
+
+    grants = grants_of([FakeClient()], family)
+
+    assert grants["g1"]["mixed_scope"] is False
+    assert grants["g1"]["has_write"] is True
+
+
+def test_a_revoked_readwrite_row_does_not_make_a_read_grant_look_mixed():
+    """Only *live* tokens decide; history is history."""
+    family = [
+        FakeToken(grant_id="g1", token_type="access", scope="read"),
+        FakeToken(
+            grant_id="g1", token_type="refresh", scope="readwrite", revoked=True
+        ),
+    ]
+
+    grants = grants_of([FakeClient()], family)
+
+    assert grants["g1"]["mixed_scope"] is False
+    assert grants["g1"]["has_write"] is False
+
+
+# --- and writing a scope makes the family uniform again ------------------
+
+
+def test_saving_a_scope_writes_one_value_across_a_mixed_family():
+    family = mixed_family()
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+
+    asyncio.run(
+        panel.update_oauth_token_scope(
+            token_id=family[0].id,
+            request=None,
+            scope="read",
+            session=session,
+            user=SingleUserSentinel(),
+        )
+    )
+
+    assert len({t.scope for t in family}) == 1, "the family must end up uniform"
+    for token in family:
+        assert "readwrite" not in token.scope.split()
+        assert "offline_access" in token.scope.split()
+
+
+def test_offline_access_is_taken_from_the_whole_live_family():
+    """Reading the marker off one row gets a mixed family wrong.
+
+    Here the row the operator clicked has no `offline_access` and its sibling
+    does; the write must not silently strip the marker from the sibling.
+    """
+    family = [
+        FakeToken(grant_id="g1", token_type="access", scope="readwrite", created_at=aged(1)),
+        FakeToken(
+            grant_id="g1",
+            token_type="refresh",
+            scope="offline_access readwrite",
+            created_at=aged(10),
+            expires_at=in_hours(720),
+        ),
+    ]
+    session = FakeSession(clients=[FakeClient()], tokens=family)
+
+    asyncio.run(
+        panel.update_oauth_token_scope(
+            token_id=family[0].id,
+            request=None,
+            scope="read",
+            session=session,
+            user=SingleUserSentinel(),
+        )
+    )
+
+    for token in family:
+        assert set(token.scope.split()) == {"read", "offline_access"}

--- a/tests/test_issue_64_revocation_endpoint_auth.py
+++ b/tests/test_issue_64_revocation_endpoint_auth.py
@@ -139,15 +139,35 @@ def test_public_client_may_still_revoke(monkeypatch):
     assert all(t.revoked for t in tokens)
 
 
-def test_public_client_may_omit_client_id(monkeypatch):
-    """Same tolerance `/token` already grants some ChatGPT connector builds."""
+def test_omitting_client_id_revokes_nothing(monkeypatch):
+    """Absence must not be treated as a match.
+
+    A public client has no secret, so `_client_authenticated` passes trivially.
+    If a missing `client_id` also counted as "the right client", then posting
+    somebody else's token value with no client field at all ended their entire
+    grant — a universal bypass that proved nothing. Unlike `/token`, where PKCE
+    binds the request to the initiating client, nothing else here identifies
+    the caller.
+    """
     tokens = family()
     session = FakeSession(clients=[public_client()], tokens=tokens)
 
     response = revoke(session, monkeypatch, token=ACCESS_VALUE)
 
+    assert response.status_code == 200, "still a uniform 200 (RFC 7009 §2.2)"
+    assert response.body == b"{}"
+    assert not any(t.revoked for t in tokens), "no mutation without a named client"
+    assert session.committed == 0
+
+
+def test_an_empty_client_id_is_not_a_match(monkeypatch):
+    tokens = family()
+    session = FakeSession(clients=[public_client()], tokens=tokens)
+
+    response = revoke(session, monkeypatch, token=ACCESS_VALUE, client_id="")
+
     assert response.status_code == 200
-    assert all(t.revoked for t in tokens)
+    assert not any(t.revoked for t in tokens)
 
 
 # --- naming a different client is a no-op with a 200 ---------------------
@@ -195,6 +215,7 @@ def test_a_missing_token_parameter_returns_200(monkeypatch):
         ({"token": ACCESS_VALUE, "client_id": "client123"}, 401),
         # Everything else the RFC calls indistinguishable.
         ({"token": ACCESS_VALUE, "client_id": "other"}, 200),
+        ({"token": ACCESS_VALUE}, 200),
         ({"token": "unknown"}, 200),
     ],
 )

--- a/tests/test_issue_64_revocation_endpoint_auth.py
+++ b/tests/test_issue_64_revocation_endpoint_auth.py
@@ -1,0 +1,219 @@
+"""RFC 7009 `/revoke` must authenticate the client, not just accept a token.
+
+The endpoint did neither client authentication nor an ownership check: it
+looked the token value up by hash and revoked. Widening revocation to the whole
+grant family (issue #64) made that materially worse — a single leaked access
+token now ends a 30-day refresh grant, not just its own remaining hour.
+
+RFC 7009 §2.1 requires the client to authenticate. §2.2 is equally load-bearing
+in the other direction: a token that is not valid *for the requesting client*
+is answered HTTP 200 and nothing happens, because an unknown token, a foreign
+token and an already-revoked one must be indistinguishable. The only case that
+is a real error is naming the right client and failing to authenticate as it.
+
+A missing `client_id` is tolerated exactly the way `/token` tolerates it — some
+ChatGPT connector builds omit it — so the client is then identified by the
+token itself, and a confidential client still has to present its secret.
+"""
+import asyncio
+import json
+
+import pytest
+
+from src.oauth import routes as oauth
+
+from _oauth_grant_fakes import FakeClient, FakeSession, FakeToken, in_hours
+
+SECRET = "s" * 64
+ACCESS_VALUE = "access-token-value"
+
+
+class FormRequest:
+    def __init__(self, form):
+        self._form = form
+
+    async def form(self):
+        return self._form
+
+
+def revoke(session, monkeypatch, **form):
+    monkeypatch.setattr(oauth, "async_session", lambda: session)
+    return asyncio.run(oauth.revoke_token.__wrapped__(FormRequest(form)))
+
+
+def family(client_id="client123"):
+    return [
+        FakeToken(
+            grant_id="g1",
+            token_type="access",
+            client_id=client_id,
+            scope="readwrite",
+            expires_at=in_hours(1),
+            token_hash=oauth._hash(ACCESS_VALUE),
+        ),
+        FakeToken(
+            grant_id="g1",
+            token_type="refresh",
+            client_id=client_id,
+            scope="readwrite",
+            expires_at=in_hours(720),
+        ),
+    ]
+
+
+def public_client(client_id="client123"):
+    return FakeClient(
+        client_id=client_id,
+        token_endpoint_auth_method="none",
+        client_secret_hash=None,
+    )
+
+
+def confidential_client(client_id="client123"):
+    return FakeClient(
+        client_id=client_id,
+        token_endpoint_auth_method="client_secret_post",
+        client_secret_hash=oauth._hash(SECRET),
+    )
+
+
+# --- confidential clients must present their secret ----------------------
+
+
+def test_confidential_client_without_a_secret_cannot_revoke(monkeypatch):
+    """The headline hole: token possession alone ended the whole grant."""
+    tokens = family()
+    session = FakeSession(clients=[confidential_client()], tokens=tokens)
+
+    response = revoke(session, monkeypatch, token=ACCESS_VALUE, client_id="client123")
+
+    assert response.status_code == 401
+    assert json.loads(response.body)["error"] == "invalid_client"
+    assert not any(t.revoked for t in tokens)
+    assert session.committed == 0
+
+
+def test_confidential_client_with_a_wrong_secret_cannot_revoke(monkeypatch):
+    tokens = family()
+    session = FakeSession(clients=[confidential_client()], tokens=tokens)
+
+    response = revoke(
+        session,
+        monkeypatch,
+        token=ACCESS_VALUE,
+        client_id="client123",
+        client_secret="w" * 64,
+    )
+
+    assert response.status_code == 401
+    assert not any(t.revoked for t in tokens)
+
+
+def test_confidential_client_with_its_secret_revokes_the_family(monkeypatch):
+    tokens = family()
+    session = FakeSession(clients=[confidential_client()], tokens=tokens)
+
+    response = revoke(
+        session,
+        monkeypatch,
+        token=ACCESS_VALUE,
+        client_id="client123",
+        client_secret=SECRET,
+    )
+
+    assert response.status_code == 200
+    assert all(t.revoked for t in tokens)
+
+
+# --- public clients authenticate by possession, as the RFC intends -------
+
+
+def test_public_client_may_still_revoke(monkeypatch):
+    """A public PKCE client has no secret; the token *is* the credential."""
+    tokens = family()
+    session = FakeSession(clients=[public_client()], tokens=tokens)
+
+    response = revoke(session, monkeypatch, token=ACCESS_VALUE, client_id="client123")
+
+    assert response.status_code == 200
+    assert all(t.revoked for t in tokens)
+
+
+def test_public_client_may_omit_client_id(monkeypatch):
+    """Same tolerance `/token` already grants some ChatGPT connector builds."""
+    tokens = family()
+    session = FakeSession(clients=[public_client()], tokens=tokens)
+
+    response = revoke(session, monkeypatch, token=ACCESS_VALUE)
+
+    assert response.status_code == 200
+    assert all(t.revoked for t in tokens)
+
+
+# --- naming a different client is a no-op with a 200 ---------------------
+
+
+def test_a_foreign_client_id_revokes_nothing_and_still_returns_200(monkeypatch):
+    """§2.2: a token not valid for the requesting client is not an error.
+
+    Answering 401 or 404 here would turn the endpoint into an oracle for
+    which client a token value belongs to.
+    """
+    tokens = family()
+    session = FakeSession(clients=[public_client()], tokens=tokens)
+
+    response = revoke(session, monkeypatch, token=ACCESS_VALUE, client_id="someone-else")
+
+    assert response.status_code == 200
+    assert response.body == b"{}"
+    assert not any(t.revoked for t in tokens)
+    assert session.committed == 0
+
+
+def test_an_unknown_token_returns_200_without_a_lookup_result(monkeypatch):
+    tokens = family()
+    session = FakeSession(clients=[public_client()], tokens=tokens)
+
+    response = revoke(session, monkeypatch, token="never-issued", client_id="client123")
+
+    assert response.status_code == 200
+    assert not any(t.revoked for t in tokens)
+
+
+def test_a_missing_token_parameter_returns_200(monkeypatch):
+    session = FakeSession(clients=[public_client()], tokens=family())
+
+    response = revoke(session, monkeypatch, client_id="client123")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "form, expected_status",
+    [
+        # The only real error: right client named, authentication failed.
+        ({"token": ACCESS_VALUE, "client_id": "client123"}, 401),
+        # Everything else the RFC calls indistinguishable.
+        ({"token": ACCESS_VALUE, "client_id": "other"}, 200),
+        ({"token": "unknown"}, 200),
+    ],
+)
+def test_only_a_failed_authentication_is_an_error(monkeypatch, form, expected_status):
+    session = FakeSession(clients=[confidential_client()], tokens=family())
+
+    response = revoke(session, monkeypatch, **form)
+
+    assert response.status_code == expected_status
+
+
+# --- the shared client-auth predicate ------------------------------------
+
+
+def test_client_authenticated_helper():
+    assert oauth._client_authenticated(confidential_client(), SECRET) is True
+    assert oauth._client_authenticated(confidential_client(), "w" * 64) is False
+    assert oauth._client_authenticated(confidential_client(), None) is False
+    assert oauth._client_authenticated(public_client(), None) is True
+    # An unregistered method is a refusal, never a fallback.
+    unknown = FakeClient(token_endpoint_auth_method="private_key_jwt")
+    assert oauth._client_authenticated(unknown, SECRET) is False

--- a/tests/test_issue_64_token_cleanup_retention.py
+++ b/tests/test_issue_64_token_cleanup_retention.py
@@ -1,0 +1,235 @@
+"""The periodic cleanup must not delete a revocation's evidence.
+
+`cleanup_expired_tokens` ran `expires_at < cutoff OR revoked` — and the second
+disjunct carried **no age condition at all**, despite the docstring promising
+"older than 7 days". It runs from the indexer loop every
+`INDEX_INTERVAL_SECONDS` (5 minutes by default), so every revoked token was
+gone within minutes of being revoked.
+
+That was harmless while the panel filtered revoked rows out of the page. It is
+not harmless now: issue #64 made the OAuth page *list* revoked tokens
+precisely because a Revoke that made the row vanish read as success even when
+it had done nothing. Purging the row five minutes later recreates the same
+blank space with a delay.
+
+The window is measured from `expires_at`. Revocation time is not stored, but a
+token can only be revoked while it exists, so its revocation time R satisfies
+`R <= expires_at`; deleting only when `expires_at < now - 7d` therefore
+guarantees `R < now - 7d`. `created_at` would give the opposite: a refresh
+token minted 30 days ago and revoked a minute ago is already 30 days past
+`created_at` and would be purged at once.
+"""
+import asyncio
+import datetime
+
+import pytest
+from sqlalchemy import or_
+from sqlalchemy.sql import operators
+from sqlalchemy.sql.dml import Delete
+from sqlalchemy.sql.elements import (
+    BinaryExpression,
+    BindParameter,
+    BooleanClauseList,
+    False_,
+    True_,
+)
+
+from src.models.db import OAuthCode, OAuthToken
+from src.services import indexer
+
+FROZEN_NOW = datetime.datetime(2026, 8, 20, 12, 0, tzinfo=datetime.timezone.utc)
+RETENTION = datetime.timedelta(days=7)
+EXPECTED_CUTOFF = FROZEN_NOW - RETENTION
+
+
+class _FrozenDatetime(datetime.datetime):
+    @classmethod
+    def now(cls, tz=None):
+        return FROZEN_NOW if tz is None else FROZEN_NOW.astimezone(tz)
+
+
+class _Result:
+    rowcount = 0
+
+
+class _RecordingSession:
+    """Captures the DELETE statements the cleanup emits, executing nothing."""
+
+    def __init__(self):
+        self.statements = []
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def execute(self, stmt, *_a, **_kw):
+        self.statements.append(stmt)
+        return _Result()
+
+    async def commit(self):
+        self.committed = True
+
+
+def run_cleanup(monkeypatch) -> _RecordingSession:
+    session = _RecordingSession()
+    monkeypatch.setattr(indexer, "async_session", lambda: session)
+    monkeypatch.setattr(indexer, "datetime", _FrozenDatetime)
+    asyncio.run(indexer.cleanup_expired_tokens())
+    assert session.committed is True
+    return session
+
+
+def statement_for(session, entity) -> Delete:
+    for stmt in session.statements:
+        assert isinstance(stmt, Delete), stmt
+        if stmt.table.name == entity.__tablename__:
+            return stmt
+    raise AssertionError(f"no DELETE emitted for {entity.__name__}")
+
+
+# --- the predicate itself -------------------------------------------------
+
+
+def test_token_cleanup_is_age_gated_and_carries_no_bare_revoked_disjunct(monkeypatch):
+    """Structural, not a string grep: the WHERE clause is compared as a tree."""
+    session = run_cleanup(monkeypatch)
+    where = statement_for(session, OAuthToken).whereclause
+
+    assert where.compare(OAuthToken.expires_at < EXPECTED_CUTOFF), (
+        "the token cleanup must delete on expiry age alone"
+    )
+    # The shape this replaces. Pinned explicitly so a revert is a test failure
+    # rather than a silent five-minute retention window.
+    assert not where.compare(
+        or_(OAuthToken.expires_at < EXPECTED_CUTOFF, OAuthToken.revoked == True)  # noqa: E712
+    )
+
+
+def test_the_cutoff_is_seven_days_before_now(monkeypatch):
+    session = run_cleanup(monkeypatch)
+    params = statement_for(session, OAuthToken).compile().params
+
+    assert params == {"expires_at_1": EXPECTED_CUTOFF}
+
+
+def test_auth_code_cleanup_is_deliberately_unchanged(monkeypatch):
+    """A used code is spent immediately and has no history value.
+
+    Pinned so the fix above is visibly scoped to tokens: an editor who
+    "simplified" both branches together would drop the `used` disjunct and
+    leave spent codes in the table until their expiry.
+    """
+    session = run_cleanup(monkeypatch)
+    where = statement_for(session, OAuthCode).whereclause
+
+    assert where.compare(
+        or_(OAuthCode.expires_at < EXPECTED_CUTOFF, OAuthCode.used == True)  # noqa: E712
+    )
+
+
+# --- what that predicate does to actual rows ------------------------------
+
+
+def _literal(node):
+    """The Python value behind a comparison's right-hand side."""
+    if isinstance(node, BindParameter):
+        return node.value
+    if isinstance(node, True_):
+        return True
+    if isinstance(node, False_):
+        return False
+    raise AssertionError(f"unsupported literal in the cleanup predicate: {node!r}")
+
+
+def evaluate(clause, row: dict) -> bool:
+    """Evaluate the emitted WHERE clause against a row, in Python.
+
+    Deliberately a real (if tiny) evaluator rather than a peek at one bind
+    parameter: reading the cutoff alone would keep passing if somebody put the
+    unqualified `OR revoked` disjunct back, since the cutoff itself would not
+    change. Walking the tree means these cases actually depend on the shape.
+    Only the node types this cleanup can emit are supported — anything else
+    fails loudly instead of being silently treated as false.
+    """
+    if isinstance(clause, BooleanClauseList):
+        parts = [evaluate(part, row) for part in clause.clauses]
+        if clause.operator is operators.or_:
+            return any(parts)
+        if clause.operator is operators.and_:
+            return all(parts)
+        raise AssertionError(f"unsupported boolean operator: {clause.operator}")
+    if isinstance(clause, BinaryExpression):
+        value = row[clause.left.name]
+        other = _literal(clause.right)
+        if clause.operator is operators.lt:
+            return value < other
+        if clause.operator is operators.eq:
+            return value == other
+        raise AssertionError(f"unsupported comparison: {clause.operator}")
+    raise AssertionError(f"unsupported clause: {clause!r}")
+
+
+def deleted_by(session, expires_at: datetime.datetime, revoked: bool = True) -> bool:
+    """Would the emitted token predicate delete this row?
+
+    `revoked` defaults to True because every case below is about a token the
+    operator has just revoked — the rows whose disappearance is the bug.
+    """
+    where = statement_for(session, OAuthToken).whereclause
+    return evaluate(where, {"expires_at": expires_at, "revoked": revoked})
+
+
+@pytest.mark.parametrize(
+    "label, expires_at, expected",
+    [
+        # A refresh token revoked a moment ago still has 30 days to run.
+        ("just revoked, 30 days of life left", FROZEN_NOW + datetime.timedelta(days=30), False),
+        # An access token revoked a moment ago dies in an hour — and its row
+        # must outlive it by a week so the operator can see the revocation.
+        ("just revoked, expires in an hour", FROZEN_NOW + datetime.timedelta(hours=1), False),
+        ("expired an hour ago", FROZEN_NOW - datetime.timedelta(hours=1), False),
+        ("expired six days ago", FROZEN_NOW - datetime.timedelta(days=6), False),
+        ("expired eight days ago", FROZEN_NOW - datetime.timedelta(days=8), True),
+        ("expired a year ago", FROZEN_NOW - datetime.timedelta(days=365), True),
+    ],
+)
+def test_retention_window_by_expiry(monkeypatch, label, expires_at, expected):
+    session = run_cleanup(monkeypatch)
+    assert deleted_by(session, expires_at) is expected, label
+
+
+def test_revocation_evidence_survives_at_least_the_retention_window(monkeypatch):
+    """The property the column choice buys, stated as a test.
+
+    A token can only be revoked while it exists, so R <= expires_at. Sweeping
+    across every plausible remaining lifetime, no row a revocation could have
+    just touched is deletable.
+    """
+    session = run_cleanup(monkeypatch)
+    for days_of_life_left in (0, 1, 7, 30):
+        expires_at = FROZEN_NOW + datetime.timedelta(days=days_of_life_left)
+        # Revoked "now"; the row must still be there.
+        assert deleted_by(session, expires_at) is False
+
+    # And a `created_at`-based window would have failed exactly here: a token
+    # minted 30 days ago, revoked now, is 30 days past creation.
+    created_at = FROZEN_NOW - datetime.timedelta(days=30)
+    assert created_at < EXPECTED_CUTOFF, "the rejected alternative really does purge it"
+
+
+def test_revoked_and_unrevoked_rows_are_treated_identically(monkeypatch):
+    """`revoked` must not appear in the predicate at all any more.
+
+    Retention is a function of expiry age alone, so the same row is deleted or
+    kept regardless of the flag. This is the assertion that fails first if the
+    unqualified disjunct comes back.
+    """
+    session = run_cleanup(monkeypatch)
+    for offset_days in (-365, -8, -7, -1, 0, 1, 30):
+        expires_at = FROZEN_NOW + datetime.timedelta(days=offset_days)
+        assert deleted_by(session, expires_at, revoked=True) is deleted_by(
+            session, expires_at, revoked=False
+        ), offset_days

--- a/tests/test_issue_66_vault_unassignment_revokes_tools.py
+++ b/tests/test_issue_66_vault_unassignment_revokes_tools.py
@@ -629,7 +629,20 @@ def test_tools_refuse_an_ownerless_caller_in_multi_user_mode(
 
 class _OAuthMiddlewareSession(_MiddlewareSession):
     """Same as `_MiddlewareSession`, for the OAuth branch: the first select
-    hits `oauth_tokens` rather than `api_keys`."""
+    hits `oauth_tokens` rather than `api_keys`.
+
+    `client_owner` answers the middleware's cross-user check, which reads
+    `OAuthClient.user_id` for the token's client. These fixtures build tokens
+    with no `client_id`, i.e. no such client row, so the honest default is
+    None — "unbound or absent", which is not a conflict. It has to be
+    dispatched explicitly rather than falling through to `user_active`, or
+    every one of these tokens would look like a grant whose client belongs to
+    somebody called `True`.
+    """
+
+    def __init__(self, api_key, user_active=True, vault_row=None, client_owner=None):
+        super().__init__(api_key, user_active=user_active, vault_row=vault_row)
+        self.client_owner = client_owner
 
     async def execute(self, stmt):
         sql = str(stmt)
@@ -639,6 +652,8 @@ class _OAuthMiddlewareSession(_MiddlewareSession):
             return _RowsResult([self.vault_row] if self.vault_row else [])
         if "FROM oauth_tokens" in sql:
             return _RowsResult([self.api_key])
+        if "FROM oauth_clients" in sql:
+            return _ScalarResult(self.client_owner)
         return _ScalarResult(self.user_active)
 
 

--- a/tests/test_issue_67_offline_access_only_client.py
+++ b/tests/test_issue_67_offline_access_only_client.py
@@ -32,6 +32,7 @@ from src.oauth import routes as oauth
 from src.oauth.scope import clamp_scope, has_vault_scope, vault_level
 
 from _oauth_grant_fakes import (
+    SeqSession,
     FakeClient,
     FakeSession,
     FakeToken,
@@ -91,36 +92,8 @@ class _RegistrationRequest:
         return self._body
 
 
-class _SeqSession:
-    def __init__(self, results=()):
-        self._results = iter(results)
-        self.added = []
-        self.committed = False
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *_exc):
-        return False
-
-    async def execute(self, _stmt, *_a, **_kw):
-        value = next(self._results)
-
-        class _R:
-            def scalar_one_or_none(self_inner):
-                return value
-
-        return _R()
-
-    def add(self, obj):
-        self.added.append(obj)
-
-    async def commit(self):
-        self.committed = True
-
-
 def _register(scope, monkeypatch):
-    session = _SeqSession()
+    session = SeqSession()
     monkeypatch.setattr(oauth, "async_session", lambda: session)
     response = asyncio.run(
         oauth.register_client.__wrapped__(
@@ -264,7 +237,7 @@ def _exchange(client_scope, code_scope, monkeypatch):
         expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
         used=False,
     )
-    session = _SeqSession([code, client])
+    session = SeqSession([code, client])
     monkeypatch.setattr(oauth, "async_session", lambda: session)
     response = asyncio.run(
         oauth._handle_auth_code(

--- a/tests/test_issue_67_offline_access_only_client.py
+++ b/tests/test_issue_67_offline_access_only_client.py
@@ -328,6 +328,88 @@ def test_panel_scope_change_is_refused_for_an_offline_only_client():
         )
 
 
+# --- the panel does not badge such a token "Active" -----------------------
+
+
+def _render_panel(clients, tokens):
+    from _oauth_grant_fakes import FakeRequest
+
+    from src.control_panel import routes as panel_routes
+
+    session = FakeSession(clients=clients, tokens=tokens)
+    response = asyncio.run(
+        panel_routes.oauth_page(
+            request=FakeRequest(), session=session, user=SingleUserSentinel()
+        )
+    )
+    return response.body.decode()
+
+
+def test_panel_shows_no_vault_scope_instead_of_active():
+    """The panel must not over-report liveness (the #76 direction).
+
+    `src/mcp_server/auth.py` 401s this token, so rendering it green — with a
+    working scope dropdown next to it — told the operator a dead credential
+    was live and offered a control that could only ever be refused.
+    """
+    tokens = [
+        FakeToken(grant_id="g1", token_type="access", scope=OFFLINE_ONLY),
+        FakeToken(grant_id="g1", token_type="refresh", scope=OFFLINE_ONLY),
+    ]
+
+    html = _render_panel([FakeClient(scope=OFFLINE_ONLY)], tokens)
+
+    assert "No vault scope" in html
+    assert 'class="badge badge-green"' not in html
+    # No scope control and no Revoke: the credential authenticates nowhere,
+    # and the select could only write a scope the client is not registered for.
+    assert "<option" not in html
+    assert "/revoke" not in html
+
+
+def test_the_grant_status_itself_is_no_vault_scope():
+    """Asserted on the route's own view, not just the rendered string."""
+    import pytest as _pytest
+
+    from _oauth_grant_fakes import FakeRequest
+    from src.control_panel import routes as panel_routes
+
+    tokens = [FakeToken(grant_id="g1", token_type="access", scope=OFFLINE_ONLY)]
+    session = FakeSession(clients=[FakeClient(scope=OFFLINE_ONLY)], tokens=tokens)
+    captured = {}
+    real = panel_routes.templates.TemplateResponse
+
+    def _capture(request, name, context, *a, **kw):
+        captured.update(context)
+        return real(request, name, context, *a, **kw)
+
+    mp = _pytest.MonkeyPatch()
+    try:
+        mp.setattr(panel_routes.templates, "TemplateResponse", _capture)
+        asyncio.run(
+            panel_routes.oauth_page(
+                request=FakeRequest(), session=session, user=SingleUserSentinel()
+            )
+        )
+    finally:
+        mp.undo()
+
+    grant = captured["clients"][0]["grants"][0]
+    assert grant["status"] == "no_vault_scope"
+    assert grant["token_id"] is None, "nothing to act on"
+    assert grant["has_write"] is False
+
+
+def test_a_normal_grant_is_still_active():
+    """The guard must not swallow the ordinary case."""
+    tokens = [FakeToken(grant_id="g1", token_type="access", scope="read")]
+
+    html = _render_panel([FakeClient(scope="read")], tokens)
+
+    assert "No vault scope" not in html
+    assert 'class="badge badge-green"' in html
+
+
 # --- and the enforcement boundary rejects a legacy token ------------------
 
 

--- a/tests/test_issue_67_offline_access_only_client.py
+++ b/tests/test_issue_67_offline_access_only_client.py
@@ -1,0 +1,373 @@
+"""A client registered for `offline_access` alone must be granted nothing.
+
+`clamp_scope` used to end with ``or "read"``. That fallback was doing two
+unrelated jobs at once:
+
+* the legitimate downgrade — a client registered `read` that asks for
+  `readwrite` gets `read` (issue #21), because the requested and registered
+  sets do not intersect at all under the old implementation; and
+* a silent default for a client registered for **no vault scope at all**.
+
+RFC 7591 registration takes `scope` verbatim, so `{"scope": "offline_access"}`
+is a client that may hold a refresh token and read nothing. Under the old
+fallback it was handed `read` over the entire vault — a permission its
+registration never named, arrived at by a code path that exists to *restrict*
+scopes.
+
+The downgrade is now expressed directly (the weaker of the two vault levels),
+so the fallback could become what it should always have been: nothing. Every
+path that writes or enforces a scope turns that into a refusal, and each of
+those paths is pinned below.
+"""
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.responses import RedirectResponse
+
+from src.control_panel import routes as panel
+from src.models.db import OAuthClient, OAuthCode, OAuthToken
+from src.oauth import routes as oauth
+from src.oauth.scope import clamp_scope, has_vault_scope, vault_level
+
+from _oauth_grant_fakes import (
+    FakeClient,
+    FakeSession,
+    FakeToken,
+    SingleUserSentinel,
+    in_hours,
+)
+
+OFFLINE_ONLY = "offline_access"
+REGISTERED_URI = "https://client.example.com/callback"
+REFRESH_SECRET = "r" * 64
+VERIFIER = "v" * 64
+
+
+def body(response) -> dict:
+    return json.loads(response.body)
+
+
+# --- the helpers ----------------------------------------------------------
+
+
+def test_vault_level_does_not_count_offline_access():
+    assert vault_level("readwrite") == "readwrite"
+    assert vault_level("offline_access readwrite") == "readwrite"
+    assert vault_level("read") == "read"
+    assert vault_level("offline_access read") == "read"
+    assert vault_level(OFFLINE_ONLY) is None
+    assert vault_level("") is None
+    assert vault_level(None) is None
+
+
+def test_has_vault_scope_is_the_same_question():
+    assert has_vault_scope("offline_access readwrite") is True
+    assert has_vault_scope("read") is True
+    assert has_vault_scope(OFFLINE_ONLY) is False
+    assert has_vault_scope("") is False
+
+
+@pytest.mark.parametrize("requested", ["read", "readwrite", "offline_access", "offline_access read", ""])
+def test_clamp_against_an_offline_only_registration_grants_nothing(requested):
+    assert clamp_scope(requested, OFFLINE_ONLY) == ""
+
+
+def test_clamp_still_downgrades_rather_than_refusing():
+    """The behaviour the old fallback was accidentally providing (issue #21)."""
+    assert clamp_scope("readwrite", "read") == "read"
+    assert clamp_scope("readwrite offline_access", "read") == "read"
+
+
+# --- /register refuses the registration in the first place ----------------
+
+
+class _RegistrationRequest:
+    def __init__(self, body):
+        self._body = body
+
+    async def json(self):
+        return self._body
+
+
+class _SeqSession:
+    def __init__(self, results=()):
+        self._results = iter(results)
+        self.added = []
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def execute(self, _stmt, *_a, **_kw):
+        value = next(self._results)
+
+        class _R:
+            def scalar_one_or_none(self_inner):
+                return value
+
+        return _R()
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+
+def _register(scope, monkeypatch):
+    session = _SeqSession()
+    monkeypatch.setattr(oauth, "async_session", lambda: session)
+    response = asyncio.run(
+        oauth.register_client.__wrapped__(
+            _RegistrationRequest(
+                {
+                    "client_name": "Scopeless",
+                    "redirect_uris": [REGISTERED_URI],
+                    "token_endpoint_auth_method": "none",
+                    "scope": scope,
+                }
+            )
+        )
+    )
+    return response, session
+
+
+def test_registering_with_offline_access_alone_is_refused(monkeypatch):
+    response, session = _register(OFFLINE_ONLY, monkeypatch)
+
+    assert response.status_code == 400
+    assert body(response)["error"] == "invalid_scope"
+    assert session.added == [], "no client row may be created"
+
+
+def test_registering_with_a_vault_scope_still_works(monkeypatch):
+    response, session = _register("read offline_access", monkeypatch)
+
+    assert response.status_code == 201
+    assert len(session.added) == 1
+
+
+# --- /authorize (POST) refuses to mint a code -----------------------------
+
+
+class _FakeAuthzSession:
+    def __init__(self, client):
+        self._client = client
+        self.added = []
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def execute(self, _stmt, *_a, **_kw):
+        client = self._client
+
+        class _R:
+            def scalar_one_or_none(self_inner):
+                return client
+
+        return _R()
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+
+class _FakeRequest:
+    def __init__(self, signed_cookie):
+        self.cookies = {"oauth_state": signed_cookie}
+        self.session = {}
+
+
+def _approve(client_scope, requested="read", monkeypatch=None):
+    mp = monkeypatch or pytest.MonkeyPatch()
+    owns = monkeypatch is None
+    try:
+        mp.setattr(oauth.settings, "multi_user_mode", False, raising=False)
+        client = OAuthClient(
+            client_id="client123",
+            client_secret_hash=None,
+            token_endpoint_auth_method="none",
+            client_name="Scopeless",
+            redirect_uris=[REGISTERED_URI],
+            scope=client_scope,
+        )
+        session = _FakeAuthzSession(client)
+        mp.setattr(oauth, "async_session", lambda: session)
+        server_state = "csrfstatetoken1234567890"
+        signed = oauth._state_serializer().dumps(server_state)
+        response = asyncio.run(
+            oauth.authorize_post(
+                _FakeRequest(signed),
+                action="approve",
+                client_id="client123",
+                redirect_uri=REGISTERED_URI,
+                code_challenge="A" * 43,
+                code_challenge_method="S256",
+                scope=requested,
+                state=server_state,
+                client_state="echo",
+            )
+        )
+        return response, session
+    finally:
+        if owns:
+            mp.undo()
+
+
+def test_consent_approval_mints_no_code_for_an_offline_only_client():
+    response, session = _approve(OFFLINE_ONLY)
+
+    assert response.status_code == 400
+    assert body(response)["error"] == "invalid_scope"
+    assert session.added == []
+    assert session.committed is False
+
+
+def test_consent_approval_still_works_for_a_read_client():
+    response, session = _approve("read offline_access")
+
+    assert isinstance(response, RedirectResponse)
+    assert len(session.added) == 1
+    assert session.added[0].scope == "read"
+
+
+# --- the token endpoint refuses the exchange ------------------------------
+
+
+def _exchange(client_scope, code_scope, monkeypatch):
+    client = OAuthClient(
+        client_id="client123",
+        client_secret_hash=None,
+        token_endpoint_auth_method="none",
+        client_name="Scopeless",
+        redirect_uris=[REGISTERED_URI],
+        scope=client_scope,
+    )
+    code = OAuthCode(
+        code_hash=oauth._hash("the-code"),
+        client_id=client.client_id,
+        redirect_uri=REGISTERED_URI,
+        scope=code_scope,
+        code_challenge=oauth._base64url_sha256(VERIFIER),
+        code_challenge_method="S256",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        used=False,
+    )
+    session = _SeqSession([code, client])
+    monkeypatch.setattr(oauth, "async_session", lambda: session)
+    response = asyncio.run(
+        oauth._handle_auth_code(
+            {
+                "code": "the-code",
+                "code_verifier": VERIFIER,
+                "redirect_uri": REGISTERED_URI,
+            }
+        )
+    )
+    return response, session, code
+
+
+def test_code_exchange_mints_no_token_for_an_offline_only_client(monkeypatch):
+    """The path that would have handed out the vault-wide read token."""
+    response, session, code = _exchange(OFFLINE_ONLY, "offline_access", monkeypatch)
+
+    assert response.status_code == 400
+    assert body(response)["error"] == "invalid_scope"
+    assert session.added == []
+    assert code.used is False, "a refusal must not burn the code"
+
+
+def test_code_exchange_refuses_even_when_the_code_claims_read(monkeypatch):
+    """A code minted before the registration was narrowed cannot resurrect it."""
+    response, session, code = _exchange(OFFLINE_ONLY, "read", monkeypatch)
+
+    assert response.status_code == 400
+    assert body(response)["error"] == "invalid_scope"
+    assert session.added == []
+
+
+# --- rotation refuses too -------------------------------------------------
+
+
+def _refresh(client_scope, token_scope, monkeypatch):
+    tokens = [
+        FakeToken(
+            grant_id="g1",
+            token_type="refresh",
+            scope=token_scope,
+            expires_at=in_hours(720),
+            token_hash=oauth._hash(REFRESH_SECRET),
+        )
+    ]
+    session = FakeSession(clients=[FakeClient(scope=client_scope)], tokens=tokens)
+    monkeypatch.setattr(oauth, "async_session", lambda: session)
+    response = asyncio.run(oauth._handle_refresh({"refresh_token": REFRESH_SECRET}))
+    return response, session, tokens[0]
+
+
+def test_rotation_refuses_when_the_registration_grants_nothing(monkeypatch):
+    """A registration narrowed to `offline_access` ends the grant at the next
+    rotation instead of re-minting read access forever."""
+    response, session, old = _refresh(OFFLINE_ONLY, "offline_access read", monkeypatch)
+
+    assert response.status_code == 400
+    assert body(response)["error"] == "invalid_scope"
+    assert [o for o in session.added if isinstance(o, OAuthToken)] == []
+    assert old.revoked is False, "nothing is committed, so the old token is untouched"
+
+
+# --- the panel refuses to write an empty scope ----------------------------
+
+
+def test_panel_scope_change_is_refused_for_an_offline_only_client():
+    tokens = [
+        FakeToken(grant_id="g1", token_type="access", scope="offline_access"),
+        FakeToken(grant_id="g1", token_type="refresh", scope="offline_access"),
+    ]
+    session = FakeSession(clients=[FakeClient(scope=OFFLINE_ONLY)], tokens=tokens)
+
+    asyncio.run(
+        panel.update_oauth_token_scope(
+            token_id=tokens[0].id,
+            request=None,
+            scope="read",
+            session=session,
+            user=SingleUserSentinel(),
+        )
+    )
+
+    assert session.committed == 0
+    for token in tokens:
+        assert token.scope == "offline_access", (
+            "writing an empty scope would be worse than refusing — the "
+            "middleware maps anything without `readwrite` to `read`"
+        )
+
+
+# --- and the enforcement boundary rejects a legacy token ------------------
+
+
+def test_middleware_source_rejects_a_token_with_no_vault_scope():
+    """No path can mint one now, but a pre-fix client could already hold one.
+
+    `src/mcp_server/auth.py` mapped every non-`readwrite` scope to `read`, so
+    an `offline_access`-only token authenticated with read access to the whole
+    vault. The boundary has to reject it, not just the mint sites.
+    """
+    from src.mcp_server import auth as mcp_auth
+
+    with open(mcp_auth.__file__) as fh:
+        source = fh.read()
+    assert "has_vault_scope(oauth_token.scope)" in source
+    assert "no_vault_scope" in source

--- a/tests/test_issue_67_panel_scope_clamp.py
+++ b/tests/test_issue_67_panel_scope_clamp.py
@@ -294,9 +294,13 @@ def test_clamp_scope_never_widens():
     assert clamp_scope("readwrite", "readwrite") == "readwrite"
     # readwrite registration implies read availability
     assert clamp_scope("read", "readwrite") == "read"
-    # empty intersection falls back to the safe default
-    assert clamp_scope("", "read") == "read"
+    # A client registered read-only that asks for readwrite is downgraded,
+    # not refused — that is what a clamp means (issue #21).
     assert clamp_scope("readwrite offline_access", "read") == "read"
+    # But "no vault scope on either side" is a refusal, never a fallback.
+    assert clamp_scope("", "read") == ""
+    assert clamp_scope("read", "offline_access") == ""
+    assert clamp_scope("offline_access", "offline_access") == ""
 
 
 def test_no_surface_keeps_a_private_copy_of_the_membership_test():

--- a/tests/test_issue_67_panel_scope_clamp.py
+++ b/tests/test_issue_67_panel_scope_clamp.py
@@ -27,6 +27,7 @@ from src.oauth import routes as oauth
 from src.oauth.scope import clamp_scope, client_can_write, token_has_write
 
 from _oauth_grant_fakes import (
+    SeqSession,
     FakeClient,
     FakeRequest,
     FakeSession,
@@ -192,36 +193,6 @@ def test_refresh_keeps_a_legitimate_readwrite_grant(monkeypatch):
 # --- the authorization-code exchange clamps too --------------------------
 
 
-class _SeqSession:
-    """Returns canned rows in call order -- enough for `_handle_auth_code`."""
-
-    def __init__(self, results):
-        self._results = iter(results)
-        self.added = []
-        self.committed = False
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *_exc):
-        return False
-
-    async def execute(self, _stmt, *_a, **_kw):
-        value = next(self._results)
-
-        class _R:
-            def scalar_one_or_none(self_inner):
-                return value
-
-        return _R()
-
-    def add(self, obj):
-        self.added.append(obj)
-
-    async def commit(self):
-        self.committed = True
-
-
 def test_auth_code_exchange_clamps_against_the_registration(monkeypatch):
     """The last write path, closed for the same reason as the other two.
 
@@ -255,7 +226,7 @@ def test_auth_code_exchange_clamps_against_the_registration(monkeypatch):
         expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
         used=False,
     )
-    session = _SeqSession([code, client])
+    session = SeqSession([code, client])
     monkeypatch.setattr(oauth, "async_session", lambda: session)
 
     response = asyncio.run(

--- a/tests/test_issue_67_panel_scope_clamp.py
+++ b/tests/test_issue_67_panel_scope_clamp.py
@@ -1,0 +1,317 @@
+"""Issue #67: no path may raise a grant above the client's registration.
+
+`OAuthClient.scope` is what the OAuth path treats as authoritative: the consent
+screen gates the Read+Write radio on it, and `authorize_post` re-clamps the
+posted form value precisely so a read-only-registered client cannot mint a
+readwrite code. The panel bypassed both -- `update_oauth_token_scope` validated
+the submitted value against the literal tuple `('read', 'readwrite')` and wrote
+it straight onto the token.
+
+And it was **permanent**: `_handle_refresh` re-minted with the token's own
+scope and never re-clamped, so a panel-granted `readwrite` on the refresh row
+survived every rotation indefinitely, not just the access token's hour.
+
+The registration is a statement about that software. These tests pin the three
+places that statement now holds: the panel handler, the rendered options, and
+rotation.
+"""
+import asyncio
+import json
+
+import pytest
+
+from src.control_panel import routes as panel
+from src.mcp_server import auth as mcp_auth
+from src.models.db import OAuthToken
+from src.oauth import routes as oauth
+from src.oauth.scope import clamp_scope, client_can_write, token_has_write
+
+from _oauth_grant_fakes import (
+    FakeClient,
+    FakeRequest,
+    FakeSession,
+    FakeToken,
+    SingleUserSentinel,
+    in_hours,
+)
+
+READ_ONLY = "read"
+FULL = "read readwrite offline_access"
+REFRESH_SECRET = "r" * 64
+
+
+def family(scope="read", grant_id="g1"):
+    return [
+        FakeToken(grant_id=grant_id, token_type="access", scope=scope, expires_at=in_hours(1)),
+        FakeToken(
+            grant_id=grant_id,
+            token_type="refresh",
+            scope=scope,
+            expires_at=in_hours(720),
+            token_hash=oauth._hash(REFRESH_SECRET),
+        ),
+    ]
+
+
+def set_scope(session, token_id, scope):
+    return asyncio.run(
+        panel.update_oauth_token_scope(
+            token_id=token_id, scope=scope, session=session, user=SingleUserSentinel()
+        )
+    )
+
+
+# --- the panel handler refuses to exceed the registration ----------------
+
+
+def test_read_only_client_cannot_be_raised_to_readwrite_from_the_panel():
+    """The failing scenario in the issue, at the handler.
+
+    A DCR client registered `"scope": "read"` gets `oauth_clients.scope =
+    'read'`. Selecting `readwrite` in the panel used to commit it with no
+    clamp, and `src/mcp_server/auth.py` then granted write.
+    """
+    tokens = family(scope="read")
+    session = FakeSession(clients=[FakeClient(scope=READ_ONLY)], tokens=tokens)
+
+    set_scope(session, tokens[0].id, "readwrite")
+
+    for token in tokens:
+        assert token.scope == "read"
+        assert token_has_write(token.scope) is False
+    assert session.committed == 0, "nothing should have been written"
+
+
+def test_readwrite_registered_client_may_still_be_raised():
+    tokens = family(scope="read")
+    session = FakeSession(clients=[FakeClient(scope=FULL)], tokens=tokens)
+
+    set_scope(session, tokens[0].id, "readwrite")
+
+    for token in tokens:
+        assert token_has_write(token.scope) is True
+
+
+def test_downgrade_is_always_allowed_whatever_the_registration():
+    """`readwrite` implies `read`; narrowing must never be refused."""
+    tokens = family(scope="readwrite")
+    session = FakeSession(clients=[FakeClient(scope=FULL)], tokens=tokens)
+
+    set_scope(session, tokens[0].id, "read")
+
+    for token in tokens:
+        assert token_has_write(token.scope) is False
+
+
+def test_offline_access_is_not_kept_past_a_registration_that_lost_it():
+    """The written value is clamped, not just the read/readwrite choice."""
+    tokens = family(scope="offline_access read")
+    session = FakeSession(clients=[FakeClient(scope=READ_ONLY)], tokens=tokens)
+
+    set_scope(session, tokens[0].id, "read")
+
+    for token in tokens:
+        assert set(token.scope.split()) == {"read"}
+
+
+def test_missing_client_row_is_a_404_not_an_unclamped_write():
+    """Without a registration there is nothing to clamp against, so refuse."""
+    from fastapi import HTTPException
+
+    tokens = family(scope="read")
+    session = FakeSession(clients=[], tokens=tokens)
+
+    with pytest.raises(HTTPException) as exc:
+        set_scope(session, tokens[0].id, "readwrite")
+
+    assert exc.value.status_code == 404
+    assert all(t.scope == "read" for t in tokens)
+
+
+# --- the template never offers an option the client cannot hold ----------
+
+
+def render(clients, tokens):
+    session = FakeSession(clients=clients, tokens=tokens)
+    response = asyncio.run(
+        panel.oauth_page(
+            request=FakeRequest(), session=session, user=SingleUserSentinel()
+        )
+    )
+    return response.body.decode()
+
+
+def test_readwrite_option_is_absent_for_a_read_only_client():
+    html = render([FakeClient(scope=READ_ONLY)], family(scope="read"))
+    assert '<option value="read"' in html
+    assert '<option value="readwrite"' not in html
+
+
+def test_readwrite_option_is_present_for_a_write_registered_client():
+    html = render([FakeClient(scope=FULL)], family(scope="read"))
+    assert '<option value="readwrite"' in html
+
+
+# --- rotation re-clamps, so nothing above the registration is permanent --
+
+
+def test_refresh_reclamps_a_scope_above_the_registration(monkeypatch):
+    """The "permanent" half of the issue.
+
+    Even if a token somehow carries `readwrite` under a read-only client --
+    a pre-fix panel write, or a registration narrowed after the grant -- the
+    next rotation must not carry it forward.
+    """
+    tokens = family(scope="offline_access readwrite")
+    session = FakeSession(clients=[FakeClient(scope=READ_ONLY)], tokens=tokens)
+    monkeypatch.setattr(oauth, "async_session", lambda: session)
+
+    response = asyncio.run(oauth._handle_refresh({"refresh_token": REFRESH_SECRET}))
+
+    assert response.status_code == 200
+    assert "readwrite" not in json.loads(response.body)["scope"].split()
+    minted = [o for o in session.added if isinstance(o, OAuthToken)]
+    assert len(minted) == 2
+    for token in minted:
+        assert token_has_write(token.scope) is False
+
+
+def test_refresh_keeps_a_legitimate_readwrite_grant(monkeypatch):
+    """The clamp must not quietly downgrade a grant the client is entitled to."""
+    tokens = family(scope="offline_access readwrite")
+    session = FakeSession(clients=[FakeClient(scope=FULL)], tokens=tokens)
+    monkeypatch.setattr(oauth, "async_session", lambda: session)
+
+    response = asyncio.run(oauth._handle_refresh({"refresh_token": REFRESH_SECRET}))
+
+    assert "readwrite" in json.loads(response.body)["scope"].split()
+    for token in [o for o in session.added if isinstance(o, OAuthToken)]:
+        assert token_has_write(token.scope) is True
+
+
+# --- the authorization-code exchange clamps too --------------------------
+
+
+class _SeqSession:
+    """Returns canned rows in call order -- enough for `_handle_auth_code`."""
+
+    def __init__(self, results):
+        self._results = iter(results)
+        self.added = []
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def execute(self, _stmt, *_a, **_kw):
+        value = next(self._results)
+
+        class _R:
+            def scalar_one_or_none(self_inner):
+                return value
+
+        return _R()
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+
+def test_auth_code_exchange_clamps_against_the_registration(monkeypatch):
+    """The last write path, closed for the same reason as the other two.
+
+    `authorize_post` already clamps what it writes onto the code, so this is
+    normally a no-op -- but it is the only thing between a code minted under
+    one registration and a token minted under a narrower one, and "normally a
+    no-op" is not a guarantee.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from src.models.db import OAuthClient, OAuthCode
+
+    verifier = "v" * 64
+    client = OAuthClient(
+        client_id="client123",
+        client_secret_hash=None,
+        token_endpoint_auth_method="none",
+        client_name="Claude",
+        redirect_uris=["https://example.test/cb"],
+        scope=READ_ONLY,
+    )
+    code = OAuthCode(
+        code_hash=oauth._hash("the-code"),
+        client_id=client.client_id,
+        redirect_uri=client.redirect_uris[0],
+        # A code carrying more than the registration allows — however it got
+        # there, it must not become a token.
+        scope="offline_access readwrite",
+        code_challenge=oauth._base64url_sha256(verifier),
+        code_challenge_method="S256",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        used=False,
+    )
+    session = _SeqSession([code, client])
+    monkeypatch.setattr(oauth, "async_session", lambda: session)
+
+    response = asyncio.run(
+        oauth._handle_auth_code(
+            {
+                "code": "the-code",
+                "code_verifier": verifier,
+                "redirect_uri": client.redirect_uris[0],
+            }
+        )
+    )
+
+    assert response.status_code == 200
+    assert "readwrite" not in json.loads(response.body)["scope"].split()
+    minted = [o for o in session.added if isinstance(o, OAuthToken)]
+    assert len(minted) == 2
+    for token in minted:
+        assert token_has_write(token.scope) is False
+
+
+# --- the helpers, and the fact that every surface uses them --------------
+
+
+def test_client_can_write_is_membership_not_equality():
+    assert client_can_write("read readwrite offline_access") is True
+    assert client_can_write("readwrite") is True
+    assert client_can_write("read") is False
+    assert client_can_write("read offline_access") is False
+    assert client_can_write("") is False
+    assert client_can_write(None) is False
+
+
+def test_clamp_scope_never_widens():
+    assert clamp_scope("readwrite", "read") == "read"
+    assert clamp_scope("read", "read") == "read"
+    assert clamp_scope("readwrite", "readwrite") == "readwrite"
+    # readwrite registration implies read availability
+    assert clamp_scope("read", "readwrite") == "read"
+    # empty intersection falls back to the safe default
+    assert clamp_scope("", "read") == "read"
+    assert clamp_scope("readwrite offline_access", "read") == "read"
+
+
+def test_no_surface_keeps_a_private_copy_of_the_membership_test():
+    """The layers that used to each carry their own `"readwrite" in …`.
+
+    They agreed by coincidence, which is not a property anything could test --
+    and it stopped holding the moment the panel grew a fourth path with no
+    clamp at all. `authorize_get` is deliberately not checked here: its
+    `"readwrite" in scope_parts` reads the *requested* scope off the query
+    string, which is a different question from what a client or a token holds.
+    """
+    for module in (panel, mcp_auth):
+        with open(module.__file__) as fh:
+            body = fh.read()
+        assert '"readwrite" in ' not in body, module.__file__
+    # And the OAuth routes' historical private name is the shared helper
+    # itself, not a second implementation kept in step by hand.
+    assert oauth._clamp_scope is clamp_scope

--- a/tests/test_issue_68_cross_user_client.py
+++ b/tests/test_issue_68_cross_user_client.py
@@ -28,6 +28,8 @@ from fastapi.responses import RedirectResponse
 
 from src.oauth import routes as oauth
 
+from _oauth_grant_fakes import SeqSession
+
 REGISTERED_URI = "https://client.example.com/callback"
 
 
@@ -192,34 +194,6 @@ def test_denial_still_redirects_rather_than_403ing():
 # --- the exchange re-checks, closing the unbound-client race --------------
 
 
-class _SeqSession:
-    def __init__(self, results):
-        self._results = iter(results)
-        self.added = []
-        self.committed = False
-
-    async def __aenter__(self):
-        return self
-
-    async def __aexit__(self, *_exc):
-        return False
-
-    async def execute(self, _stmt, *_a, **_kw):
-        value = next(self._results)
-
-        class _R:
-            def scalar_one_or_none(self_inner):
-                return value
-
-        return _R()
-
-    def add(self, obj):
-        self.added.append(obj)
-
-    async def commit(self):
-        self.committed = True
-
-
 def _exchange(client_user_id, code_user_id):
     from datetime import datetime, timedelta, timezone
 
@@ -246,7 +220,7 @@ def _exchange(client_user_id, code_user_id):
         used=False,
         user_id=code_user_id,
     )
-    session = _SeqSession([code, client])
+    session = SeqSession([code, client])
     monkeypatch = pytest.MonkeyPatch()
     try:
         monkeypatch.setattr(oauth, "async_session", lambda: session)

--- a/tests/test_issue_68_cross_user_client.py
+++ b/tests/test_issue_68_cross_user_client.py
@@ -25,6 +25,7 @@ import json
 
 import pytest
 from fastapi.responses import RedirectResponse
+from sqlalchemy.sql.dml import Update
 
 from src.oauth import routes as oauth
 
@@ -61,7 +62,18 @@ class _FakeSession:
     async def __aexit__(self, *_exc):
         return False
 
-    async def execute(self, _stmt):
+    async def execute(self, stmt, *_a, **_kw):
+        # The first-authorizer claim is a conditional `UPDATE oauth_clients ...
+        # WHERE user_id IS NULL RETURNING client_id`, so the database — not
+        # whichever transaction read its snapshot last — decides who wins when
+        # two users consent to the same unbound client at once. The fake
+        # applies it only when the row really is unowned, and `claimed_by`
+        # lets a test stage a concurrent winner.
+        if isinstance(stmt, Update):
+            if self._client is not None and self._client.user_id is None:
+                self._client.user_id = dict(stmt.compile().params).get("user_id")
+                return _Result(self._client.client_id)
+            return _Result(None)
         return _Result(self._client)
 
     def add(self, obj):
@@ -265,6 +277,115 @@ def test_a_single_user_code_is_unaffected_by_a_claimed_client():
 
     assert response.status_code == 200
     assert len(session.added) == 2
+
+
+# --- the first-claim race -------------------------------------------------
+
+
+def _selects_only_owner(stmt) -> bool:
+    """Is this `select(OAuthClient.user_id)` rather than `select(OAuthClient)`?"""
+    try:
+        descriptions = stmt.column_descriptions
+    except Exception:
+        return False
+    return len(descriptions) == 1 and getattr(
+        descriptions[0].get("expr"), "key", None
+    ) == "user_id"
+
+
+class _ContendedSession(_FakeSession):
+    """A session whose client is claimed by somebody else mid-transaction.
+
+    Models the interleaving exactly: both consents read `user_id IS NULL` from
+    their own snapshot, then one commits. The loser's conditional UPDATE
+    matches nothing, and its follow-up SELECT — a new statement, so a new
+    snapshot — sees the winner.
+    """
+
+    def __init__(self, client, winner_user_id):
+        super().__init__(client)
+        self._winner = winner_user_id
+        self.claim_attempts = 0
+
+    async def execute(self, stmt, *_a, **_kw):
+        if isinstance(stmt, Update):
+            self.claim_attempts += 1
+            # The winner got there between our snapshot and this statement.
+            self._client.user_id = self._winner
+            return _Result(None)
+        if _selects_only_owner(stmt):
+            # The handler re-reads `OAuthClient.user_id` alone; returning the
+            # whole row here would make every self-race look like a conflict.
+            return _Result(self._client.user_id)
+        return _Result(self._client)
+
+
+def _approve_contended(winner_user_id, session_user_id):
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(oauth.settings, "multi_user_mode", True, raising=False)
+        client = _FakeClient(user_id=None)
+        session = _ContendedSession(client, winner_user_id)
+        monkeypatch.setattr(oauth, "async_session", lambda: session)
+
+        async def _resolve(_request, _session):
+            return _SessionUser(session_user_id)
+
+        monkeypatch.setattr(oauth, "get_active_session_user", _resolve)
+        server_state = "csrfstatetoken1234567890"
+        signed = oauth._state_serializer().dumps(server_state)
+        response = asyncio.run(
+            oauth.authorize_post(
+                _FakeRequest(signed),
+                action="approve",
+                client_id="client123",
+                redirect_uri=REGISTERED_URI,
+                code_challenge="A" * 43,
+                code_challenge_method="S256",
+                scope="readwrite",
+                state=server_state,
+                client_state="clientecho",
+            )
+        )
+        return response, session, client
+    finally:
+        monkeypatch.undo()
+
+
+def test_losing_the_claim_race_to_another_user_mints_nothing():
+    """The unconditional ORM assignment let the loser overwrite the winner.
+
+    `client_row.user_id is None` was read from this transaction's snapshot, so
+    both consents believed the client was unbound and the second write won —
+    silently re-binding a client another user had just claimed, and minting a
+    code under it.
+    """
+    response, session, client = _approve_contended(winner_user_id=1, session_user_id=2)
+
+    assert session.claim_attempts == 1
+    assert response.status_code == 403
+    assert error(response)["error"] == "access_denied"
+    assert session.added == [], "no authorization code may be minted"
+    assert client.user_id == 1, "the winner's claim must stand"
+
+
+def test_losing_the_claim_race_to_yourself_is_not_an_error():
+    """One person with two tabs is the ordinary case, not a conflict."""
+    response, session, client = _approve_contended(winner_user_id=5, session_user_id=5)
+
+    assert isinstance(response, RedirectResponse)
+    assert len(session.added) == 1
+    assert session.added[0].user_id == 5
+    assert client.user_id == 5
+
+
+def test_the_claim_is_conditional_on_the_row_still_being_unowned():
+    """`WHERE user_id IS NULL` is what makes the database the arbiter."""
+    import inspect
+
+    source = inspect.getsource(oauth.authorize_post)
+    assert "OAuthClient.user_id.is_(None)" in source
+    assert ".returning(" in source
 
 
 # --- the helper -----------------------------------------------------------

--- a/tests/test_issue_68_cross_user_client.py
+++ b/tests/test_issue_68_cross_user_client.py
@@ -1,0 +1,305 @@
+"""Issue #68: a client bound to one user must not mint grants for another.
+
+An OAuth client binds to its **first** authorizing user and never rebinds
+(`src/oauth/routes.py`: "Subsequent authorizes for the same client leave
+`user_id` alone"). The enforcement layer authenticates on the `OAuthToken` row
+alone and never consults the client's owner, so a second user who authorized
+the same `client_id` got live tokens under a client they do not own:
+
+* `oauth_page` filters clients by `OAuthClient.user_id`, so their own live
+  readwrite grant rendered as "No OAuth clients registered" -- invisible and
+  unrevokable in the only UI they have;
+* the owner's "Delete this client and revoke all its tokens?" cascades through
+  `oauth_tokens.client_id ondelete=CASCADE` and silently kills it.
+
+The issue offers two fixes and prefers (b): refuse the reuse at the source,
+which also closes the converse hazard. Unioning the client list instead (a)
+would have to gate every client-level action, and the first draft of that idea
+renders the owner's Delete button to the other user.
+
+Preconditions are narrow -- `multi_user_mode` defaults to False -- so the
+single-user path is pinned here too: it must be completely unaffected.
+"""
+import asyncio
+import json
+
+import pytest
+from fastapi.responses import RedirectResponse
+
+from src.oauth import routes as oauth
+
+REGISTERED_URI = "https://client.example.com/callback"
+
+
+class _FakeClient:
+    def __init__(self, user_id=None, scope="read readwrite offline_access"):
+        self.client_id = "client123"
+        self.scope = scope
+        self.redirect_uris = [REGISTERED_URI]
+        self.user_id = user_id
+
+
+class _Result:
+    def __init__(self, obj):
+        self._obj = obj
+
+    def scalar_one_or_none(self):
+        return self._obj
+
+
+class _FakeSession:
+    def __init__(self, client):
+        self._client = client
+        self.added = []
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def execute(self, _stmt):
+        return _Result(self._client)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+
+class _FakeRequest:
+    def __init__(self, signed_cookie):
+        self.cookies = {"oauth_state": signed_cookie}
+        self.session = {}
+
+
+class _SessionUser:
+    def __init__(self, uid):
+        self.id = uid
+
+
+def approve(client, *, multi_user, session_user_id=None, action="approve"):
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(oauth.settings, "multi_user_mode", multi_user, raising=False)
+        session = _FakeSession(client)
+        monkeypatch.setattr(oauth, "async_session", lambda: session)
+
+        async def _resolve(_request, _session):
+            return _SessionUser(session_user_id) if session_user_id else None
+
+        monkeypatch.setattr(oauth, "get_active_session_user", _resolve)
+
+        server_state = "csrfstatetoken1234567890"
+        signed = oauth._state_serializer().dumps(server_state)
+        response = asyncio.run(
+            oauth.authorize_post(
+                _FakeRequest(signed),
+                action=action,
+                client_id="client123",
+                redirect_uri=REGISTERED_URI,
+                code_challenge="A" * 43,
+                code_challenge_method="S256",
+                scope="readwrite",
+                state=server_state,
+                client_state="clientecho",
+            )
+        )
+        return response, session
+    finally:
+        monkeypatch.undo()
+
+
+def error(response) -> dict:
+    return json.loads(response.body)
+
+
+# --- the refusal ----------------------------------------------------------
+
+
+def test_second_user_cannot_authorize_a_client_owned_by_someone_else():
+    """User B approving user A's client mints nothing at all."""
+    response, session = approve(
+        _FakeClient(user_id=1), multi_user=True, session_user_id=2
+    )
+
+    assert response.status_code == 403
+    assert error(response)["error"] == "access_denied"
+    assert session.added == [], "no authorization code may be minted"
+    assert session.committed is False
+
+
+def test_the_refusal_does_not_rebind_the_client():
+    """The owner's binding is left exactly as it was."""
+    client = _FakeClient(user_id=1)
+    approve(client, multi_user=True, session_user_id=2)
+
+    assert client.user_id == 1
+
+
+def test_the_owner_can_still_authorize_their_own_client():
+    response, session = approve(
+        _FakeClient(user_id=7), multi_user=True, session_user_id=7
+    )
+
+    assert isinstance(response, RedirectResponse)
+    assert len(session.added) == 1
+    assert session.added[0].user_id == 7
+
+
+def test_an_unbound_client_is_claimed_by_its_first_authorizer():
+    """First /authorize wins is unchanged -- RFC 7591 registration is
+    unauthenticated, so there is nothing to bind at registration time."""
+    client = _FakeClient(user_id=None)
+    response, session = approve(client, multi_user=True, session_user_id=5)
+
+    assert isinstance(response, RedirectResponse)
+    assert client.user_id == 5
+    assert session.added[0].user_id == 5
+
+
+def test_single_user_mode_is_unaffected():
+    """`multi_user_mode` defaults to False and there is no second identity.
+
+    A legacy client carrying a stale `user_id` must not lock the single-user
+    deployment out of its own connector.
+    """
+    for owner in (None, 1):
+        response, session = approve(_FakeClient(user_id=owner), multi_user=False)
+
+        assert isinstance(response, RedirectResponse), owner
+        assert len(session.added) == 1
+        assert session.added[0].user_id is None
+
+
+def test_denial_still_redirects_rather_than_403ing():
+    """A user who clicks Deny gets the protocol's access_denied redirect.
+
+    The cross-user check sits after the deny branch on purpose: the client is
+    entitled to a redirect it can parse, and nothing is minted either way.
+    """
+    response, session = approve(
+        _FakeClient(user_id=1), multi_user=True, session_user_id=2, action="deny"
+    )
+
+    assert isinstance(response, RedirectResponse)
+    assert "error=access_denied" in response.headers["location"]
+    assert session.added == []
+
+
+# --- the exchange re-checks, closing the unbound-client race --------------
+
+
+class _SeqSession:
+    def __init__(self, results):
+        self._results = iter(results)
+        self.added = []
+        self.committed = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+    async def execute(self, _stmt, *_a, **_kw):
+        value = next(self._results)
+
+        class _R:
+            def scalar_one_or_none(self_inner):
+                return value
+
+        return _R()
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    async def commit(self):
+        self.committed = True
+
+
+def _exchange(client_user_id, code_user_id):
+    from datetime import datetime, timedelta, timezone
+
+    from src.models.db import OAuthClient, OAuthCode
+
+    verifier = "v" * 64
+    client = OAuthClient(
+        client_id="client123",
+        client_secret_hash=None,
+        token_endpoint_auth_method="none",
+        client_name="Claude",
+        redirect_uris=[REGISTERED_URI],
+        scope="read readwrite offline_access",
+        user_id=client_user_id,
+    )
+    code = OAuthCode(
+        code_hash=oauth._hash("the-code"),
+        client_id=client.client_id,
+        redirect_uri=REGISTERED_URI,
+        scope="read",
+        code_challenge=oauth._base64url_sha256(verifier),
+        code_challenge_method="S256",
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        used=False,
+        user_id=code_user_id,
+    )
+    session = _SeqSession([code, client])
+    monkeypatch = pytest.MonkeyPatch()
+    try:
+        monkeypatch.setattr(oauth, "async_session", lambda: session)
+        response = asyncio.run(
+            oauth._handle_auth_code(
+                {
+                    "code": "the-code",
+                    "code_verifier": verifier,
+                    "redirect_uri": REGISTERED_URI,
+                }
+            )
+        )
+        return response, session, code
+    finally:
+        monkeypatch.undo()
+
+
+def test_a_code_cannot_be_exchanged_under_a_client_another_user_claimed():
+    """`authorize_post` claims an unbound client in the same transaction as
+    the code, so two users consenting to the same unbound client at once both
+    get a code and only one claim wins. The loser's code must not become
+    tokens under a client they do not own."""
+    response, session, code = _exchange(client_user_id=1, code_user_id=2)
+
+    assert response.status_code == 400
+    assert error(response)["error"] == "invalid_grant"
+    assert session.added == []
+    assert code.used is False, "a refused exchange must not burn the code"
+
+
+def test_the_matching_owner_exchanges_normally():
+    response, session, _ = _exchange(client_user_id=7, code_user_id=7)
+
+    assert response.status_code == 200
+    assert len(session.added) == 2
+
+
+def test_a_single_user_code_is_unaffected_by_a_claimed_client():
+    """A code minted before multi-user mode carries a NULL `user_id`; the
+    bootstrap may since have claimed the client. That must still exchange."""
+    response, session, _ = _exchange(client_user_id=1, code_user_id=None)
+
+    assert response.status_code == 200
+    assert len(session.added) == 2
+
+
+# --- the helper -----------------------------------------------------------
+
+
+def test_client_belongs_to_another_user_helper():
+    assert oauth._client_belongs_to_another_user(_FakeClient(user_id=1), 2) is True
+    assert oauth._client_belongs_to_another_user(_FakeClient(user_id=1), 1) is False
+    # Unbound client: about to be claimed by its first authorizer.
+    assert oauth._client_belongs_to_another_user(_FakeClient(user_id=None), 2) is False
+    # No session identity: single-user mode, no other users to conflict with.
+    assert oauth._client_belongs_to_another_user(_FakeClient(user_id=1), None) is False

--- a/tests/test_oauth_grant_fakes_fidelity.py
+++ b/tests/test_oauth_grant_fakes_fidelity.py
@@ -1,0 +1,159 @@
+"""The fake session must not be more forgiving than Postgres.
+
+Every concurrency and listing property in the grant-family suite is asserted
+*through* `tests/_oauth_grant_fakes.FakeSession`, so a fake that answers a
+question more loosely than the database does converts a real regression into a
+green run. Two loosenesses were found by review and are pinned here:
+
+* **Lock detection by substring.** `"pg_advisory_xact_lock" in str(stmt)` counts
+  a decoy — the function name inside a SQL comment, or a statement that merely
+  mentions it — as a lock that was taken. Every "the lock came first" assertion
+  would then pass against a handler that never locked.
+* **Expiry ignored.** `oauth_page` splits its listing with `expires_at > now`
+  and `expires_at <= now`. A fake that ignored both returned every row to both
+  queries, so the live/dead split — the thing that keeps a live grant on the
+  page and caps only history — was never exercised, and an expired token would
+  have rendered as live.
+"""
+import datetime
+
+from sqlalchemy import or_, select, text
+
+from src.models.db import OAuthToken
+
+from _oauth_grant_fakes import (
+    ADVISORY_LOCK_SQL,
+    FakeSession,
+    FakeToken,
+    _is_advisory_lock,
+    in_hours,
+    utcnow,
+)
+
+
+# --- the lock matcher -----------------------------------------------------
+
+
+def test_the_real_lock_statement_is_recognised():
+    assert _is_advisory_lock(text(ADVISORY_LOCK_SQL)) is True
+    # Whitespace is normalized, so a reformatted but identical statement counts.
+    assert _is_advisory_lock(text("SELECT   pg_advisory_xact_lock(:key)\n")) is True
+
+
+def test_a_decoy_mentioning_the_lock_is_not_a_lock():
+    """A comment naming the function must not be counted as taking it."""
+    decoys = [
+        text("SELECT 1 -- pg_advisory_xact_lock(:key)"),
+        text("/* pg_advisory_xact_lock */ SELECT 1"),
+        text("SELECT pg_advisory_xact_lock(:key), 1"),
+        text("SELECT pg_try_advisory_xact_lock(:key)"),
+        select(OAuthToken).where(OAuthToken.grant_id == "pg_advisory_xact_lock(:key)"),
+    ]
+    for stmt in decoys:
+        assert _is_advisory_lock(stmt) is False, str(stmt)
+
+
+def test_a_decoy_is_not_recorded_as_an_advisory_lock():
+    """End to end through the fake: the decoy must not land in the log.
+
+    This is the assertion that matters — `advisory_locks` is what the ordering
+    tests read, so a decoy counted there is a lock the handler never took. The
+    fake refuses the statement outright instead, which is the right second
+    half: an unmodelled statement must fail loudly, not pass as something else.
+    """
+    import asyncio
+
+    import pytest
+
+    session = FakeSession(tokens=[])
+
+    with pytest.raises(AssertionError, match="unexpected statement"):
+        asyncio.run(
+            session.execute(
+                text("SELECT 1 -- pg_advisory_xact_lock(:key)"), {"key": 99}
+            )
+        )
+
+    assert session.advisory_locks == []
+
+
+# --- expiry, both directions ---------------------------------------------
+
+
+def _tokens():
+    return [
+        FakeToken(grant_id="g1", token_type="access", expires_at=in_hours(1)),
+        FakeToken(grant_id="g1", token_type="refresh", expires_at=in_hours(-1)),
+    ]
+
+
+def _run(session, stmt):
+    import asyncio
+
+    async def go():
+        result = await session.execute(stmt)
+        return result.scalars().all()
+
+    return asyncio.run(go())
+
+
+def test_a_greater_than_comparison_keeps_only_unexpired_rows():
+    tokens = _tokens()
+    session = FakeSession(tokens=tokens)
+    now = utcnow()
+
+    rows = _run(session, select(OAuthToken).where(OAuthToken.expires_at > now))
+
+    assert [t.token_type for t in rows] == ["access"]
+
+
+def test_a_less_than_or_equal_comparison_keeps_only_expired_rows():
+    tokens = _tokens()
+    session = FakeSession(tokens=tokens)
+    now = utcnow()
+
+    rows = _run(session, select(OAuthToken).where(OAuthToken.expires_at <= now))
+
+    assert [t.token_type for t in rows] == ["refresh"]
+
+
+def test_the_history_disjunction_keeps_revoked_but_unexpired_rows():
+    """`revoked OR expires_at <= now` is a disjunction, not two AND filters.
+
+    Evaluating the halves separately would drop every revoked-but-unexpired
+    row — exactly the revocation the operator just performed, and the row the
+    panel lists so that revocation is visible.
+    """
+    revoked_live = FakeToken(
+        grant_id="g1", token_type="access", revoked=True, expires_at=in_hours(5)
+    )
+    expired = FakeToken(grant_id="g1", token_type="refresh", expires_at=in_hours(-1))
+    healthy = FakeToken(grant_id="g1", token_type="access", expires_at=in_hours(5))
+    session = FakeSession(tokens=[revoked_live, expired, healthy])
+    now = utcnow()
+
+    rows = _run(
+        session,
+        select(OAuthToken).where(
+            or_(OAuthToken.revoked == True, OAuthToken.expires_at <= now)  # noqa: E712
+        ),
+    )
+
+    assert {t.id for t in rows} == {revoked_live.id, expired.id}
+
+
+def test_an_unmodelled_comparison_fails_loudly():
+    """Silence would be the failure mode this whole module is about."""
+    import asyncio
+
+    import pytest
+
+    session = FakeSession(tokens=_tokens())
+    stmt = select(OAuthToken).where(
+        OAuthToken.expires_at.between(
+            utcnow(), utcnow() + datetime.timedelta(hours=2)
+        )
+    )
+
+    with pytest.raises(AssertionError, match="expires_at"):
+        asyncio.run(session.execute(stmt))

--- a/tests/test_oauth_panel_scope_display.py
+++ b/tests/test_oauth_panel_scope_display.py
@@ -113,7 +113,6 @@ def test_oauth_page_and_middleware_agree_on_every_scope_string():
         "readwrite",
         "offline_access read",
         "offline_access readwrite",
-        "",
     ):
         middleware_permission = "readwrite" if token_has_write(scope) else "read"
         html = render_oauth_page(
@@ -121,6 +120,17 @@ def test_oauth_page_and_middleware_agree_on_every_scope_string():
             tokens=[FakeToken(grant_id="g1", scope=scope)],
         )
         assert selected_option(html) == middleware_permission, scope
+
+    # A scope with no vault permission at all is not "read" on either side:
+    # the middleware 401s it and the page offers no scope control for it.
+    # Feeding it to `selected_option` would assert a permission neither layer
+    # grants — see tests/test_issue_67_offline_access_only_client.py.
+    for scope in ("", "offline_access"):
+        html = render_oauth_page(
+            clients=[FakeClient()],
+            tokens=[FakeToken(grant_id="g1", scope=scope)],
+        )
+        assert "<option" not in html, scope
 
     # And the middleware really is built on that helper, not a private copy.
     source = mcp_auth.__file__

--- a/tests/test_oauth_panel_scope_display.py
+++ b/tests/test_oauth_panel_scope_display.py
@@ -1,195 +1,291 @@
-"""Regression test: the admin panel's OAuth token scope dropdown must
-reflect a token's actual granted permission, not just an exact string
-match against "read" / "readwrite".
+"""The admin panel's OAuth scope dropdown must reflect the *granted* permission.
 
-`OAuthToken.scope` is a space-separated set (e.g. "offline_access
-readwrite" - offline_access is requested by every DCR-registered client
-per DEFAULT_CLIENT_SCOPE in src/oauth/routes.py). oauth.html's <select>
-previously compared `token.scope == 'read'` / `== 'readwrite'` directly:
-neither literal ever matches a scope string that also carries
-offline_access, so NEITHER <option> got `selected` and the browser fell
-back to showing the first one, "read" - misrepresenting an actual
-readwrite grant as read-only in the UI. The real permission (checked by
-src/mcp_server/auth.py via `"readwrite" in scope_parts`) was correct the
-whole time; only the display was wrong.
+`OAuthToken.scope` is a space-separated set (e.g. "offline_access readwrite" --
+offline_access is requested by every DCR-registered client per
+DEFAULT_CLIENT_SCOPE in src/oauth/routes.py). oauth.html's <select> originally
+compared `token.scope == 'read'` / `== 'readwrite'` directly: neither literal
+ever matches a scope string that also carries offline_access, so NEITHER
+<option> got `selected`, the browser fell back to the first one, and a real
+readwrite grant rendered as read-only. #62 fixed that by computing a
+membership-based `has_write` in `oauth_page`.
 
-Fix: compute `has_write` (a membership check) in oauth_page and drive the
-template's `selected` attributes off that instead of raw string equality.
-Also verified: update_oauth_token_scope preserves the offline_access
-marker instead of silently dropping it when an admin flips read/readwrite
-via the panel.
+**These tests exercise the route, not a hand-built context** -- that is issue
+#65 gap 1. The original fixture supplied both `scope` and `has_write` to the
+template, so setting `has_write=False` unconditionally in `oauth_page` left
+every assertion green: the route half of the fix was untested. Here the fake
+session yields `OAuthToken`-shaped rows and `oauth_page` derives everything,
+so a regression in the derivation fails these tests.
+
+Gap 2 (an assertion that only exercised Python's `in`) is replaced by calls
+into the production helper `src.oauth.scope.token_has_write`, which is now also
+what `src/mcp_server/auth.py` maps a token to a permission with -- those two
+agreeing is the property that actually matters.
 """
 import asyncio
-import os
+import re
 
-import pydantic_settings
+import pytest
 
-_orig_init = pydantic_settings.BaseSettings.__init__
+from src.control_panel import routes
+from src.mcp_server import auth as mcp_auth
+from src.oauth.scope import token_has_write
 
-
-def _no_env_file_init(self, *args, **kwargs):
-    kwargs.setdefault("_env_file", None)
-    _orig_init(self, *args, **kwargs)
-
-
-pydantic_settings.BaseSettings.__init__ = _no_env_file_init
-try:
-    from starlette.templating import Jinja2Templates
-
-    from src.control_panel import routes
-finally:
-    pydantic_settings.BaseSettings.__init__ = _orig_init
-
-
-TEMPLATES_DIR = os.path.join(
-    os.path.dirname(routes.__file__), "templates"
+from _oauth_grant_fakes import (
+    FakeClient,
+    FakeRequest,
+    FakeSession,
+    FakeToken,
+    FakeUser,
+    SingleUserSentinel,
+    in_hours,
 )
 
 
-def _render_oauth_page(tokens: list[dict]) -> str:
-    templates = Jinja2Templates(directory=TEMPLATES_DIR)
-    response = templates.TemplateResponse(
-        request=None,  # oauth.html never touches `request` directly
-        name="oauth.html",
-        context={
-            "active": "oauth",
-            "is_admin": True,
-            "multi_user_mode": False,
-            "username": "admin",
-            "csrf_token": "test-csrf-token",
-            "clients": [
-                {
-                    "client_id": "client123",
-                    "client_name": "Claude",
-                    "created_at": "2026-08-20T00:00:00Z",
-                    "tokens": tokens,
-                }
-            ],
-        },
+def render_oauth_page(*, clients, tokens, users=(), user=None) -> str:
+    """Run the real `oauth_page` over fake rows and return the rendered HTML."""
+    session = FakeSession(clients=clients, tokens=tokens, users=users)
+    response = asyncio.run(
+        routes.oauth_page(
+            request=FakeRequest(),
+            session=session,
+            user=user or SingleUserSentinel(),
+        )
     )
     return response.body.decode()
 
 
-def _base_token(**overrides) -> dict:
-    token = {
-        "id": 1,
-        "token_type": "access",
-        "scope": "offline_access readwrite",
-        "has_write": True,
-        "revoked": False,
-        "expired": False,
-        "expires_at": "2026-09-01T00:00:00Z",
-        "created_at": "2026-08-20T00:00:00Z",
-    }
-    token.update(overrides)
-    return token
-
-
-def _selected_option(html: str) -> str:
-    """Return the value= of whichever <option> in the scope <select> is selected."""
-    import re
-
+def selected_option(html: str) -> str:
+    """The value= of whichever <option> in the scope <select> is selected."""
+    found = []
     for value in ("read", "readwrite"):
-        m = re.search(
-            rf'<option value="{value}"\s*[^>]*>',
-            html,
-        )
-        assert m, f"couldn't find <option value=\"{value}\"> at all"
+        m = re.search(rf'<option value="{value}"\s*[^>]*>', html)
+        if m is None:
+            continue
+        found.append(value)
         if "selected" in m.group(0):
             return value
+    assert found, "no scope <option> rendered at all"
     return "NONE-SELECTED"
 
 
-def test_readwrite_token_with_offline_access_shows_readwrite_selected():
-    """The exact scenario that fooled the panel before this fix: a real
-    readwrite grant that also carries offline_access."""
-    html = _render_oauth_page([_base_token(scope="offline_access readwrite", has_write=True)])
-    assert _selected_option(html) == "readwrite"
+def rendered_options(html: str) -> set[str]:
+    return set(re.findall(r'<option value="(read|readwrite)"', html))
 
 
-def test_read_token_with_offline_access_shows_read_selected():
-    html = _render_oauth_page([_base_token(scope="offline_access read", has_write=False)])
-    assert _selected_option(html) == "read"
+# --- oauth_page derives has_write from the token's own scope (gap 1) -------
 
 
-def test_bare_readwrite_token_shows_readwrite_selected():
-    html = _render_oauth_page([_base_token(scope="readwrite", has_write=True)])
-    assert _selected_option(html) == "readwrite"
+@pytest.mark.parametrize(
+    "scope, expected",
+    [
+        ("offline_access readwrite", "readwrite"),
+        ("offline_access read", "read"),
+        ("readwrite", "readwrite"),
+        ("read", "read"),
+        # Order within the set must not matter.
+        ("readwrite offline_access", "readwrite"),
+    ],
+)
+def test_oauth_page_derives_selected_scope_from_token_scope(scope, expected):
+    """The route -- not the fixture -- decides which option is selected.
+
+    Nothing here supplies `has_write`; `oauth_page` computes it from `scope`.
+    Hard-coding `has_write=False` in the route (issue #65's demonstration of
+    the gap) flips every `readwrite` case to `read` and fails.
+    """
+    html = render_oauth_page(
+        clients=[FakeClient()],
+        tokens=[FakeToken(grant_id="g1", scope=scope)],
+    )
+    assert selected_option(html) == expected
 
 
-# --- oauth_page's has_write computation (the actual fix) ------------------
+def test_oauth_page_and_middleware_agree_on_every_scope_string():
+    """The panel badge and the enforced permission come from one helper.
+
+    Before this, `oauth_page` and `src/mcp_server/auth.py` each carried their
+    own membership check. They agreed by coincidence, which is not a property
+    anything could test; now there is a single definition and this pins both
+    ends of it.
+    """
+    for scope in (
+        "read",
+        "readwrite",
+        "offline_access read",
+        "offline_access readwrite",
+        "",
+    ):
+        middleware_permission = "readwrite" if token_has_write(scope) else "read"
+        html = render_oauth_page(
+            clients=[FakeClient()],
+            tokens=[FakeToken(grant_id="g1", scope=scope)],
+        )
+        assert selected_option(html) == middleware_permission, scope
+
+    # And the middleware really is built on that helper, not a private copy.
+    source = mcp_auth.__file__
+    with open(source) as fh:
+        body = fh.read()
+    assert "token_has_write(oauth_token.scope)" in body
 
 
-def test_has_write_is_membership_not_equality():
-    assert ("readwrite" in "offline_access readwrite".split()) is True
-    assert ("readwrite" in "offline_access read".split()) is False
-    assert ("readwrite" in "read".split()) is False
-    assert ("readwrite" in "readwrite".split()) is True
+# --- the helper itself (gap 2: was a tautology over Python builtins) -------
+
+
+def test_token_has_write_is_membership_not_equality():
+    """Calls production code. The assertion it replaces could not fail."""
+    assert token_has_write("offline_access readwrite") is True
+    assert token_has_write("readwrite offline_access") is True
+    assert token_has_write("readwrite") is True
+    assert token_has_write("offline_access read") is False
+    assert token_has_write("read") is False
+    assert token_has_write("") is False
+    assert token_has_write(None) is False
+    # The trap the display bug fell into: a set is not its longest member.
+    assert ("offline_access readwrite" == "readwrite") is False
 
 
 # --- update_oauth_token_scope preserves offline_access ---------------------
 
 
-class _FakeToken:
-    def __init__(self, scope, revoked=False, user_id=None):
-        self.id = 1
-        self.scope = scope
-        self.revoked = revoked
-        self.user_id = user_id
-
-
-class _FakeSession:
-    def __init__(self, token):
-        self._token = token
-        self.committed = False
-
-    async def execute(self, _stmt):
-        class _Result:
-            def __init__(self, obj):
-                self._obj = obj
-
-            def scalar_one_or_none(self):
-                return self._obj
-
-        return _Result(self._token)
-
-    async def commit(self):
-        self.committed = True
-
-
-class _SingleUserSentinel:
-    id = None
-    is_admin = True
+def _update_scope(tokens, clients, scope, token_id=None):
+    session = FakeSession(clients=clients, tokens=tokens)
+    asyncio.run(
+        routes.update_oauth_token_scope(
+            token_id=token_id if token_id is not None else tokens[0].id,
+            scope=scope,
+            session=session,
+            user=SingleUserSentinel(),
+        )
+    )
+    return session
 
 
 def test_update_scope_preserves_offline_access_marker():
-    token = _FakeToken(scope="offline_access readwrite")
-    session = _FakeSession(token)
+    token = FakeToken(grant_id="g1", scope="offline_access readwrite")
+    session = _update_scope([token], [FakeClient()], "read")
 
-    asyncio.run(
-        routes.update_oauth_token_scope(
-            token_id=1,
-            scope="read",
-            session=session,
-            user=_SingleUserSentinel(),
-        )
-    )
-
-    assert token.scope == "read offline_access"
-    assert session.committed is True
+    assert set(token.scope.split()) == {"read", "offline_access"}
+    assert session.committed == 1
 
 
 def test_update_scope_without_offline_access_stays_bare():
-    token = _FakeToken(scope="readwrite")
-    session = _FakeSession(token)
-
-    asyncio.run(
-        routes.update_oauth_token_scope(
-            token_id=1,
-            scope="read",
-            session=session,
-            user=_SingleUserSentinel(),
-        )
-    )
+    token = FakeToken(grant_id="g1", scope="readwrite")
+    _update_scope([token], [FakeClient()], "read")
 
     assert token.scope == "read"
+
+
+# --- revoked and expired rows stay visible (issue #64) --------------------
+
+
+def test_revoked_tokens_are_listed_so_a_revocation_is_visible():
+    """Filtering revoked rows out made a no-op Revoke look like it worked."""
+    html = render_oauth_page(
+        clients=[FakeClient()],
+        tokens=[
+            FakeToken(grant_id="g1", token_type="access", revoked=True),
+            FakeToken(grant_id="g1", token_type="refresh", revoked=True),
+        ],
+    )
+    assert "Revoked" in html
+    # A fully revoked grant offers no controls to act on.
+    assert "/revoke" not in html
+    assert "<option" not in html
+
+
+def test_expired_token_renders_expired_not_active():
+    html = render_oauth_page(
+        clients=[FakeClient()],
+        tokens=[FakeToken(grant_id="g1", expires_at=in_hours(-1))],
+    )
+    assert "Expired" in html
+    assert 'class="badge badge-green"' not in html
+
+
+# --- one control per grant, not one per row (issue #64) -------------------
+
+
+def test_a_grant_renders_exactly_one_revoke_control_and_one_scope_select():
+    """Two rows, one grant, one of each control.
+
+    Per-row controls are what misled the operator: two independently editable
+    scope selects for one grant, and a Revoke on the access row that the
+    sibling refresh token undid within the hour.
+    """
+    html = render_oauth_page(
+        clients=[FakeClient()],
+        tokens=[
+            FakeToken(grant_id="g1", token_type="access", scope="readwrite"),
+            FakeToken(grant_id="g1", token_type="refresh", scope="readwrite"),
+        ],
+    )
+    assert html.count("/revoke") == 1
+    assert html.count("<select") == 1
+
+
+def test_two_grants_for_one_client_get_separate_controls():
+    html = render_oauth_page(
+        clients=[FakeClient()],
+        tokens=[
+            FakeToken(grant_id="g1", token_type="access"),
+            FakeToken(grant_id="g1", token_type="refresh"),
+            FakeToken(grant_id="g2", token_type="access"),
+            FakeToken(grant_id="g2", token_type="refresh"),
+        ],
+    )
+    assert html.count("/revoke") == 2
+    assert html.count("<select") == 2
+
+
+# --- issue #76: the owner's is_active is part of "Active" ----------------
+
+
+def test_deactivated_owner_makes_the_grant_badge_owner_inactive():
+    """`APIKeyMiddleware` 401s these tokens; the panel used to badge them green."""
+    html = render_oauth_page(
+        clients=[FakeClient(user_id=7)],
+        tokens=[FakeToken(grant_id="g1", user_id=7)],
+        users=[FakeUser(id=7, is_active=False)],
+    )
+    assert "Owner inactive" in html
+    assert 'class="badge badge-green"' not in html
+
+
+def test_active_owner_still_badges_active():
+    html = render_oauth_page(
+        clients=[FakeClient(user_id=7)],
+        tokens=[FakeToken(grant_id="g1", user_id=7)],
+        users=[FakeUser(id=7, is_active=True)],
+    )
+    assert "Owner inactive" not in html
+    assert 'class="badge badge-green"' in html
+
+
+def test_single_user_tokens_have_no_owner_to_check():
+    """`user_id IS NULL` is single-user mode; the middleware skips the check."""
+    html = render_oauth_page(
+        clients=[FakeClient()],
+        tokens=[FakeToken(grant_id="g1", user_id=None)],
+    )
+    assert "Owner inactive" not in html
+    assert 'class="badge badge-green"' in html
+
+
+# --- issue #67: the readwrite option is gated on the client's registration -
+
+
+def test_read_only_client_never_renders_the_readwrite_option():
+    html = render_oauth_page(
+        clients=[FakeClient(scope="read")],
+        tokens=[FakeToken(grant_id="g1", scope="read")],
+    )
+    assert rendered_options(html) == {"read"}
+
+
+def test_readwrite_client_renders_both_options():
+    html = render_oauth_page(
+        clients=[FakeClient(scope="read readwrite offline_access")],
+        tokens=[FakeToken(grant_id="g1", scope="read")],
+    )
+    assert rendered_options(html) == {"read", "readwrite"}


### PR DESCRIPTION
Closes #64, closes #67, closes #68, closes #65, closes #76.

- **#64** `oauth_tokens.grant_id` (NOT NULL, indexed; migration `014_oauth_grant_id` backfills one id per `(client_id, user_id)`, verifies rather than adopts a pre-existing column, refuses ambiguity). Panel revoke / scope change and RFC 7009 `/revoke` act on the whole family under a `pg_advisory_xact_lock` keyed on the grant, which `_handle_refresh` also takes, so a revoke cannot be undone by a racing rotation. Per-grant UI with revoked history visible; `cleanup_expired_tokens` keeps revoked rows for the 7-day window.
- **#67** shared `src/oauth/scope.py` (`clamp_scope`, `client_can_write`, `token_has_write`, `has_vault_scope`) used by auth.py, the OAuth routes and the panel; every scope write clamps against `OAuthClient.scope`; empty intersection fails closed; panel refuses/hides readwrite for read-only clients.
- **#68** `authorize_post` refuses a client bound to another user (conditional first-claim `UPDATE … WHERE user_id IS NULL`), re-checked at code exchange and at refresh; `/revoke` authenticates the client and requires a matching `client_id`; ownerless mints refused in multi-user mode and the bootstrap claim is serialized with the mint paths.
- **#65** gaps 1–2: `oauth_page`'s `has_write` derivation tested through the route; tautology removed. (Gap 3 shipped in #79.)
- **#76** OAuth half: owner-inactive / no-vault-scope statuses match the middleware.
- OpenSpec change `oauth-grant-families` (archived after deploy).

Gates: `make test-schema` 35 passed; openspec-verifier no gaps; Codex adversarial 3 rounds (remaining: in-flight-request window, documented); 1242 passed / 5 skipped unit; 11 passed Postgres integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mSEspK9GFPSdxmK9XrrMQ