### PR TITLE
fix(transfer): publish uploads at the umask default, not 0600 (#95)

### DIFF
--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -2830,6 +2830,11 @@ async def import_from_url_impl(url: str, path: str, overwrite: bool = False) -> 
         return f"{e}. Nothing was written."
     except vault_fs.UnsafePath as e:
         return f"{e}. Nothing was written."
+    except vault_fs.UnsupportedFilesystem as e:
+        # Not an OSError, so the clause below does not cover it. Reachable
+        # from the publish itself and, since #95, from the staging directory
+        # refusing to be made private.
+        return f"{e}. Nothing was written."
     except OSError as e:
         return f"Could not write {rel}: {e}"
 

--- a/src/services/transfer.py
+++ b/src/services/transfer.py
@@ -1274,6 +1274,12 @@ async def _stream_locked(
                 deadline=deadline,
                 idle_timeout=idle_timeout,
             )
+            # Publication links this very inode into place, so the 0600 the
+            # staging file was created with would become the published mode.
+            # Relax it to what a plain write would have produced, exactly as
+            # `vault._atomic_write_at` does — an upload must not land less
+            # readable than the note beside it (#95).
+            os.fchmod(fd, vault_fs.default_file_mode())
         finally:
             os.close(fd)
 

--- a/src/services/transfer.py
+++ b/src/services/transfer.py
@@ -1262,9 +1262,7 @@ async def _stream_locked(
         probe_fd, name = vault_fs.open_parent(root_fd, row.path, create=True)
         os.close(probe_fd)
 
-        staging_fd = vault_fs.open_dir_beneath(
-            root_fd, vault_fs.STAGING_DIR, create=True
-        )
+        staging_fd = vault_fs.open_staging_dir(root_fd)
         fd, tmp_name = vault_fs.create_temp(staging_fd)
         try:
             size, digest, head = await _drain(
@@ -1279,6 +1277,13 @@ async def _stream_locked(
             # Relax it to what a plain write would have produced, exactly as
             # `vault._atomic_write_at` does — an upload must not land less
             # readable than the note beside it (#95).
+            #
+            # Relaxing it here rather than at publish time means the bytes are
+            # group/world-readable for as long as the gate takes, which can be
+            # minutes; `open_staging_dir` holds `.transfer-tmp` at 0700 so that
+            # window is not reachable. Keeping the descriptor open until publish
+            # would be the alternative and is worse: it pins an fd across an
+            # unbounded wait on `SELECT … FOR UPDATE`, per upload.
             os.fchmod(fd, vault_fs.default_file_mode())
         finally:
             os.close(fd)

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -706,40 +706,6 @@ def read_file(relative_path: str, user_id: int | None = None) -> dict:
 # the name (a symlink decoy, or a leftover from a crash) cannot wedge a write.
 _TEMP_ATTEMPTS = 3
 
-# Mode a plain `open(..., "w")` produces, cached for the life of the process.
-_default_file_mode_cache: int | None = None
-
-
-def _default_file_mode() -> int:
-    """The mode a plain `open(..., "w")` would give a new file: 0o666 & ~umask.
-
-    `_atomic_write_at` creates its temp file at 0o600 so the content is never
-    readable by anyone else while it is being written, then relaxes it to this
-    before publication. Without that, every note the server rewrote would
-    silently drop from the umask default (0o644 on the container) to 0o600 and
-    become unreadable to anything else sharing the vault.
-
-    Read from `/proc/self/status` where available; the `os.umask` read-restore
-    dance is the portable fallback and is only reached once.
-    """
-    global _default_file_mode_cache
-    if _default_file_mode_cache is None:
-        mask: int | None = None
-        try:
-            with open("/proc/self/status", encoding="ascii") as status:
-                for line in status:
-                    if line.startswith("Umask:"):
-                        mask = int(line.split()[1], 8)
-                        break
-        except OSError:
-            mask = None
-        if mask is None:
-            mask = os.umask(0o022)
-            os.umask(mask)
-        _default_file_mode_cache = 0o666 & ~mask
-    return _default_file_mode_cache
-
-
 def _temp_candidate(name: str) -> str:
     """A fresh temp *name* for `name`, to be created in the same directory.
 
@@ -900,7 +866,7 @@ def _atomic_write_at(
         with os.fdopen(fd, "wb", closefd=False) as stream:
             stream.write(payload)
             stream.flush()
-        os.fchmod(fd, _default_file_mode())
+        os.fchmod(fd, vault_fs.default_file_mode())
         os.fsync(fd)
 
         if expected is not None:

--- a/src/services/vault_fs.py
+++ b/src/services/vault_fs.py
@@ -233,11 +233,56 @@ def _open_dir_nofollow(parent_fd: int, part: str, rel_dir) -> int:
 # ── temp files and fingerprints ─────────────────────────────────────────────
 
 
+# Mode a plain `open(..., "w")` produces, cached for the life of the process.
+_default_file_mode_cache: int | None = None
+
+
+def default_file_mode() -> int:
+    """The mode a plain `open(..., "w")` would give a new file: 0o666 & ~umask.
+
+    Every staging descriptor in this package is created at 0o600 so the
+    content is never readable by anyone else while it is being written, and
+    publication is a `linkat`/`rename` of that same inode — so the staging
+    mode *is* the published mode unless a writer relaxes it first. Without
+    that step a file the server wrote silently drops from the umask default
+    (0o644 on the container) to 0o600 and becomes unreadable to anything else
+    sharing the vault: another container, a backup agent, a sync client (#95).
+
+    Both writers call this immediately before publishing — `vault`'s
+    `_atomic_write_at` for notes and raw file writes, `transfer`'s
+    `stream_to_vault` for uploads and imports. It lives here because `vault`
+    and `transfer` both depend on this module and neither depends on the
+    other; a second copy is how the two paths drifted apart in the first place.
+
+    Read from `/proc/self/status` where available; the `os.umask` read-restore
+    dance is the portable fallback and is only reached once.
+    """
+    global _default_file_mode_cache
+    if _default_file_mode_cache is None:
+        mask: int | None = None
+        try:
+            with open("/proc/self/status", encoding="ascii") as status:
+                for line in status:
+                    if line.startswith("Umask:"):
+                        mask = int(line.split()[1], 8)
+                        break
+        except OSError:
+            mask = None
+        if mask is None:
+            mask = os.umask(0o022)
+            os.umask(mask)
+        _default_file_mode_cache = 0o666 & ~mask
+    return _default_file_mode_cache
+
+
 def create_temp(dir_fd: int) -> tuple[int, str]:
     """Create an exclusive `.tmp-<32 hex>` file in `dir_fd`; return (fd, name).
 
     Mode 0600 and `O_EXCL|O_NOFOLLOW`: the name cannot pre-exist, cannot be a
     symlink, and the content is never world-readable while it is being written.
+    That 0600 is for the *staging* window only — publication links this inode
+    into place, so the caller must relax the mode with `default_file_mode()`
+    before publishing or the file lands unreadable to everything else (#95).
     The `.tmp-` prefix keeps it invisible to the indexer and to every dot-dir
     guarded tool, so a crashed upload leaves nothing an agent can see.
     """

--- a/src/services/vault_fs.py
+++ b/src/services/vault_fs.py
@@ -216,6 +216,48 @@ def _open_child(parent_fd: int, part: str, *, create: bool, rel_dir) -> int:
     return _open_dir_nofollow(parent_fd, part, rel_dir)
 
 
+# Owner-only: nothing but this process has any business in the staging
+# directory. See `open_staging_dir`.
+STAGING_DIR_MODE = 0o700
+
+
+def open_staging_dir(root_fd: int) -> int:
+    """Open `.transfer-tmp` beneath `root_fd`, enforcing owner-only access.
+
+    Staged bytes are relaxed to `default_file_mode()` before publication, so
+    the directory — not the file — is what keeps an in-flight upload private.
+    That matters because staging is the window in which the bytes exist but
+    the publish gate has not yet revalidated the credential: a body that is
+    about to be *refused* is on disk for the duration, and under a
+    group-writable umask a peer could also alter it after `_drain` computed
+    its digest, so the server would publish bytes that do not match the
+    sha256 it reports. 0700 removes both, whatever the staged file's own mode
+    and whatever the operator's umask.
+
+    The mode is enforced on every open, not just at creation: `mkdir` is
+    masked by the umask, and a `.transfer-tmp` left at 0755 by an older
+    release (or by a `mkdir -p` from anywhere else) must be corrected rather
+    than trusted. `fchmod` goes through the descriptor we just opened
+    `O_NOFOLLOW`, so it cannot be redirected to another directory by a
+    rename in between.
+
+    Destination directories are deliberately *not* treated this way — they
+    hold published vault content and get the ordinary 0755 from `_open_child`.
+    """
+    fd = open_dir_beneath(root_fd, STAGING_DIR, create=True)
+    try:
+        current = stat.S_IMODE(os.fstat(fd).st_mode)
+        if current != STAGING_DIR_MODE:
+            os.fchmod(fd, STAGING_DIR_MODE)
+            logger.info(
+                "Tightened %s from %o to %o", STAGING_DIR, current, STAGING_DIR_MODE
+            )
+    except OSError:
+        os.close(fd)
+        raise
+    return fd
+
+
 def _open_dir_nofollow(parent_fd: int, part: str, rel_dir) -> int:
     try:
         return os.open(part, _O_DIR, dir_fd=parent_fd)

--- a/src/services/vault_fs.py
+++ b/src/services/vault_fs.py
@@ -1107,7 +1107,10 @@ def prune_stale_staging(
             if _unlink_quietly(staging_fd, entry, published=False):
                 removed += 1
     finally:
-        os.close(staging_fd)
+        # Janitorial work must never fail the operation that triggered it, and
+        # a bare `os.close` can raise (EIO). `prune_stale_staging` is called
+        # from the publication probe, i.e. on the foreground upload path.
+        close_quietly(staging_fd, STAGING_DIR)
     if removed:
         logger.info("Pruned %d stale staged upload(s) from %s", removed, STAGING_DIR)
     return removed

--- a/src/services/vault_fs.py
+++ b/src/services/vault_fs.py
@@ -221,7 +221,7 @@ def _open_child(parent_fd: int, part: str, *, create: bool, rel_dir) -> int:
 STAGING_DIR_MODE = 0o700
 
 
-def open_staging_dir(root_fd: int) -> int:
+def open_staging_dir(root_fd: int, *, create: bool = True) -> int:
     """Open `.transfer-tmp` beneath `root_fd`, enforcing owner-only access.
 
     Staged bytes are relaxed to `default_file_mode()` before publication, so
@@ -244,16 +244,38 @@ def open_staging_dir(root_fd: int) -> int:
     Destination directories are deliberately *not* treated this way — they
     hold published vault content and get the ordinary 0755 from `_open_child`.
     """
-    fd = open_dir_beneath(root_fd, STAGING_DIR, create=True)
+    fd = open_dir_beneath(root_fd, STAGING_DIR, create=create)
     try:
-        current = stat.S_IMODE(os.fstat(fd).st_mode)
-        if current != STAGING_DIR_MODE:
+        st = os.fstat(fd)
+        if st.st_uid != os.geteuid():
+            raise UnsafePath(
+                f"{STAGING_DIR} is owned by uid {st.st_uid}, not by this "
+                f"process (uid {os.geteuid()}); refusing to stage uploads in it"
+            )
+        if stat.S_IMODE(st.st_mode) != STAGING_DIR_MODE:
             os.fchmod(fd, STAGING_DIR_MODE)
             logger.info(
-                "Tightened %s from %o to %o", STAGING_DIR, current, STAGING_DIR_MODE
+                "Tightened %s from %o to %o",
+                STAGING_DIR,
+                stat.S_IMODE(st.st_mode),
+                STAGING_DIR_MODE,
             )
-    except OSError:
-        os.close(fd)
+            # Verify rather than trust. A filesystem that accepts `fchmod` and
+            # does not apply it (or applies it partially) would otherwise leave
+            # the isolation guarantee false while every call reported success —
+            # and that guarantee is the only thing protecting a staged upload,
+            # because the staged file itself is relaxed to the umask default
+            # before the publish gate. Same posture as the publication and
+            # trash probes: refuse the operation rather than degrade silently.
+            effective = stat.S_IMODE(os.fstat(fd).st_mode)
+            if effective != STAGING_DIR_MODE:
+                raise UnsupportedFilesystem(
+                    f"Could not restrict {STAGING_DIR} to {STAGING_DIR_MODE:o}; "
+                    f"it is {effective:o} after chmod. Uploads need a staging "
+                    f"directory no other user can read."
+                )
+    except BaseException:
+        close_quietly(fd, STAGING_DIR)
         raise
     return fd
 
@@ -1059,7 +1081,10 @@ def prune_stale_staging(
     able to fail an operation.
     """
     try:
-        staging_fd = open_dir_beneath(root_fd, STAGING_DIR, create=False)
+        # Tighten before listing, never `open_dir_beneath` directly: this is
+        # the one other opener of the directory, and on a deployment upgrading
+        # from a release that left it 0755 the prune runs first (#95).
+        staging_fd = open_staging_dir(root_fd, create=False)
     except (FileNotFoundError, VaultFSError, OSError):
         return 0
     removed = 0

--- a/tests/test_transfer_service.py
+++ b/tests/test_transfer_service.py
@@ -167,6 +167,87 @@ async def test_uploaded_file_keeps_the_umask_default_mode(vault):
     assert published == vault_fs.default_file_mode()
 
 
+async def test_the_staging_directory_is_owner_only(vault):
+    """Staged bytes are relaxed before publication, so the directory is the
+    thing keeping an in-flight upload private (#95)."""
+    row = FakeRow(str(vault), "Attachments/shot.png")
+    await stream_to_vault(
+        row, chunks_of(PNG), max_bytes=1_000_000, content_length=len(PNG),
+        deadline=deadline_in(30),
+    )
+    staging = vault / vault_fs.STAGING_DIR
+    assert staging.stat().st_mode & 0o777 == 0o700
+
+
+async def test_a_pre_existing_permissive_staging_directory_is_tightened(vault):
+    """An older release left `.transfer-tmp` at 0755; opening it must fix that
+    rather than trust it."""
+    staging = vault / vault_fs.STAGING_DIR
+    staging.mkdir(mode=0o755)
+    os.chmod(staging, 0o755)  # defeat the umask, so 0755 is really on disk
+    assert staging.stat().st_mode & 0o777 == 0o755
+
+    row = FakeRow(str(vault), "Attachments/shot.png")
+    await stream_to_vault(
+        row, chunks_of(PNG), max_bytes=1_000_000, content_length=len(PNG),
+        deadline=deadline_in(30),
+    )
+    assert staging.stat().st_mode & 0o777 == 0o700
+
+
+async def test_published_mode_follows_the_umask_rather_than_a_hardcoded_644(
+    vault, monkeypatch
+):
+    """The mode must be derived from the umask, not pinned to 0644 — which a
+    fix that hardcoded the common case would also have passed."""
+    monkeypatch.setattr(vault_fs, "_default_file_mode_cache", None)
+    previous = os.umask(0o077)
+    try:
+        row = FakeRow(str(vault), "Attachments/private.png")
+        await stream_to_vault(
+            row, chunks_of(PNG), max_bytes=1_000_000, content_length=len(PNG),
+            deadline=deadline_in(30),
+        )
+        assert (vault / "Attachments" / "private.png").stat().st_mode & 0o777 == 0o600
+    finally:
+        os.umask(previous)
+        vault_fs._default_file_mode_cache = None
+
+
+async def test_overwrite_resets_the_incumbent_mode_to_server_policy(vault):
+    """Declared policy, not an accident: publication swaps in the staged inode,
+    so an overwrite lands the umask default even over a restrictive incumbent.
+
+    The note path (`vault._atomic_write_at`) has always behaved this way; the
+    two publish paths agreeing is the point of #95. Preserving incumbent bits
+    instead would be a product decision affecting both.
+    """
+    target = vault / "Attachments" / "secret.png"
+    target.write_bytes(b"old")
+    os.chmod(target, 0o600)
+    before = target.stat()
+
+    row = FakeRow(
+        str(vault),
+        "Attachments/secret.png",
+        overwrite=True,
+        expected_fingerprint={
+            "dev": before.st_dev,
+            "inode": before.st_ino,
+            "size": before.st_size,
+            "mtime_ns": before.st_mtime_ns,
+            "ctime_ns": before.st_ctime_ns,
+            "sha256": hashlib.sha256(b"old").hexdigest(),
+        },
+    )
+    await stream_to_vault(
+        row, chunks_of(PNG), max_bytes=1_000_000, content_length=len(PNG),
+        deadline=deadline_in(30),
+    )
+    assert target.read_bytes() == PNG
+    assert target.stat().st_mode & 0o777 == vault_fs.default_file_mode()
+
+
 async def test_stream_creates_missing_parent_directories(vault):
     row = FakeRow(str(vault), "New/Deep/file.bin")
     await stream_to_vault(

--- a/tests/test_transfer_service.py
+++ b/tests/test_transfer_service.py
@@ -556,6 +556,42 @@ async def test_a_staging_directory_that_cannot_be_tightened_refuses_the_upload(
     assert not (vault / "Attachments" / "a.bin").exists()
 
 
+@pytest.mark.parametrize("partial", [0o750, 0o710, 0o701])
+async def test_a_partially_applied_chmod_refuses_too(vault, monkeypatch, partial):
+    """The check is exact equality, not "narrower than it was".
+
+    A filesystem that clamps the mode to something still group- or
+    world-reachable must refuse; only a no-op chmod would be caught by a test
+    that just compares against the original 0755.
+    """
+    staging = vault / vault_fs.STAGING_DIR
+    staging.mkdir()
+    os.chmod(staging, 0o755)
+    real_fchmod = os.fchmod
+    monkeypatch.setattr(os, "fchmod", lambda fd, mode: real_fchmod(fd, partial))
+
+    row = FakeRow(str(vault), "Attachments/a.bin")
+    with pytest.raises(vault_fs.UnsupportedFilesystem):
+        await stream_to_vault(
+            row, chunks_of(b"payload"), max_bytes=100, deadline=deadline_in(30)
+        )
+    assert not (vault / "Attachments" / "a.bin").exists()
+
+
+async def test_ownership_is_compared_against_the_effective_uid(vault, monkeypatch):
+    """`geteuid`, not `getuid` — the test environment has them equal, so
+    nothing else here would notice the difference."""
+    (vault / vault_fs.STAGING_DIR).mkdir(mode=0o700)
+    monkeypatch.setattr(os, "geteuid", lambda: os.getuid() + 1)
+
+    row = FakeRow(str(vault), "Attachments/a.bin")
+    with pytest.raises(vault_fs.UnsafePath, match="owned by uid"):
+        await stream_to_vault(
+            row, chunks_of(b"payload"), max_bytes=100, deadline=deadline_in(30)
+        )
+    assert not (vault / "Attachments" / "a.bin").exists()
+
+
 async def test_a_foreign_owned_staging_directory_refuses_the_upload(
     vault, monkeypatch
 ):

--- a/tests/test_transfer_service.py
+++ b/tests/test_transfer_service.py
@@ -144,6 +144,29 @@ async def test_stream_writes_exact_bytes_hash_and_mime(vault):
     assert temps_under(vault) == []
 
 
+async def test_uploaded_file_keeps_the_umask_default_mode(vault):
+    """Staging at 0600 must not leak into the published upload's permissions.
+
+    Publication links the staging inode into place, so without the relax step
+    an upload lands 0600 while every note beside it is 0644 — unreadable to
+    anything sharing the vault under a different uid or group (#95).
+    """
+    row = FakeRow(str(vault), "Attachments/shot.png")
+    await stream_to_vault(
+        row,
+        chunks_of(PNG),
+        max_bytes=1_000_000,
+        content_length=len(PNG),
+        deadline=deadline_in(30),
+    )
+    reference = vault / "Attachments" / "reference.png"
+    reference.write_bytes(PNG)
+
+    published = (vault / "Attachments" / "shot.png").stat().st_mode & 0o777
+    assert published == reference.stat().st_mode & 0o777
+    assert published == vault_fs.default_file_mode()
+
+
 async def test_stream_creates_missing_parent_directories(vault):
     row = FakeRow(str(vault), "New/Deep/file.bin")
     await stream_to_vault(

--- a/tests/test_transfer_service.py
+++ b/tests/test_transfer_service.py
@@ -22,6 +22,7 @@ import http.server
 import os
 import socket
 import ssl
+import stat
 import subprocess
 import sys
 import threading
@@ -498,6 +499,87 @@ async def test_bytes_are_staged_outside_the_destination_folder(vault):
     assert seen == [[]], "the temp file was staged in the destination folder"
     assert (vault / vault_fs.STAGING_DIR).is_dir()
     assert list((vault / vault_fs.STAGING_DIR).iterdir()) == []
+
+
+async def test_the_staging_directory_is_private_while_the_gate_holds(vault):
+    """Ordering, not just the end state.
+
+    The staged file is relaxed to the umask default before the gate opens, and
+    the gate can wait unboundedly on `SELECT ... FOR UPDATE`. So the directory
+    must already be 0700 *at that moment* — a tightening that only happened
+    during cleanup would leave exactly the exposure #95 exists to remove, while
+    still passing an end-state assertion.
+    """
+    seen: dict = {}
+
+    class PeekingGate(RecordingGate):
+        async def __aenter__(self):
+            staging = vault / vault_fs.STAGING_DIR
+            seen["dir_mode"] = staging.stat().st_mode & 0o777
+            seen["file_modes"] = sorted(
+                p.stat().st_mode & 0o777 for p in staging.iterdir()
+            )
+            return await super().__aenter__()
+
+    row = FakeRow(str(vault), "Attachments/a.bin")
+    await stream_to_vault(
+        row,
+        chunks_of(b"payload"),
+        max_bytes=100,
+        deadline=deadline_in(30),
+        before_publish=PeekingGate(allow=True),
+    )
+    assert seen["dir_mode"] == 0o700, "staged bytes were exposed while the gate held"
+    # Documents the ordering the 0700 exists to compensate for: by gate time the
+    # staged inode is already at the published mode.
+    assert seen["file_modes"] == [vault_fs.default_file_mode()]
+
+
+async def test_a_staging_directory_that_cannot_be_tightened_refuses_the_upload(
+    vault, monkeypatch
+):
+    """Fail closed when the isolation guarantee cannot be established.
+
+    A filesystem that accepts `fchmod` without applying it would otherwise
+    leave every call reporting success while the directory stayed readable.
+    """
+    staging = vault / vault_fs.STAGING_DIR
+    staging.mkdir()
+    os.chmod(staging, 0o755)
+    monkeypatch.setattr(os, "fchmod", lambda *args, **kwargs: None)
+
+    row = FakeRow(str(vault), "Attachments/a.bin")
+    with pytest.raises(vault_fs.UnsupportedFilesystem, match="0700|700"):
+        await stream_to_vault(
+            row, chunks_of(b"payload"), max_bytes=100, deadline=deadline_in(30)
+        )
+    assert not (vault / "Attachments" / "a.bin").exists()
+
+
+async def test_a_foreign_owned_staging_directory_refuses_the_upload(
+    vault, monkeypatch
+):
+    """0700 means nothing if somebody else owns the directory."""
+    staging = vault / vault_fs.STAGING_DIR
+    staging.mkdir(mode=0o700)
+    real_fstat = os.fstat
+
+    def foreign(fd):
+        st = real_fstat(fd)
+        if stat.S_ISDIR(st.st_mode):
+            return os.stat_result(
+                (st.st_mode, st.st_ino, st.st_dev, st.st_nlink, st.st_uid + 1)
+                + tuple(st)[5:]
+            )
+        return st
+
+    monkeypatch.setattr(os, "fstat", foreign)
+    row = FakeRow(str(vault), "Attachments/a.bin")
+    with pytest.raises(vault_fs.UnsafePath, match="owned by uid"):
+        await stream_to_vault(
+            row, chunks_of(b"payload"), max_bytes=100, deadline=deadline_in(30)
+        )
+    assert not (vault / "Attachments" / "a.bin").exists()
 
 
 async def test_a_commit_failure_after_publication_is_its_own_error(vault):

--- a/tests/test_transfer_tools.py
+++ b/tests/test_transfer_tools.py
@@ -657,6 +657,23 @@ async def test_import_publishes_through_the_locked_identity_gate(
     assert call["need_write"] is True
 
 
+async def test_import_reports_an_unusable_staging_directory_instead_of_raising(
+    vault, readwrite, canned_fetch, publish_gate, monkeypatch
+):
+    """`UnsupportedFilesystem` is not an `OSError`, so the tool's catch-all did
+    not cover it and the refusal escaped as a raw MCP tool exception (#95)."""
+    staging = vault / vault_fs.STAGING_DIR
+    staging.mkdir()
+    os.chmod(staging, 0o755)
+    monkeypatch.setattr(os, "fchmod", lambda *args, **kwargs: None)
+
+    result = await tools.import_from_url_impl(
+        "https://example.com/a.png", "Attachments/a.png"
+    )
+    assert "Nothing was written." in result
+    assert not (vault / "Attachments" / "a.png").exists()
+
+
 async def test_import_publishes_nothing_when_the_gate_refuses(
     vault, readwrite, canned_fetch, publish_gate
 ):

--- a/tests/test_vault_mutation_safety.py
+++ b/tests/test_vault_mutation_safety.py
@@ -386,4 +386,4 @@ def test_written_note_keeps_the_umask_default_mode(offline):
 
     published = (offline / "mode.md").stat().st_mode & 0o777
     assert published == reference.stat().st_mode & 0o777
-    assert published == vault_service._default_file_mode()
+    assert published == vault_fs.default_file_mode()


### PR DESCRIPTION
Closes #95.

## The bug

`vault_fs.create_temp` opens the staging file at `0600` — correctly, so the bytes are never readable by anyone else while they are being written. But publication is a `linkat`/`os.replace` of *that same inode*, so the staging mode is the published mode. Files arriving through `request_upload` / `PUT /transfer/upload` and `import_from_url` therefore landed `0600`, while every note beside them is `0644`.

Observed on a live upload:

```
-rw-------  1 appuser appuser  3128646  Attachments/chatgpt-upload-test.png   <- uploaded
-rwxrw-rw-  1 appuser appuser  2343992  Attachments/20230304_111852.jpg       <- pre-existing
```

The note path already had the fix and documents exactly this consequence — `vault._atomic_write_at` relaxes the staged descriptor with `os.fchmod` before publishing. The transfer path never got it.

## The change

- `transfer.stream_to_vault` relaxes the staged descriptor immediately after the drain, before the descriptor closes and long before publication.
- `_default_file_mode` moves from `vault` to `vault_fs` as the public `default_file_mode()`. Both writers already depend on `vault_fs` and neither depends on the other, so this is the layer that holds it — and one definition is what stops the two publish paths drifting apart again, which is how this happened.
- `create_temp`'s docstring now says its `0600` covers the staging window only and the caller must relax it before publishing.

## Scope

Deliberately not bundled: **the transfer path never `fsync`s the staged bytes.** `_atomic_write_at` does, with a comment explaining that a crash just after the rename can otherwise publish a file whose data blocks never landed — the transfer path has the same exposure. Filed separately rather than folded in here.

## Verification

- `tests/test_transfer_service.py::test_uploaded_file_keeps_the_umask_default_mode` is the new gate. Confirmed it **fails** (`0600` vs `0644`) with the `fchmod` removed, so it is a real gate and not a tautology.
- The existing note-path gate is rewired to the moved helper.
- Full suite: 1352 passed, 108 skipped.
- Postgres transfer gate against a throwaway `pgvector/pgvector:pg16`: 68 passed.
- Adversarial Codex pass on the write path: running; results posted here.

No migration, no config, no API surface change.