### PR TITLE
Transfer: scope check_upload handles to the OAuth grant family (#74)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -743,6 +743,21 @@ What deliberately did **not** widen:
 - **The API-key path is untouched.** A key does not rotate; a second key of the
   same user is a different principal.
 
+The `EXISTS` compares `client_id` as well as `grant_id`. One `grant_id` belongs
+to exactly one `(client_id, user_id)` by invariant, not by constraint, and this
+predicate is the access control — so a family that somehow spanned two clients
+still cannot leak between them.
+
+**Accepted limitation — pre-014 families are approximate.** 014's backfill
+groups pre-existing rows by `(client_id, user_id)`, which #64 accepted as the
+best available guess (nothing in the old schema recorded which consent a row
+came from). Two consents by the same user *for the same client* made before 014
+therefore share one family, so a token from either can read `check_upload`
+status — path, size, sha256, mime — for a handle minted by the other. Same
+user, same client, read-only status on a handle that authorises nothing, and it
+shrinks as those tokens age out; every grant issued after 014 is exact. Not
+worth inventing a consent boundary the database never recorded.
+
 ### A link never outlives the credential that minted it
 
 Redemption re-checks the credential (`_credential_ok`), so `transfer_tokens.expires_at` alone was never the effective lifetime: an OAuth access token lives one hour, and `expires_in=3600` on that path is therefore *always* divergent (#73). `transfer.plan_mint_window` computes `min(requested TTL, credential expiry)` and the row stores that, so the tool result, `/transfer/*/info` and both pages all show a deadline enforcement agrees with — clamping once instead of teaching three surfaces the same arithmetic. **`mint_token` calls it itself, in its own transaction, immediately before the INSERT, and takes no window parameter** — it *returns* the window so the tools can report a clamp. Do not add one back: a caller-supplied deadline is a caller-supplied security boundary, and a stale window (computed before a revocation, or by a path that forgot) is exactly the divergence this exists to remove. The same call re-validates the credential with `_credential_ok`, the redemption predicate, so a key revoked, downgraded, deactivated or reassigned between the tool's permission check and the INSERT mints nothing rather than a row whose only future is the 404. **That re-validation is an unlocked `SELECT`, and deliberately so:** a revocation committing between it and the INSERT yields a capability every redemption rejects and `check_upload` reports as `revoked` — fail-closed, the same optimistic level declared elsewhere here, and the locked re-check that actually matters is the publish gate.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -680,7 +680,7 @@ may do at mint time, and the route acts on nothing else.**
 
 **Tools** (`src/mcp_server/tools.py`, registered in `server.py`):
 - `request_upload(path, overwrite=False, expires_in=None)` — readwrite. Mints a single-use upload capability; returns `upload_id` (opaque `public_id`, never the row id), a `…/transfer/upload#<token>` URL, `expires_at` and `max_bytes`.
-- `check_upload(upload_id)` — `pending` | `uploading` | `unknown` | `revoked` | `completed{path,size,sha256,mime,completed_at}` | `expired`, scoped to the exact minting credential *and* user. Another identity's handle is `not found`. See "check_upload answers for the vault, not for the row" below.
+- `check_upload(upload_id)` — `pending` | `uploading` | `unknown` | `revoked` | `completed{path,size,sha256,mime,completed_at}` | `expired`, scoped to the minting **principal** *and* user — the API key itself, or, for OAuth, the whole grant family behind the presented access token. Another principal's handle is `not found`. See "check_upload answers for the vault, not for the row" below.
 - `request_download(path, expires_in=None)` — read is enough. Multi-use within its TTL; bound to the file's exact bytes at mint.
 - `import_from_url(url, path, overwrite=False)` — readwrite. Server-side fetch under the SSRF policy, straight through the same capped, anchored publish.
 - `delete_file(path, permanent=False)` — readwrite. See "File-access tools".
@@ -704,9 +704,44 @@ Three rules, each of which was violated by reading `state` and `expires_at` and 
 
 - **A claimed token is answered before expiry, and never as "never used".** `claimed` past its TTL is reached by exactly one path — `PostPublishFailure` — and that path runs *after* the bytes are in the vault. The expiry branch used to fire first and say the link "was never used", about a file sitting at the path; with a ten-minute TTL that was the answer an agent was most likely to see (#75). Inside `min(expires_at, claimed_at + TRANSFER_MAX_UPLOAD_SECONDS)` the answer is `uploading` and it names that deadline; past it, `unknown` — the bytes may be there, go `list_files`/`read_file` the path before re-minting, the same thing `import_from_url` says for the same outcome. `consumed` is the one mid-flight end state that *is* provably empty (the timeout paths raise before `publish`), and it says so.
 - **One deadline, and one clock.** The arithmetic lives once, in `transfer.upload_stream_deadline`, which returns an *absolute UTC instant*; `routes._upload_deadline` returns that instant unchanged and the route hands it to `stream_to_vault`, which measures it through `transfer._deadline_remaining` against `transfer.now_utc()` — the same function `check_upload` compares with. Both halves are load-bearing. A second copy of the arithmetic would drift. Converting to `time.monotonic()` at claim time (which is what the route used to do) keeps the arithmetic shared but splits the *clock*: a realtime step then moves the tool and not the route, and the tool reports a stream live that the route has already killed. The accepted trade-off is that a backward realtime step extends an upload — two surfaces that agree beats two that disagree, because the disagreement is what an agent relays to a human. `import_from_url` still passes a monotonic float: its fetch budget is private and no surface reports on it. **Nothing under `src/transfer/` may define its own "now".**
-- **Liveness is re-checked, inside the open session.** `lookup_by_public_id` filters on public_id/direction/identity only, while `PUT /transfer/upload` also requires `resolve_identity_ok(need_write=True)` and `resolve_root_ok`. So after an OAuth scope downgrade or a vault reassignment the tool asserted "pending" about a link every redemption would 404 (#71). Both predicates now run for `pending`/`claimed` rows and produce a `revoked` answer naming the cause. **`completed` rows are deliberately not re-checked** — that transfer already happened, and a later revocation must not turn a true report of a landed file into a false "revoked". For a `claimed` row the dead reason is *appended* to the ambiguity, never substituted for it: revocation does not un-publish bytes.
+- **Liveness is re-checked, inside the open session.** `lookup_by_public_id` filters on public_id/direction/principal only, while `PUT /transfer/upload` also requires `resolve_identity_ok(need_write=True)` and `resolve_root_ok`. So after an OAuth scope downgrade or a vault reassignment the tool asserted "pending" about a link every redemption would 404 (#71). Both predicates now run for `pending`/`claimed` rows and produce a `revoked` answer naming the cause. **`completed` rows are deliberately not re-checked** — that transfer already happened, and a later revocation must not turn a true report of a landed file into a false "revoked". For a `claimed` row the dead reason is *appended* to the ambiguity, never substituted for it: revocation does not un-publish bytes.
 
 Precision here is the design, not an exception to it — this side is authenticated and identity-scoped. None of the branches may put a token or any other secret into `usage_logs`; the `upload_id` shape check still runs before `_tracked` sees the argument.
+
+### The handle belongs to the principal, not to the credential row
+
+`lookup_by_public_id` scoped an OAuth-minted transfer to the exact
+`oauth_tokens.id` that minted it. An access token lives one hour and rotation
+mints a **new row** for the same user, the same client and the same consent, so
+an hour later the agent's own `check_upload` answered "no upload link with id …
+was minted by this identity" — the message reserved for a genuinely foreign
+handle — about a `completed` upload whose sha256 `request_upload` had told it
+to come back for (#74).
+
+The scope is the stable principal instead. An API key *is* one; an OAuth access
+token is one hour of one, and the principal behind it is the **grant family**
+(`oauth_tokens.grant_id`, migration 014). The lookup is one statement with a
+correlated `EXISTS` joining the *minting* token to the *presenting* token on
+`grant_id` — no column on `transfer_tokens`, no migration, and nothing to keep
+in sync: `grant_id` never changes after insert, and the row cascades away with
+its minting token anyway. The `user_id` comparison stays on top of it.
+
+What deliberately did **not** widen:
+
+- **A different grant is still `not found`** — another client, or a second
+  `/authorize` approval by the same user for the same client. Two consents are
+  two things the operator can revoke independently.
+- **Redemption stays bound to the minting credential row.** `resolve_identity_ok`
+  and the publish gate still load the exact `oauth_tokens` row named on the
+  token. That cannot make `check_upload` lie, because `plan_mint_window` clamps
+  every capability's expiry to that credential's own (see below): the minting
+  access token outlives every link it minted unless it is revoked, and a
+  revocation *should* kill the link. Widening redemption to "any live token of
+  the family" would bind an already-minted capability to credentials that did
+  not exist when it was minted — strictly more than the operator agreed to, for
+  no case that is currently wrong.
+- **The API-key path is untouched.** A key does not rotate; a second key of the
+  same user is a different principal.
 
 ### A link never outlives the credential that minted it
 

--- a/openspec/changes/transfer-grant-scoped-identity/design.md
+++ b/openspec/changes/transfer-grant-scoped-identity/design.md
@@ -77,7 +77,8 @@ the operator agreed to at mint time, for no case that is currently wrong.
   the same user for the same client. Two consents are two things the operator
   revokes independently; one must not read the other's handles. This is the
   existing "Cross-identity lookup" scenario, re-stated in terms that survive a
-  rotation.
+  rotation. Exact for every grant issued after migration 014; see D4a for the
+  pre-014 backfill's one approximation.
 - **A different user.** The `user_id` comparison stays. The family invariant
   (one `grant_id` ⇒ one `(client_id, user_id)`) already implies it for the
   OAuth path, but it is the *only* check on the API-key path — a key reassigned
@@ -86,6 +87,28 @@ the operator agreed to at mint time, for no case that is currently wrong.
 - **The other credential kind.** An OAuth caller never matches a key-minted row
   (`key_id IS NULL` is required) and a key caller never matches an OAuth-minted
   one (`oauth_token_id IS NULL`).
+
+## D4a. Accepted limitation: pre-014 families are approximate
+
+Migration 014 backfills `grant_id` one value per distinct `(client_id,
+user_id)`, which #64 accepted as approximate — nothing in the pre-014 schema
+recorded which consent a row descended from, so there was nothing better to
+group by. Two consents made by the same user **for the same client** before 014
+therefore share one backfilled family, and this change makes a token from
+either able to read `check_upload` status — path, size, sha256, mime — for a
+handle minted by the other.
+
+Accepted, not fixed. It is the same user and the same client software, the
+exposure is read-only status on a handle that authorises nothing, and it is
+bounded: every grant issued after 014 is exact, and pre-014 families can only
+shrink as their tokens age out (`cleanup_expired_tokens` deletes 7 days past
+expiry). Fixing it would mean inventing a consent boundary the database never
+recorded.
+
+The one thing that *is* defended is the cross-**client** case, which the
+backfill cannot produce and the invariant forbids: the `EXISTS` compares
+`client_id` as well as `grant_id`, so a family that somehow spanned two clients
+still cannot leak between them.
 
 ## D5. Testing
 

--- a/openspec/changes/transfer-grant-scoped-identity/design.md
+++ b/openspec/changes/transfer-grant-scoped-identity/design.md
@@ -1,0 +1,104 @@
+# Design
+
+## D1. What a transfer handle belongs to
+
+A capability token is redeemed by whoever holds it, so it is bound to
+everything it may do at mint time. A **handle** (`public_id`) is not a
+capability: it authorises nothing, and `check_upload` is the only read scoped
+by identity rather than by a bearer token. That scoping is the access control,
+so the only question is what "the same identity" means over time.
+
+- An **API key** is a principal. It does not rotate. Nothing stands behind it.
+- An **OAuth access token** is one hour of a principal. The thing that persists
+  across rotations — and the thing the operator actually consented to and can
+  revoke — is the grant. Since migration 014 that is `oauth_tokens.grant_id`,
+  NOT NULL, one value per `/authorize` approval, inherited by every rotation,
+  and belonging to exactly one `(client_id, user_id)`.
+
+So: key → the key row; OAuth → the family. That is the whole change.
+
+## D2. Why no `transfer_tokens.grant_id` column
+
+The alternative was to freeze the minting grant onto the transfer row
+(migration 015, backfilled from the joined `oauth_tokens.grant_id`, indexed)
+and compare columns. It was rejected because every argument for it is empty
+here:
+
+- **Not a hot path.** `check_upload` is one call per upload the agent follows
+  up on. The uniform-404 routes do not use this function at all — they look a
+  token up by hash — so nothing on the public path gets slower.
+- **Nothing to freeze.** `grant_id` is assigned at insert and never updated;
+  rotation *copies* it. The joined value and a frozen copy can never differ.
+- **The row cannot outlive the join.** `transfer_tokens.oauth_token_id` is
+  `ON DELETE CASCADE`, and `cleanup_expired_tokens` keeps an `oauth_tokens`
+  row until 7 days past its expiry while transfer rows are pruned 1 day past
+  theirs — which the mint clamp already bounds by the credential's expiry. The
+  minting row is therefore present for the whole time the transfer row is.
+- **A migration is not free.** It is a live-database change plus a new case in
+  the schema gate, in exchange for none of the above.
+
+The predicate is instead one correlated `EXISTS` over `oauth_tokens` aliased
+twice (`minting_token`, `presenting_token`) joined on `grant_id`, inside the
+single statement the lookup already issued. If the presenting token's row is
+gone the `EXISTS` is false and the answer is "not found" — the fail-closed
+direction.
+
+## D3. Redemption stays bound to the minting credential row
+
+The natural-looking completion of this change is to widen `resolve_identity_ok`
+and the publish gate the same way, so that a pending upload minted under access
+token A stays redeemable once A expires and its family sibling B is live. It is
+**not** done, and the fail-closed default costs nothing here — which is the part
+worth recording, because "fail closed" is only free when it cannot make another
+surface lie.
+
+`plan_mint_window` clamps every capability's expiry to
+`min(requested TTL, minting credential's expiry)`. So `transfer_tokens.expires_at
+<= oauth_tokens.expires_at` for the minting row, always. Consequences:
+
+- While the link is live, the minting token is live too — rotation revokes only
+  the *refresh* token, so the replaced access token runs to its own expiry
+  (`src/oauth/routes.py`). The narrow binding refuses nothing that the link's
+  own TTL would not have refused a moment later.
+- When the minting token is revoked, the family is revoked with it (#64's
+  revocation is family-scoped), so widening would not have kept the link alive
+  anyway — and it should not.
+- `check_upload` therefore cannot be pushed back into lying: the row it now
+  finds after a rotation is reported `expired` by its own `expires_at` in
+  exactly the cases where the minting credential is dead.
+
+Widening redemption, by contrast, would bind an already-issued capability to
+credentials that did not exist when it was issued. That is strictly more than
+the operator agreed to at mint time, for no case that is currently wrong.
+
+## D4. What must still be refused
+
+- **A different grant.** Another client, or a second `/authorize` approval by
+  the same user for the same client. Two consents are two things the operator
+  revokes independently; one must not read the other's handles. This is the
+  existing "Cross-identity lookup" scenario, re-stated in terms that survive a
+  rotation.
+- **A different user.** The `user_id` comparison stays. The family invariant
+  (one `grant_id` ⇒ one `(client_id, user_id)`) already implies it for the
+  OAuth path, but it is the *only* check on the API-key path — a key reassigned
+  to another user must not carry its handles across — and defence in depth
+  costs one predicate.
+- **The other credential kind.** An OAuth caller never matches a key-minted row
+  (`key_id IS NULL` is required) and a key caller never matches an OAuth-minted
+  one (`oauth_token_id IS NULL`).
+
+## D5. Testing
+
+The behavioural proof needs real rows and a real correlated subquery, so it
+lives in `tests/integration/test_transfer_pg.py` — the module that is already
+the mandatory Postgres gate for transfer security properties. `_rotate` models
+`_handle_refresh` (new row, same `grant_id`, old access token left to its own
+expiry) and `_second_consent` models a second approval.
+
+The always-on suite cannot execute the predicate, so
+`tests/test_issue_74_transfer_grant_lookup.py` pins its *shape*: it captures
+the statement `lookup_by_public_id` actually issues and compiles it, asserting
+that the OAuth branch never constrains `transfer_tokens.oauth_token_id` to the
+presenting id and that the API-key branch never mentions `oauth_tokens` at all.
+Both files were checked against the pre-change service to confirm they fail
+there.

--- a/openspec/changes/transfer-grant-scoped-identity/proposal.md
+++ b/openspec/changes/transfer-grant-scoped-identity/proposal.md
@@ -34,9 +34,16 @@ and for OAuth that row is one hour of a principal, not the principal.
   joining `oauth_tokens` to itself on `grant_id`. See design.md for why the
   frozen-column alternative buys nothing here.
 - **Nothing else widens.** A different grant — another client, or a second
-  `/authorize` approval by the same user — is still `not found`. Redemption on
-  the `/transfer/*` routes stays bound to the exact minting credential row;
-  design.md records why that cannot make the tool lie again.
+  `/authorize` approval by the same user — is still `not found`, and the family
+  comparison includes `client_id` as well as `grant_id` so two clients can
+  never share a principal. Redemption on the `/transfer/*` routes stays bound
+  to the exact minting credential row; design.md records why that cannot make
+  the tool lie again.
+- **One accepted limitation, recorded rather than fixed** (design.md D4a):
+  014's backfill groups pre-existing rows by `(client_id, user_id)`, so two
+  consents made by the same user for the same client *before* 014 share one
+  family and can read each other's handle status. Same user, same client,
+  read-only status; every grant issued after 014 is exact.
 - **`_credential_ok` uses `src.oauth.scope.token_has_write`** instead of its
   private `"readwrite" not in (cred.scope or "").split()` copy. Same
   behaviour, one fewer place for the definition of "write" to drift (#67).
@@ -64,7 +71,7 @@ and for OAuth that row is one hour of a principal, not the principal.
 No migration, no schema change, no config. `Identity` is unchanged, so nothing
 outside the transfer service needed to learn about grants.
 
-**Archive after `transfer-status-honesty`.** Both MODIFY the `check_upload`
-requirement; this change's block is that change's text plus the principal
-wording, so archiving in that order preserves both. The reverse order drops
-the status-honesty text.
+Rebased onto `origin/main` after the wave-1 archive, so the MODIFIED
+`check_upload` block is diffed against the **archived** requirement text: the
+only differences are the principal wording, the renamed cross-principal
+scenario, and the added rotation scenario.

--- a/openspec/changes/transfer-grant-scoped-identity/proposal.md
+++ b/openspec/changes/transfer-grant-scoped-identity/proposal.md
@@ -1,0 +1,70 @@
+## Why
+
+`check_upload` calls the agent's own upload link somebody else's.
+
+`lookup_by_public_id` scopes an OAuth-minted transfer to the exact
+`oauth_tokens.id` row that minted it, because `transfer_tokens` records that id
+and nothing else about the OAuth side. But an access token lives one hour, and
+`_handle_refresh` mints a **brand-new row** for the same user, the same client
+and the same consent. After any rotation the lookup matches nothing, and the
+tool answers with the string reserved for a genuinely foreign handle: "not
+found: no upload link with id … was minted by this identity" (#74).
+
+The completed case needs no assumption about refresh timing. An agent mints an
+upload link at 14:50; the human uploads at 14:55 and it completes; the access
+token expires at 15:50 and the client refreshes; at 15:55 the agent calls
+`check_upload` to get the sha256 — which `request_upload`'s own result text
+instructs it to do. The row is present (transfer rows are pruned only a day
+past expiry) and reads `completed` with path, size, sha256 and mime. The tool
+disowns it.
+
+The implementation matched the spec. **The spec's notion of OAuth identity is
+what is too narrow**: it defines a transfer's identity as the credential row,
+and for OAuth that row is one hour of a principal, not the principal.
+
+## What Changes
+
+- **`lookup_by_public_id` scopes to the principal, not the credential row.** An
+  API key is its own principal and is unchanged. An OAuth access token's
+  principal is its **grant family** — `oauth_tokens.grant_id`, NOT NULL since
+  migration 014 (#64) — so the lookup matches a transfer row whose *minting*
+  token is a sibling of the *presenting* token in that family. `user_id` is
+  still compared on top.
+- **No new column and no migration.** The predicate is one correlated `EXISTS`
+  joining `oauth_tokens` to itself on `grant_id`. See design.md for why the
+  frozen-column alternative buys nothing here.
+- **Nothing else widens.** A different grant — another client, or a second
+  `/authorize` approval by the same user — is still `not found`. Redemption on
+  the `/transfer/*` routes stays bound to the exact minting credential row;
+  design.md records why that cannot make the tool lie again.
+- **`_credential_ok` uses `src.oauth.scope.token_has_write`** instead of its
+  private `"readwrite" not in (cred.scope or "").split()` copy. Same
+  behaviour, one fewer place for the definition of "write" to drift (#67).
+- Test fixtures in `tests/integration/test_transfer_pg.py` seed `grant_id`,
+  which migration 014 made NOT NULL after that module was last touched.
+
+## Capabilities
+
+### Modified Capabilities
+- `file-transfer`: handle scoping is defined against the minting principal
+  (grant family for OAuth, the key itself for an API key) rather than the
+  credential row, and the redemption/lookup asymmetry is stated.
+
+## Impact
+
+- `src/services/transfer.py` — `lookup_by_public_id`, new `_same` /
+  `_minted_by_principal` helpers, `_credential_ok`'s write test
+- `src/mcp_server/tools.py` — comment only, in `check_upload_impl`
+- `tests/test_issue_74_transfer_grant_lookup.py` — new
+- `tests/integration/test_transfer_pg.py` — `grant_id` in the fixtures, plus a
+  handle-scoping section (rotation, multi-hop rotation, second consent, other
+  user, other key, vanished presenting token, direction, redemption binding)
+- `CLAUDE.md` — "The handle belongs to the principal, not to the credential row"
+
+No migration, no schema change, no config. `Identity` is unchanged, so nothing
+outside the transfer service needed to learn about grants.
+
+**Archive after `transfer-status-honesty`.** Both MODIFY the `check_upload`
+requirement; this change's block is that change's text plus the principal
+wording, so archiving in that order preserves both. The reverse order drops
+the status-honesty text.

--- a/openspec/changes/transfer-grant-scoped-identity/specs/file-transfer/spec.md
+++ b/openspec/changes/transfer-grant-scoped-identity/specs/file-transfer/spec.md
@@ -1,0 +1,93 @@
+## ADDED Requirements
+
+### Requirement: A transfer handle is scoped to the minting principal
+
+The identity-scoped lookup behind `check_upload` SHALL resolve a `public_id` only for the **principal** that minted it, where the principal of an API key is that `api_keys` row and the principal of an OAuth access token is its **grant family** (`oauth_tokens.grant_id`), and SHALL additionally require the calling `user_id` to equal the row's. A handle SHALL therefore remain visible to its minting agent across any number of refresh rotations within one grant, and SHALL remain invisible to every other principal — a different API key, a different client, or a second `/authorize` approval by the same user for the same client. When the presenting credential row cannot be resolved, the lookup SHALL find nothing.
+
+Redemption SHALL NOT be widened in the same way: the `/transfer/*` routes and the publish gate SHALL keep re-validating the exact credential row recorded on the token. This is safe because a capability's expiry is already clamped to that credential's own expiry, so the minting credential outlives every link it minted unless it is revoked — and a revocation SHALL kill the link.
+
+#### Scenario: A rotated access token still owns its handles
+
+- **WHEN** an upload link is minted, completes, and the minting access token is then replaced by one or more refresh rotations within the same grant
+- **THEN** the identity-scoped lookup SHALL return that row for any live token of the grant, with its recorded `path`, `size`, `sha256` and `mime`
+
+#### Scenario: A second consent is a different principal
+
+- **WHEN** the same user approves the same client a second time, producing a second grant family, and a token of that family presents the first family's handle
+- **THEN** the lookup SHALL find nothing
+
+#### Scenario: Another user, another key
+
+- **WHEN** a handle minted by one principal is presented by another user's credential, by the same grant under a different `user_id`, or by a different API key of the same user
+- **THEN** the lookup SHALL find nothing in every case
+
+#### Scenario: The two credential kinds do not see each other
+
+- **WHEN** an API-key-minted handle is presented by an OAuth token, or an OAuth-minted handle is presented by an API key
+- **THEN** the lookup SHALL find nothing in both directions
+
+#### Scenario: The presenting credential row is gone
+
+- **WHEN** the `oauth_tokens` row of the presenting access token has been deleted while the transfer row survives
+- **THEN** the lookup SHALL find nothing
+
+#### Scenario: Redemption stays bound to the minting credential
+
+- **WHEN** an upload link's minting access token is revoked while a sibling token of the same grant family is still live
+- **THEN** redemption SHALL be refused with the uniform 404, and the identity-scoped lookup SHALL still return the row so the authenticated tool can report it as no longer redeemable rather than as never minted
+
+## MODIFIED Requirements
+
+### Requirement: `check_upload` tool
+
+`check_upload(upload_id)` SHALL report the outcome of an upload link honestly, never asserting more about the vault than the token row proves, and SHALL return one of: `completed` (with `path`, `size`, `sha256`, `mime`, `completed_at`); `uploading` for a claimed token still inside its stream deadline, naming that deadline; `unknown` for a claimed token past it, stating that the bytes may already be in the vault because a publish can succeed and still fail to record its completion, and directing the caller to `list_files` / `read_file` the bound path before re-minting; `revoked` for a `pending` token whose minting credential no longer satisfies the redemption predicates or whose vault root has changed; `expired`; or `pending`. The stream deadline SHALL be `min(expires_at, claimed_at + TRANSFER_MAX_UPLOAD_SECONDS)` as an absolute UTC instant, computed by the same helper the upload route enforces it with **and measured against the same clock**: the route SHALL enforce that instant directly rather than converting it to a monotonic value, so that a realtime clock step cannot make the route and this tool describe different instants. A claimed or consumed token SHALL NEVER be reported as unused, whatever its expiry — "never used" SHALL be reachable only for a `pending` row — and a consumed token SHALL additionally state that nothing was published, since the deadline and idle-timeout paths abort before `publish`. For `pending` and `claimed` rows the tool SHALL re-check `resolve_identity_ok(need_write=True)` and `resolve_root_ok` against the database inside the session that read the row, because redemption decides usability from a strictly larger predicate than the row's state; `completed` rows SHALL NOT be re-checked. It SHALL report `not found` for an `upload_id` minted outside the calling **principal** — a different API key, a different OAuth grant family, or, in multi-user mode, a different user — as the handle-scoping requirement defines it, and SHALL NOT report `not found` merely because the presenting OAuth access token is a later rotation of the one that minted the handle. Precise status is permitted here and nowhere else: this side is authenticated and identity-scoped, unlike the public routes' uniform 404. The argument SHALL be validated against the exact shape `upload_id`s are minted with (22 characters of the URL-safe base64 alphabet) **before** it is written to `usage_logs`: an off-shape value SHALL be logged as a fixed `<invalid>` marker, SHALL NOT reach the database lookup, and SHALL return `not found`. No branch SHALL write a token, a credential, or any other secret into `usage_logs`.
+
+#### Scenario: A misused argument never reaches the log
+
+- **WHEN** `check_upload` is called with a whole `…/transfer/upload#<token>` URL, or with the token itself, in place of the handle
+- **THEN** the tool SHALL return `not found` and the `usage_logs` row SHALL record `upload_id` as `<invalid>`, containing no part of the supplied value
+
+#### Scenario: Status transitions
+
+- **WHEN** `check_upload` is called before an upload, after a completed upload, and after expiry of an unused token
+- **THEN** it SHALL return `pending`, then `completed` with the file's `sha256`, then `expired`
+
+#### Scenario: Cross-principal lookup
+
+- **WHEN** a credential outside the minting principal — another API key, or an access token from another grant family — calls `check_upload` with that handle
+- **THEN** the tool SHALL return `not found`
+
+#### Scenario: The agent's own handle after a refresh rotation
+
+- **WHEN** the OAuth access token that minted an upload link has been replaced by a routine refresh, and the agent calls `check_upload` with that `upload_id` presenting the new access token
+- **THEN** the tool SHALL answer for the row — `completed` with its `sha256` for an upload that landed, or the state's ordinary answer otherwise — and SHALL NOT report `not found`
+
+#### Scenario: A claimed token past its stream deadline
+
+- **WHEN** a token was claimed, the publish stranded it in `claimed` (a `PostPublishFailure`), and `check_upload` is called after `min(expires_at, claimed_at + TRANSFER_MAX_UPLOAD_SECONDS)` has passed
+- **THEN** the tool SHALL report `unknown`, SHALL NOT say the link was never used, and SHALL direct the caller to inspect the bound path with `list_files` or `read_file` before minting another link
+
+#### Scenario: A claimed token still in flight
+
+- **WHEN** `check_upload` is called on a token claimed a moment ago, inside its stream deadline
+- **THEN** the tool SHALL report `uploading`, name the deadline as a timestamp, and SHALL NOT assert that the transfer will not complete
+
+#### Scenario: A realtime clock step
+
+- **WHEN** the system clock steps forward or backward past a claimed token's stream deadline
+- **THEN** `check_upload`'s classification and the upload route's enforcement SHALL move together, both measured against the same clock and the same absolute instant
+
+#### Scenario: The credential lost write access after the mint
+
+- **WHEN** the OAuth token that minted a still-`pending` upload link has its scope downgraded to read, or the user's vault root is reassigned
+- **THEN** `check_upload` SHALL report that the link is no longer redeemable and name the reason, rather than reporting `pending`
+
+#### Scenario: A consumed link past its TTL
+
+- **WHEN** `check_upload` is called on a token whose stream was cut short (state `consumed`) after its TTL has passed
+- **THEN** the tool SHALL say the upload was cut short and that nothing was published, and SHALL NOT say the link was never used
+
+#### Scenario: A completed row needs no liveness re-check
+
+- **WHEN** `check_upload` is called on a `completed` row whose credential has since been revoked
+- **THEN** the tool SHALL report `completed` with the recorded `size`, `sha256`, `mime` and `completed_at`, and SHALL NOT run the liveness predicates

--- a/openspec/changes/transfer-grant-scoped-identity/specs/file-transfer/spec.md
+++ b/openspec/changes/transfer-grant-scoped-identity/specs/file-transfer/spec.md
@@ -2,7 +2,7 @@
 
 ### Requirement: A transfer handle is scoped to the minting principal
 
-The identity-scoped lookup behind `check_upload` SHALL resolve a `public_id` only for the **principal** that minted it, where the principal of an API key is that `api_keys` row and the principal of an OAuth access token is its **grant family** (`oauth_tokens.grant_id`), and SHALL additionally require the calling `user_id` to equal the row's. A handle SHALL therefore remain visible to its minting agent across any number of refresh rotations within one grant, and SHALL remain invisible to every other principal — a different API key, a different client, or a second `/authorize` approval by the same user for the same client. When the presenting credential row cannot be resolved, the lookup SHALL find nothing.
+The identity-scoped lookup behind `check_upload` SHALL resolve a `public_id` only for the **principal** that minted it, where the principal of an API key is that `api_keys` row and the principal of an OAuth access token is its **grant family** (`oauth_tokens.grant_id`), and SHALL additionally require the calling `user_id` to equal the row's. A handle SHALL therefore remain visible to its minting agent across any number of refresh rotations within one grant, and SHALL remain invisible to every other principal — a different API key, a different client, or a second `/authorize` approval by the same user for the same client. When the presenting credential row cannot be resolved, the lookup SHALL find nothing. The family comparison SHALL include the credentials' `client_id` as well as their `grant_id`, so that two clients can never share a principal. Grant separation is exact for every grant issued after migration 014; for rows whose `grant_id` came from 014's backfill it is approximate in one direction, because that backfill groups by `(client_id, user_id)` — two pre-014 consents by the same user for the same client share one family, and a token of either MAY therefore read the other's handle status. That is an accepted limitation, not a permitted widening: it grants read-only status on a handle that authorises nothing, and no other pair of principals SHALL be conflated.
 
 Redemption SHALL NOT be widened in the same way: the `/transfer/*` routes and the publish gate SHALL keep re-validating the exact credential row recorded on the token. This is safe because a capability's expiry is already clamped to that credential's own expiry, so the minting credential outlives every link it minted unless it is revoked — and a revocation SHALL kill the link.
 
@@ -15,6 +15,11 @@ Redemption SHALL NOT be widened in the same way: the `/transfer/*` routes and th
 
 - **WHEN** the same user approves the same client a second time, producing a second grant family, and a token of that family presents the first family's handle
 - **THEN** the lookup SHALL find nothing
+
+#### Scenario: Two clients never share a principal
+
+- **WHEN** a token registered to a different `client_id` presents a handle whose minting token carries the same `grant_id`
+- **THEN** the lookup SHALL find nothing, and a token of the minting client's own family SHALL still resolve it
 
 #### Scenario: Another user, another key
 

--- a/openspec/changes/transfer-grant-scoped-identity/tasks.md
+++ b/openspec/changes/transfer-grant-scoped-identity/tasks.md
@@ -8,6 +8,9 @@
       branch keeps the exact `key_id` / both-null comparison.
 - [x] 1.2 Rewrite `lookup_by_public_id` to use them, keeping `public_id`,
       `direction` and `user_id` unchanged and applying no state filter.
+- [x] 1.2a Compare `client_id` alongside `grant_id` in the `EXISTS` — the
+      one-family-per-`(client_id, user_id)` rule is an invariant, not a
+      constraint, and this predicate is the access control.
 - [x] 1.3 Document the widening *and* the two things that did not widen
       (a different grant; redemption) in the function docstring.
 - [x] 1.4 Update the comment in `check_upload_impl` that describes what the
@@ -44,3 +47,9 @@
       credential row" subsection under **File transfer**, and the two places
       that said the lookup scopes to the credential row.
 - [x] 4.2 Spec deltas + `openspec validate --strict`.
+- [x] 4.3 Record the accepted limitation — 014's backfill groups pre-existing
+      rows by `(client_id, user_id)`, so two pre-014 consents by the same user
+      for the same client share a family — in design.md (D4a), CLAUDE.md and
+      the principal requirement.
+- [x] 4.4 Rebase onto `origin/main` after the wave-1 archive and re-diff the
+      MODIFIED `check_upload` block against the archived baseline.

--- a/openspec/changes/transfer-grant-scoped-identity/tasks.md
+++ b/openspec/changes/transfer-grant-scoped-identity/tasks.md
@@ -1,0 +1,46 @@
+# Tasks
+
+## 1. Scope the lookup to the principal
+
+- [x] 1.1 Add `_same` and `_minted_by_principal` to `src/services/transfer.py`;
+      the OAuth branch is a correlated `EXISTS` joining `oauth_tokens` to
+      itself on `grant_id` (minting token ↔ presenting token), the other
+      branch keeps the exact `key_id` / both-null comparison.
+- [x] 1.2 Rewrite `lookup_by_public_id` to use them, keeping `public_id`,
+      `direction` and `user_id` unchanged and applying no state filter.
+- [x] 1.3 Document the widening *and* the two things that did not widen
+      (a different grant; redemption) in the function docstring.
+- [x] 1.4 Update the comment in `check_upload_impl` that describes what the
+      lookup matches on. No other tools change; `Identity` is unchanged.
+
+## 2. One definition of "write"
+
+- [x] 2.1 Replace `_credential_ok`'s private
+      `"readwrite" not in (cred.scope or "").split()` with
+      `src.oauth.scope.token_has_write`.
+
+## 3. Tests
+
+- [x] 3.1 `tests/integration/test_transfer_pg.py`: seed `grant_id` in
+      `_seed_identity` and `_ownerless_credentials` (migration 014 made it NOT
+      NULL after this module was last touched), and add `_rotate` /
+      `_second_consent` helpers.
+- [x] 3.2 Add the handle-scoping section: rotation finds the completed row,
+      three rotations still find it, a second consent does not, another user
+      does not, a second API key does not, the two credential kinds do not see
+      each other, a vanished presenting token is not found, `direction` still
+      scopes, and redemption stays bound to the minting row.
+- [x] 3.3 `tests/test_issue_74_transfer_grant_lookup.py`: pin the compiled
+      predicate for all three identity shapes plus the shared-helper swap.
+- [x] 3.4 Confirm the new tests fail against the pre-change service (stash the
+      service file and re-run) — 2 unit + 4 integration failures.
+- [x] 3.5 Full suite green: `pytest --ignore=tests/integration`, and
+      `tests/integration/test_transfer_pg.py` against a throwaway
+      `pgvector/pgvector:pg16`.
+
+## 4. Documentation
+
+- [x] 4.1 CLAUDE.md: new "The handle belongs to the principal, not to the
+      credential row" subsection under **File transfer**, and the two places
+      that said the lookup scopes to the credential row.
+- [x] 4.2 Spec deltas + `openspec validate --strict`.

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -2385,13 +2385,19 @@ async def check_upload_impl(upload_id: str) -> str:
             "`upload_id` from `request_upload` (22 characters), not the upload "
             "URL and not the token after the `#`."
         )
+    # The identity is the request's credential as `APIKeyMiddleware` resolved
+    # it. `lookup_by_public_id` is what turns it into a *principal*: an API key
+    # is one, an OAuth access token is one hour of one, so the OAuth path
+    # matches the whole grant family behind the presented token. Without that,
+    # the hourly refresh made this tool answer "not minted by this identity"
+    # about the agent's own completed upload (#74).
     identity = _transfer_identity()
     async with async_session() as session:
         row = await transfer.lookup_by_public_id(
             session, upload_id, identity=identity, direction="upload"
         )
         # **The liveness re-check runs inside the session**, before it closes.
-        # `lookup_by_public_id` matches on public_id/direction/identity and
+        # `lookup_by_public_id` matches on public_id/direction/principal and
         # applies no state filter, but the redemption route decides usability
         # from a strictly larger predicate: `PUT /transfer/upload` also
         # requires `resolve_identity_ok(need_write=True)` and

--- a/src/services/transfer.py
+++ b/src/services/transfer.py
@@ -48,10 +48,12 @@ from urllib.parse import urljoin, urlsplit, urlunsplit
 
 import httpx
 import idna
-from sqlalchemy import delete, select, update
+from sqlalchemy import and_, delete, literal, select, update
+from sqlalchemy.orm import aliased
 
 from src.config import settings
 from src.models.db import APIKey, OAuthToken, TransferToken, User
+from src.oauth.scope import token_has_write
 from src.services import vault_fs
 from src.services.vault import classify_bytes
 
@@ -573,29 +575,105 @@ async def lookup_token(session, token: str, *, direction: str) -> TransferToken 
     return result.scalar_one_or_none()
 
 
+def _same(column, value):
+    """`column = value`, or `column IS NULL` when `value` is `None`.
+
+    `column == None` renders as `= NULL`, which is never true — and would
+    silently turn "single-user API key" into "matches nothing".
+    """
+    return column.is_(None) if value is None else column == value
+
+
+def _minted_by_principal(identity: Identity):
+    """WHERE fragment: was this row minted by the principal now asking?
+
+    Two different questions, because the two credential kinds have different
+    lifetimes:
+
+    - An **API key** *is* the principal. It does not rotate, so the row must
+      name this exact key and carry no OAuth credential.
+    - An **OAuth access token** is one hour of one principal. The principal is
+      the grant family behind it (`oauth_tokens.grant_id`, migration 014):
+      every row minted from one `/authorize` approval shares it and every
+      rotation inherits it. So the row's *minting* token and the *presenting*
+      token merely have to be siblings in that family. Pinning the row id
+      instead is issue #74 — after the hourly refresh the agent's own upload
+      handle came back "not minted by this identity".
+
+    The family predicate is a correlated `EXISTS` rather than a join on the
+    outer select, so the lookup stays a single statement returning at most the
+    one `public_id` row. `grant_id` is NOT NULL on `oauth_tokens`, so there is
+    no null-equality trap here; if the presenting token's row has since been
+    deleted the `EXISTS` is simply false and the answer is "not found", which
+    is the fail-closed direction.
+    """
+    if identity.oauth_token_id is None:
+        return and_(
+            _same(TransferToken.key_id, identity.key_id),
+            TransferToken.oauth_token_id.is_(None),
+        )
+    minting = aliased(OAuthToken, name="minting_token")
+    presenting = aliased(OAuthToken, name="presenting_token")
+    return and_(
+        TransferToken.key_id.is_(None),
+        select(literal(1))
+        .select_from(minting)
+        .join(presenting, presenting.grant_id == minting.grant_id)
+        .where(
+            minting.id == TransferToken.oauth_token_id,
+            presenting.id == identity.oauth_token_id,
+        )
+        .exists(),
+    )
+
+
 async def lookup_by_public_id(
     session, public_id: str, *, identity: Identity, direction: str
 ) -> TransferToken | None:
-    """A transfer row by its public handle, **scoped to the calling identity**.
+    """A transfer row by its public handle, **scoped to the calling principal**.
 
-    `check_upload` is the only read that is not gated by a capability, so the
-    scoping is the access control: the credential must be the exact one that
-    minted the row, and the user must match too. A handle minted by another key
-    — or by the same key after it was reassigned to another user — is simply
-    not found. No state filter: reporting `expired` and `completed` is the
-    whole job.
+    `check_upload` is the only read that is not gated by a capability, so this
+    scoping is the access control. What it scopes *to* is the stable principal
+    behind the request, not the credential row the request happened to arrive
+    on:
+
+    - **API key** — the key row itself, unchanged. A key is the principal: it
+      does not rotate, and nothing else stands behind it.
+    - **OAuth** — the *grant family* (`oauth_tokens.grant_id`, migration 014).
+      An access token rotates roughly hourly, and rotation mints a brand-new
+      `oauth_tokens` row for the same user, the same client and the same
+      consent. Matching on the row id therefore made the agent's own handle
+      stop being its own after a routine refresh: `check_upload` answered "no
+      upload link with id … was minted by this identity" about a *completed*
+      upload it had minted an hour earlier, which is the one message reserved
+      for someone else's handle (issue #74). One consent is one principal, so
+      the family is what the handle belongs to.
+
+    The `user_id` comparison is kept on top of both. A grant family already
+    belongs to exactly one `(client_id, user_id)` — the invariant
+    `src/oauth/grants.py` establishes and 014's backfill preserves — so this is
+    defence in depth for the OAuth path; on the API-key path it is the check
+    that stops a key reassigned to another user from carrying its old handles
+    across.
+
+    What is deliberately *not* widened: a token from a **different** grant is
+    still not found, even for the same user and the same client software. A
+    second `/authorize` approval is a second consent, and the operator may
+    revoke either one independently. Nor does this touch redemption — the
+    `/transfer/*` routes still re-validate the exact credential row that
+    minted the capability (see `resolve_identity_ok`). That asymmetry is
+    intentional and costs nothing, because `plan_mint_window` clamps every
+    capability's expiry to the minting credential's own: the minting access
+    token outlives the link it minted unless it is revoked, and a revocation
+    *should* kill the link.
+
+    No state filter: reporting `expired` and `completed` is the whole job.
     """
-    def same(column, value):
-        # `column == None` renders as `= NULL`, which is never true — and would
-        # silently turn "single-user API key" into "matches nothing".
-        return column.is_(None) if value is None else column == value
-
     stmt = select(TransferToken).where(
         TransferToken.public_id == public_id,
         TransferToken.direction == direction,
-        same(TransferToken.key_id, identity.key_id),
-        same(TransferToken.oauth_token_id, identity.oauth_token_id),
-        same(TransferToken.user_id, identity.user_id),
+        _same(TransferToken.user_id, identity.user_id),
+        _minted_by_principal(identity),
     )
     result = await session.execute(stmt.execution_options(populate_existing=True))
     return result.scalar_one_or_none()
@@ -646,7 +724,7 @@ def _credential_ok(cred, *, need_write: bool, row: TransferToken) -> bool:
             return False
         if cred.expires_at is None or cred.expires_at <= now:
             return False
-        if need_write and "readwrite" not in (cred.scope or "").split():
+        if need_write and not token_has_write(cred.scope):
             return False
     else:  # pragma: no cover - defensive
         return False

--- a/src/services/transfer.py
+++ b/src/services/transfer.py
@@ -606,6 +606,20 @@ def _minted_by_principal(identity: Identity):
     no null-equality trap here; if the presenting token's row has since been
     deleted the `EXISTS` is simply false and the answer is "not found", which
     is the fail-closed direction.
+
+    **`client_id` is compared as well as `grant_id`.** A grant belongs to
+    exactly one `(client_id, user_id)` — the invariant `src/oauth/grants.py`
+    establishes at every write site — so post-014 the extra equality can never
+    change the answer. It is here because the invariant is *asserted* rather
+    than enforced by a constraint, and because this predicate is the access
+    control: if a family ever did span two clients, the failure would be one
+    client reading another's handles, which is the one thing this must not do.
+
+    What it does **not** fix, because no predicate here can: 014's backfill
+    groups pre-014 rows by `(client_id, user_id)`, which #64 accepted as
+    approximate. Two consents by the same user *for the same client* made
+    before 014 therefore share one family, and this predicate holds for both.
+    See the "same-client, pre-014" limitation in CLAUDE.md.
     """
     if identity.oauth_token_id is None:
         return and_(
@@ -618,7 +632,13 @@ def _minted_by_principal(identity: Identity):
         TransferToken.key_id.is_(None),
         select(literal(1))
         .select_from(minting)
-        .join(presenting, presenting.grant_id == minting.grant_id)
+        .join(
+            presenting,
+            and_(
+                presenting.grant_id == minting.grant_id,
+                presenting.client_id == minting.client_id,
+            ),
+        )
         .where(
             minting.id == TransferToken.oauth_token_id,
             presenting.id == identity.oauth_token_id,

--- a/tests/integration/test_transfer_pg.py
+++ b/tests/integration/test_transfer_pg.py
@@ -39,6 +39,7 @@ from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from src.models.db import APIKey, OAuthClient, OAuthToken, TransferToken, UsageLog, User
+from src.oauth.grants import new_grant_id, revoke_grant_family
 from src.services import transfer
 
 PGVECTOR_TEST_ADMIN_URL = os.environ.get("PGVECTOR_TEST_ADMIN_URL")
@@ -213,12 +214,16 @@ async def _seed_identity(session, *, permission="readwrite", vault_path="/obsidi
     session.add(client)
     await session.flush()
 
+    # `grant_id` is NOT NULL since migration 014: an access token belongs to
+    # the consent it descends from, and `lookup_by_public_id` scopes an OAuth
+    # handle to that family rather than to this one row (#74).
     oauth = OAuthToken(
         user_id=user.id,
         token_hash=uuid.uuid4().hex + uuid.uuid4().hex,
         token_type="access",
         client_id=client.client_id,
         scope="readwrite",
+        grant_id=new_grant_id(),
         expires_at=_now() + datetime.timedelta(hours=1),
         revoked=False,
     )
@@ -226,6 +231,54 @@ async def _seed_identity(session, *, permission="readwrite", vault_path="/obsidi
     await session.flush()
     await session.commit()
     return user, key, oauth
+
+
+async def _rotate(session, oauth, *, expire_old=True):
+    """What `_handle_refresh` does: a new access-token row in the same family.
+
+    Same user, same client, same consent — a different `oauth_tokens.id`. The
+    replaced access token is left live to its own expiry by rotation (only the
+    refresh token is revoked), so `expire_old` models the far more common case
+    where the agent comes back after the old hour has run out.
+    """
+    fresh = OAuthToken(
+        user_id=oauth.user_id,
+        token_hash=uuid.uuid4().hex + uuid.uuid4().hex,
+        token_type="access",
+        client_id=oauth.client_id,
+        scope=oauth.scope,
+        grant_id=oauth.grant_id,
+        expires_at=_now() + datetime.timedelta(hours=1),
+        revoked=False,
+    )
+    session.add(fresh)
+    if expire_old:
+        oauth.expires_at = _now() - datetime.timedelta(seconds=1)
+    await session.commit()
+    await session.refresh(fresh)
+    return fresh
+
+
+async def _second_consent(session, oauth):
+    """Another `/authorize` approval by the same user for the same client.
+
+    A different grant family, which the operator can revoke independently of
+    the first — so its tokens must not see the first one's handles.
+    """
+    other = OAuthToken(
+        user_id=oauth.user_id,
+        token_hash=uuid.uuid4().hex + uuid.uuid4().hex,
+        token_type="access",
+        client_id=oauth.client_id,
+        scope=oauth.scope,
+        grant_id=new_grant_id(),
+        expires_at=_now() + datetime.timedelta(hours=1),
+        revoked=False,
+    )
+    session.add(other)
+    await session.commit()
+    await session.refresh(other)
+    return other
 
 
 async def _add_token(session, *, key=None, oauth=None, user=None, direction="upload",
@@ -710,6 +763,265 @@ async def test_single_user_root_compares_against_settings(clean, monkeypatch):
         assert await transfer.resolve_root_ok(session, row) is False
 
 
+# ── 3.1 handle scoping: the principal, not the credential row ───────────────
+#
+# `check_upload` is the only transfer read that is not gated by a capability,
+# so `lookup_by_public_id`'s WHERE clause *is* its access control. It has to
+# answer two questions at once, and a fake session can express neither: an
+# OAuth handle belongs to the whole grant family behind the presented token
+# (#74 — otherwise the hourly refresh made the agent's own completed upload
+# read as somebody else's handle), and a handle from any *other* principal is
+# still invisible. Both are one correlated `EXISTS` over real rows.
+
+
+async def _mint_oauth_upload(session, user, oauth, path="Attachments/a.png"):
+    token, row, _window = await transfer.mint_token(
+        session,
+        "upload",
+        path,
+        overwrite=False,
+        identity=transfer.Identity(oauth_token_id=oauth.id, user_id=user.id),
+        vault_root="/obsidian",
+        expected_fingerprint=None,
+    )
+    return token, row
+
+
+async def _lookup(session, row, identity, direction="upload"):
+    return await transfer.lookup_by_public_id(
+        session, row.public_id, identity=identity, direction=direction
+    )
+
+
+async def test_an_oauth_handle_survives_refresh_rotation(clean):
+    """The #74 scenario, in its assumption-free form: a *completed* upload.
+
+    Minted at 14:50 and uploaded at 14:55; the access token expires at 15:50
+    and the client refreshes; at 15:55 the agent calls `check_upload` to get
+    the sha256 that `request_upload`'s own result told it to fetch. The row is
+    right there, `completed`, with the digest — and the old lookup answered
+    "no upload link with id … was minted by this identity".
+    """
+    async with clean() as session:
+        user, _, oauth = await _seed_identity(session)
+        token, row = await _mint_oauth_upload(session, user, oauth)
+        claimed = await transfer.claim_upload(session, token)
+        assert claimed is not None
+        await transfer.complete_upload(
+            session, claimed, size=3, sha256="d" * 64, mime="image/png"
+        )
+
+        fresh = await _rotate(session, oauth)
+        assert fresh.id != oauth.id and fresh.grant_id == oauth.grant_id
+
+        found = await _lookup(
+            session,
+            row,
+            transfer.Identity(oauth_token_id=fresh.id, user_id=user.id),
+        )
+    assert found is not None, "the agent's own handle after one rotation"
+    assert found.id == row.id
+    assert found.state == "completed"
+    assert found.sha256 == "d" * 64
+
+
+async def test_an_oauth_handle_survives_several_rotations(clean):
+    """The family is the principal, so the number of hops does not matter."""
+    async with clean() as session:
+        user, _, oauth = await _seed_identity(session)
+        _token, row = await _mint_oauth_upload(session, user, oauth)
+        current = oauth
+        for _ in range(3):
+            current = await _rotate(session, current)
+        found = await _lookup(
+            session,
+            row,
+            transfer.Identity(oauth_token_id=current.id, user_id=user.id),
+        )
+    assert found is not None and found.id == row.id
+
+
+async def test_a_second_consent_by_the_same_user_is_a_different_principal(clean):
+    """Same user, same client software — but a grant the operator revokes alone."""
+    async with clean() as session:
+        user, _, oauth = await _seed_identity(session)
+        _token, row = await _mint_oauth_upload(session, user, oauth)
+        other = await _second_consent(session, oauth)
+        assert other.grant_id != oauth.grant_id
+
+        found = await _lookup(
+            session,
+            row,
+            transfer.Identity(oauth_token_id=other.id, user_id=user.id),
+        )
+    assert found is None
+
+
+async def test_another_users_grant_never_sees_the_handle(clean):
+    async with clean() as session:
+        user, _, oauth = await _seed_identity(session)
+        _token, row = await _mint_oauth_upload(session, user, oauth)
+        other_user, other_key, other_oauth = await _seed_identity(session)
+
+        assert (
+            await _lookup(
+                session,
+                row,
+                transfer.Identity(
+                    oauth_token_id=other_oauth.id, user_id=other_user.id
+                ),
+            )
+            is None
+        )
+        # And the same grant presented under the wrong user id — the defence
+        # in depth on top of the family invariant.
+        assert (
+            await _lookup(
+                session,
+                row,
+                transfer.Identity(oauth_token_id=oauth.id, user_id=other_user.id),
+            )
+            is None
+        )
+        assert (
+            await _lookup(
+                session,
+                row,
+                transfer.Identity(key_id=other_key.id, user_id=other_user.id),
+            )
+            is None
+        )
+
+
+async def test_the_two_credential_kinds_do_not_see_each_other(clean):
+    """An API key is its own principal; nothing about it becomes a family."""
+    async with clean() as session:
+        user, key, oauth = await _seed_identity(session)
+        _token, oauth_row = await _mint_oauth_upload(session, user, oauth)
+        _key_token, key_row = await _mint(session, user, key)
+
+        assert (
+            await _lookup(
+                session,
+                oauth_row,
+                transfer.Identity(key_id=key.id, user_id=user.id),
+            )
+            is None
+        )
+        assert (
+            await _lookup(
+                session,
+                key_row,
+                transfer.Identity(oauth_token_id=oauth.id, user_id=user.id),
+            )
+            is None
+        )
+        # Each still finds its own.
+        assert (
+            await _lookup(
+                session, key_row, transfer.Identity(key_id=key.id, user_id=user.id)
+            )
+        ).id == key_row.id
+
+
+async def test_a_second_api_key_of_the_same_user_is_a_different_principal(clean):
+    async with clean() as session:
+        user, key, _ = await _seed_identity(session)
+        _token, row = await _mint(session, user, key)
+        second = APIKey(
+            user_id=user.id,
+            name="k2",
+            key_hash=uuid.uuid4().hex + uuid.uuid4().hex,
+            key_prefix="omcp_test",
+            permission="readwrite",
+            is_active=True,
+        )
+        session.add(second)
+        await session.commit()
+
+        assert (
+            await _lookup(
+                session, row, transfer.Identity(key_id=second.id, user_id=user.id)
+            )
+            is None
+        )
+
+
+async def test_a_vanished_presenting_token_is_not_found(clean):
+    """No row, no family, no answer — the fail-closed direction.
+
+    The *minting* token is what `transfer_tokens.oauth_token_id` cascades
+    from, so deleting a rotated sibling leaves the transfer row in place and
+    only removes the presenting side of the `EXISTS`.
+    """
+    async with clean() as session:
+        user, _, oauth = await _seed_identity(session)
+        _token, row = await _mint_oauth_upload(session, user, oauth)
+        fresh = await _rotate(session, oauth)
+        vanished_id = fresh.id
+        await session.delete(fresh)
+        await session.commit()
+
+        surviving = (
+            await session.execute(select(func.count()).select_from(TransferToken))
+        ).scalar_one()
+        assert surviving == 1, "only the presenting sibling was deleted"
+        assert (
+            await _lookup(
+                session,
+                row,
+                transfer.Identity(oauth_token_id=vanished_id, user_id=user.id),
+            )
+            is None
+        )
+
+
+async def test_direction_still_scopes_the_handle(clean):
+    """An upload handle is not a download handle, family or not."""
+    async with clean() as session:
+        user, _, oauth = await _seed_identity(session)
+        _token, row = await _mint_oauth_upload(session, user, oauth)
+        fresh = await _rotate(session, oauth)
+        identity = transfer.Identity(oauth_token_id=fresh.id, user_id=user.id)
+        assert await _lookup(session, row, identity, direction="download") is None
+        assert await _lookup(session, row, identity, direction="upload") is not None
+
+
+async def test_redemption_stays_bound_to_the_minting_token(clean):
+    """The deliberate asymmetry: the *lookup* widened, redemption did not.
+
+    `resolve_identity_ok` still loads the exact credential row the capability
+    was minted under, and that costs nothing because `plan_mint_window` clamps
+    a capability's expiry to that credential's own: the minting access token
+    outlives every link it minted unless it is revoked, and a revocation
+    *should* kill the link. Widening redemption to "any live token of the
+    family" would bind an already-minted capability to credentials that did
+    not exist when it was minted.
+    """
+    async with clean() as session:
+        user, _, oauth = await _seed_identity(session)
+        _token, row = await _mint_oauth_upload(session, user, oauth)
+        # (1) The clamp. This is the whole reason the narrow binding is safe.
+        assert row.expires_at <= oauth.expires_at
+
+        # (2) A proactive refresh inside the old token's hour. Rotation revokes
+        #     only the refresh token, so the minting access token is untouched
+        #     and the link really is still redeemable — which is what the
+        #     widened lookup now lets `check_upload` report.
+        fresh = await _rotate(session, oauth, expire_old=False)
+        identity = transfer.Identity(oauth_token_id=fresh.id, user_id=user.id)
+        assert await transfer.resolve_identity_ok(session, row, need_write=True) is True
+        assert (await _lookup(session, row, identity)).id == row.id
+
+        # (3) Revoking the grant kills the family, minting token included. The
+        #     handle is still the agent's own — so it is found, and reported
+        #     dead, rather than disowned.
+        await revoke_grant_family(session, oauth.grant_id)
+        await session.commit()
+        assert await transfer.resolve_identity_ok(session, row, need_write=True) is False
+        assert (await _lookup(session, row, identity)).id == row.id
+
+
 # ── 3.1 the pre-publication lock ────────────────────────────────────────────
 
 
@@ -1023,6 +1335,7 @@ async def _ownerless_credentials(session):
         token_type="access",
         client_id=client.client_id,
         scope="readwrite",
+        grant_id=new_grant_id(),
         expires_at=_now() + datetime.timedelta(hours=1),
         revoked=False,
     )

--- a/tests/integration/test_transfer_pg.py
+++ b/tests/integration/test_transfer_pg.py
@@ -857,6 +857,65 @@ async def test_a_second_consent_by_the_same_user_is_a_different_principal(clean)
     assert found is None
 
 
+async def test_a_grant_id_shared_across_clients_still_cannot_cross(clean):
+    """The `client_id` half of the family predicate, exercised directly.
+
+    "One `grant_id` belongs to exactly one `(client_id, user_id)`" is an
+    invariant every write site upholds, not a constraint the database
+    enforces, and 014's backfill groups by exactly those two columns — so
+    post-014 this row cannot arise. The predicate compares `client_id` anyway,
+    because it *is* the access control here: if a family ever did span two
+    clients, the failure would be one client reading another's handles.
+    """
+    async with clean() as session:
+        user, _, oauth = await _seed_identity(session)
+        _token, row = await _mint_oauth_upload(session, user, oauth)
+
+        second_client = OAuthClient(
+            user_id=user.id,
+            client_id=uuid.uuid4().hex,
+            client_secret_hash="y" * 64,
+            client_name="c2",
+            redirect_uris=["https://elsewhere.example/cb"],
+            scope="readwrite",
+        )
+        session.add(second_client)
+        await session.flush()
+        impostor = OAuthToken(
+            user_id=user.id,
+            token_hash=uuid.uuid4().hex + uuid.uuid4().hex,
+            token_type="access",
+            client_id=second_client.client_id,
+            scope="readwrite",
+            # The shape the invariant forbids: another client's token wearing
+            # this family's id.
+            grant_id=oauth.grant_id,
+            expires_at=_now() + datetime.timedelta(hours=1),
+            revoked=False,
+        )
+        session.add(impostor)
+        await session.commit()
+
+        assert (
+            await _lookup(
+                session,
+                row,
+                transfer.Identity(oauth_token_id=impostor.id, user_id=user.id),
+            )
+            is None
+        ), "a second client sharing the grant id must not read its handles"
+        # And the legitimate sibling of the same client still resolves, so the
+        # refusal above is the `client_id` comparison and not a broken family.
+        sibling = await _rotate(session, oauth, expire_old=False)
+        assert (
+            await _lookup(
+                session,
+                row,
+                transfer.Identity(oauth_token_id=sibling.id, user_id=user.id),
+            )
+        ).id == row.id
+
+
 async def test_another_users_grant_never_sees_the_handle(clean):
     async with clean() as session:
         user, _, oauth = await _seed_identity(session)

--- a/tests/test_issue_74_transfer_grant_lookup.py
+++ b/tests/test_issue_74_transfer_grant_lookup.py
@@ -1,0 +1,173 @@
+"""#74 — `check_upload` must survive a routine OAuth refresh rotation.
+
+`lookup_by_public_id` used to scope an OAuth-minted transfer to the exact
+`oauth_tokens.id` row that minted it. An access token lives one hour and
+rotation mints a *new* row for the same user, the same client and the same
+consent, so an hour after minting an upload link the agent's own
+`check_upload` answered "no upload link with id … was minted by this
+identity" — the message reserved for somebody else's handle — about a
+completed upload it had minted itself.
+
+The behavioural proof lives in `tests/integration/test_transfer_pg.py`, which
+runs the real correlated `EXISTS` against Postgres with real rotated rows.
+What is pinned *here* is the predicate the service builds, because that is
+what the always-on suite can see: the OAuth branch must key on the grant
+family and must not pin the presenting token's row id, and the API-key branch
+must stay exactly as narrow as it was.
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime
+import inspect
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from src.models.db import OAuthToken, TransferToken
+from src.oauth import scope as oauth_scope
+from src.services import transfer
+
+
+def _sql(identity: transfer.Identity) -> str:
+    """The statement `lookup_by_public_id` would issue, as literal SQL.
+
+    Captured from the service itself rather than rebuilt here: a test that
+    reconstructs the query pins its own copy of the predicate, not the one
+    production runs.
+    """
+    captured: list = []
+
+    class _Result:
+        def scalar_one_or_none(self):
+            return None
+
+    class _Session:
+        async def execute(self, stmt):
+            captured.append(stmt)
+            return _Result()
+
+    asyncio.run(
+        transfer.lookup_by_public_id(
+            _Session(),
+            "a" * 22,
+            identity=identity,
+            direction="upload",
+        )
+    )
+    assert len(captured) == 1, "the lookup must stay a single statement"
+    return str(
+        captured[0].compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    )
+
+
+OAUTH = transfer.Identity(oauth_token_id=9, user_id=7)
+API_KEY = transfer.Identity(key_id=3, user_id=7)
+NO_CREDENTIAL = transfer.Identity()
+
+
+def test_oauth_lookup_keys_on_the_grant_family_not_the_token_row():
+    sql = _sql(OAUTH)
+    # The presenting token's row id may only appear as the *entry point* into
+    # its family, never as a constraint on the transfer row itself. This is
+    # the exact predicate #74 is about.
+    assert "transfer_tokens.oauth_token_id = 9" not in sql
+    assert "grant_id" in sql, "the family is what an OAuth handle belongs to"
+    assert "presenting_token.id = 9" in sql
+    assert "minting_token.id = transfer_tokens.oauth_token_id" in sql
+    assert "presenting_token.grant_id = minting_token.grant_id" in sql
+
+
+def test_oauth_lookup_keeps_every_other_scoping_predicate():
+    sql = _sql(OAUTH)
+    assert "transfer_tokens.public_id = '" + "a" * 22 + "'" in sql
+    assert "transfer_tokens.direction = 'upload'" in sql
+    # Defence in depth on top of the family: a grant belongs to one
+    # (client_id, user_id), but the user comparison stays regardless.
+    assert "transfer_tokens.user_id = 7" in sql
+    # An OAuth caller must never reach an API-key-minted row.
+    assert "transfer_tokens.key_id IS NULL" in sql
+
+
+def test_api_key_lookup_is_not_widened():
+    """A key does not rotate, so nothing about it becomes a family."""
+    sql = _sql(API_KEY)
+    assert "transfer_tokens.key_id = 3" in sql
+    assert "transfer_tokens.oauth_token_id IS NULL" in sql
+    assert "oauth_tokens" not in sql
+    assert "grant_id" not in sql
+
+
+def test_credential_less_identity_still_matches_only_credential_less_rows():
+    sql = _sql(NO_CREDENTIAL)
+    assert "transfer_tokens.key_id IS NULL" in sql
+    assert "transfer_tokens.oauth_token_id IS NULL" in sql
+    assert "transfer_tokens.user_id IS NULL" in sql
+    assert "oauth_tokens" not in sql
+
+
+def test_lookup_returns_none_when_nothing_matches():
+    """The capture harness stands in for a real miss; the answer is `None`."""
+
+    class _Result:
+        def scalar_one_or_none(self):
+            return None
+
+    class _Session:
+        async def execute(self, stmt):
+            return _Result()
+
+    assert (
+        asyncio.run(
+            transfer.lookup_by_public_id(
+                _Session(), "b" * 22, identity=OAUTH, direction="upload"
+            )
+        )
+        is None
+    )
+
+
+def test_write_scope_test_is_the_shared_helper():
+    """The private `"readwrite" not in scope.split()` copy is gone.
+
+    Behaviour is unchanged — both forms are membership tests — but a fourth
+    private copy of "does this scope grant write" is exactly what
+    `src/oauth/scope.py` was created to prevent (#67).
+    """
+    assert transfer.token_has_write is oauth_scope.token_has_write
+    source = inspect.getsource(transfer)
+    assert '"readwrite" not in' not in source
+    assert "'readwrite' not in" not in source
+
+
+@pytest.mark.parametrize(
+    "scope,expected",
+    [
+        ("readwrite", True),
+        ("offline_access readwrite", True),
+        ("read", False),
+        (None, False),
+    ],
+)
+def test_oauth_write_predicate_reads_scope_as_a_set(scope, expected):
+    """`_credential_ok`'s write test, through whichever helper it now calls.
+
+    A scope string is a space-separated *set*: `"offline_access readwrite"` is
+    a write grant. Unchanged behaviour, asserted so the delegation cannot
+    quietly become an equality test.
+    """
+    token = OAuthToken(
+        user_id=None,
+        token_hash="x" * 64,
+        token_type="access",
+        client_id="c",
+        scope=scope,
+        grant_id="g",
+        expires_at=datetime.datetime.now(datetime.timezone.utc)
+        + datetime.timedelta(hours=1),
+        revoked=False,
+    )
+    row = TransferToken(user_id=None)
+    assert transfer._credential_ok(token, need_write=True, row=row) is expected

--- a/tests/test_issue_74_transfer_grant_lookup.py
+++ b/tests/test_issue_74_transfer_grant_lookup.py
@@ -78,6 +78,11 @@ def test_oauth_lookup_keys_on_the_grant_family_not_the_token_row():
     assert "presenting_token.id = 9" in sql
     assert "minting_token.id = transfer_tokens.oauth_token_id" in sql
     assert "presenting_token.grant_id = minting_token.grant_id" in sql
+    # Defence in depth on top of the family. One `grant_id` belongs to one
+    # `(client_id, user_id)` by invariant, not by constraint, and this
+    # predicate *is* the access control — so the client is compared too, and
+    # a family that somehow spanned two clients still cannot leak across them.
+    assert "presenting_token.client_id = minting_token.client_id" in sql
 
 
 def test_oauth_lookup_keeps_every_other_scoping_predicate():


### PR DESCRIPTION
Closes #74.

- `lookup_by_public_id` matches OAuth-minted handles on the grant family (`oauth_tokens.grant_id` + `client_id` + `user_id`) via a correlated EXISTS instead of the exact minting token row, so the agent's own `check_upload` survives refresh rotation. No migration needed.
- Redemption stays bound to the minting credential row (fail-closed); the expiry clamp from #73 guarantees a live link has a live minting token.
- `_credential_ok` uses the shared `token_has_write` helper.
- Fixed the Postgres transfer fixtures that were missing the NOT NULL `grant_id` since 014.
- Accepted limitation recorded: pre-014 families are grouped by `(client_id, user_id)`, so two pre-migration consents by the same user+client share status visibility.
- OpenSpec change `transfer-grant-scoped-identity` (archived after deploy).

Gates: openspec-verifier no gaps; Codex adversarial (MINOR fixed, MAJOR accepted/documented); 1317 passed / 5 skipped unit; 79 passed Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013mSEspK9GFPSdxmK9XrrMQ