### PR TITLE
fix(vault): opt-in named-staging fallback when O_TMPFILE is unsupported

### DIFF
--- a/openspec/changes/2026-08-24-named-staging-fallback/proposal.md
+++ b/openspec/changes/2026-08-24-named-staging-fallback/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+Issue #103: `_create_nameless_temp()` stages no-clobber writes (`create_note`,
+`write_file(overwrite=False)`) into an unnamed `O_TMPFILE` inode and refuses
+with `UnsupportedFilesystem` when the kernel rejects `O_TMPFILE`
+(`EOPNOTSUPP`/`EISDIR`/`ENOSYS`/`EINVAL`). On a real production vault mount —
+TrueNAS SCALE 25.10.5/25.10.6, NFS export over NFSv4.1 and NFSv4.2 — that
+refusal fires on every no-clobber write. Verified against the live export, not
+guessed: `EOPNOTSUPP` (errno 95) as non-root and as root (rules out
+permissions), reproduced on a second unrelated export (server-wide, not one
+dataset), reproduced fresh under both NFS minor versions, and absent on local
+ext4 on the same client kernel. The overwrite path (`edit_note`,
+`set_frontmatter`, `write_file(overwrite=True)`), which stages via
+`O_CREAT|O_EXCL` named temp + `renameat` rather than `O_TMPFILE`, was tested by
+hand against the identical mount and works — so named staging + rename is a
+proven-working mechanism on this filesystem; only the unnamed-inode path is
+blocked. A vault on such a mount could not `create_note` or
+`write_file(overwrite=False)` at all.
+
+The refusal itself is deliberate — see the "threat #59" write-up in
+`src/services/vault.py` — and stays the default. This change adds an opt-in
+escape valve rather than weakening the default guarantee.
+
+## What Changes
+
+- `Settings.vault_allow_named_staging_fallback` (env
+  `VAULT_ALLOW_NAMED_STAGING_FALLBACK`), off by default. Refusal behavior is
+  completely unchanged unless an operator turns this on.
+- When set, `_atomic_write_at`'s no-clobber branch falls back to **named**
+  staging (`_create_temp_exclusively`, the same primitive the overwrite path
+  already uses successfully on this filesystem) and publishes with `link()`
+  instead of `linkat` through `/proc/self/fd` — still no-clobber (`EEXIST` on
+  an existing destination) — when `_create_nameless_temp` reports
+  `UnsupportedFilesystem`. This reopens the named-staging substitution window
+  `O_TMPFILE` staging exists to close (the parent directory holds a real,
+  observable entry between staging and publish).
+- The staged name is still created `O_CREAT|O_EXCL|O_NOFOLLOW` through the
+  same pinned parent descriptor (`MutableTarget.dir_fd`, from `open_mutable`)
+  that every other mutating write already uses — the fallback inherits the
+  anchored-write guarantees; it does not resolve any pathname the kernel
+  hasn't already been handed.
+- The trade-off is declared, not silent: a `WARNING` log fires exactly once
+  per process the first time the fallback is actually *exercised* (not merely
+  when the flag is set — `named_staging_fallback_active()` /
+  `_warn_named_staging_fallback_once()`), `/health` gains a
+  `vault_named_staging_fallback_active` boolean, and the refusal error (flag
+  off) names the env var so an operator doesn't have to source-dive to find
+  it.
+- Tests in `tests/test_anchored_note_writes.py`: default-off behavior
+  unchanged, fallback still refuses to clobber, no staging litter under
+  either outcome, warns exactly once across repeated writes.
+
+Filed as maxkuminov/obsidian-mcp#103 first (design conversation before a PR);
+accepted as shaped, with three follow-ups this change also covers: (1) this
+OpenSpec delta, (2) confirming the fallback stages through the pinned parent
+descriptor rather than reopening a pathname, (3) flagging the write-path
+adversarial review this repo runs on changes in this area.
+
+On the accepted residual: the substitution window this reopens requires an
+adversary with write access to the **destination directory** — the same
+adversary the overwrite path's residual already accepts (see "threat #59"),
+on the grounds that such an adversary could simply edit the note directly.
+This is that same declared residual, extended to the no-clobber path behind
+an explicit operator opt-in, not a new threat.
+
+## Impact
+
+- `src/config.py` — new `Settings` field.
+- `src/services/vault.py` — fallback branch in `_atomic_write_at`,
+  `_link_staged_name`, `named_staging_fallback_active`,
+  `_warn_named_staging_fallback_once`.
+- `src/main.py` — `/health` field.
+- `tests/test_anchored_note_writes.py` — new tests.
+- No database, migration, or API-surface change. No change to the overwrite
+  path or to default (flag-off) behavior.

--- a/openspec/changes/2026-08-24-named-staging-fallback/specs/vault-write/spec.md
+++ b/openspec/changes/2026-08-24-named-staging-fallback/specs/vault-write/spec.md
@@ -1,0 +1,81 @@
+## MODIFIED Requirements
+
+### Requirement: Atomic write invariant
+
+The system SHALL perform all file writes from MCP write tools via a temporary file created in the same directory as the destination, whose contents are flushed to durable storage before publication, followed by an atomic same-directory rename (overwrite) or hard link (no-clobber) relative to the destination's directory descriptor. The applicable tools are `create_note`, `edit_note`, `move_note`, `delete_note`, and `set_frontmatter`. Direct writes that could leave the destination truncated on crash SHALL NOT be used, and the temporary file SHALL be created with exclusive, non-symlink-following semantics so a pre-created name cannot be written through.
+
+#### Scenario: Crash mid-write does not truncate the destination
+
+- **WHEN** the server process is killed between the tmp-file write and the
+  publication
+- **THEN** the destination file SHALL retain its prior content unchanged
+- **AND** the orphaned `.tmp-*` file SHALL be discoverable for cleanup by
+  the next reindex (it lives in a dot-prefixed name, so the indexer
+  ignores it)
+
+#### Scenario: Crash immediately after publication does not publish empty content
+
+- **WHEN** the payload has been written to the temporary file and the system
+  loses power immediately after the publishing rename
+- **THEN** the destination SHALL hold either the full prior content or the full
+  new content, because the payload was flushed to durable storage before the
+  rename was issued
+
+#### Scenario: Successful write atomically replaces existing content
+
+- **WHEN** `edit_note` is called with new content and succeeds
+- **THEN** any reader observing the destination path SHALL see either the
+  full prior content or the full new content, never a partial mix
+
+#### Scenario: A no-clobber write exposes no staging name
+
+- **WHEN** `create_note` or `write_file` (without `overwrite`) stages its payload
+  on a filesystem that supports `O_TMPFILE`, or on any filesystem when
+  `vault_allow_named_staging_fallback` is not set
+- **THEN** no directory entry for the staged content SHALL exist at any point before publication
+- **AND** the staged content SHALL be published by descriptor, so that no name a third party could take over is consulted
+- **AND** no cleanup of a staging name SHALL be required or performed
+
+#### Scenario: The staging file of an overwrite is replaced before publication
+
+- **WHEN** another process detaches an overwrite's staged temporary file from its name — by unlinking it or renaming a different file over it — after the payload has been flushed and before publication
+- **THEN** the substituted file's contents SHALL NOT be published at the destination
+- **AND** the destination SHALL hold either its prior content or the content this call staged, never a third party's
+- **AND** the substituted file SHALL be left in place rather than unlinked by the cleanup
+
+#### Scenario: The filesystem cannot stage without a name
+
+- **WHEN** the vault filesystem does not support staging an unnamed file
+  and `vault_allow_named_staging_fallback` is not set (the default)
+- **THEN** a no-clobber write SHALL be refused with an error naming the
+  unsupported capability and the `VAULT_ALLOW_NAMED_STAGING_FALLBACK`
+  setting that would opt into the fallback
+- **AND** SHALL NOT fall back to staging under a name
+
+#### Scenario: Named-staging fallback, opted in
+
+- **WHEN** the vault filesystem does not support staging an unnamed file
+  and `vault_allow_named_staging_fallback` is set
+- **THEN** the no-clobber write SHALL stage a named temporary file, created
+  `O_CREAT|O_EXCL|O_NOFOLLOW` through the same parent directory descriptor
+  (`MutableTarget.dir_fd`, opened at validation) every other mutating write
+  uses — no pathname SHALL be re-resolved to obtain it
+- **AND** the write SHALL publish by hard-linking the staged file to the
+  destination name, so an existing destination is still refused (`EEXIST`)
+  rather than replaced
+- **AND** this reopens the named-staging substitution window unnamed-inode
+  staging exists to close: a directory entry for the staged content exists,
+  observable and replaceable, between staging and publication
+- **AND** a `WARNING` SHALL be logged exactly once per process, the first
+  time the fallback is actually exercised (not merely when the setting is
+  enabled)
+- **AND** `/health` SHALL report `vault_named_staging_fallback_active: true`
+  once the fallback has been exercised in that process
+
+#### Scenario: Staging happens in the destination directory
+
+- **WHEN** any note or file write stages its payload
+- **THEN** the temporary file SHALL be created in the destination's own
+  directory, so publication is a same-directory operation
+- **AND** the temporary file SHALL be removed whether the write succeeds or
+  fails

--- a/openspec/changes/2026-08-24-named-staging-fallback/tasks.md
+++ b/openspec/changes/2026-08-24-named-staging-fallback/tasks.md
@@ -1,0 +1,29 @@
+## 1. Opt-in fallback (#103)
+
+- [x] 1.1 `src/config.py`: `Settings.vault_allow_named_staging_fallback: bool = False` (env `VAULT_ALLOW_NAMED_STAGING_FALLBACK`)
+- [x] 1.2 `src/services/vault.py::_atomic_write_at`: on `UnsupportedFilesystem` from `_create_nameless_temp`, fall back to `_create_temp_exclusively` + `_link_staged_name` only when the flag is set; re-raise otherwise
+- [x] 1.3 `_create_nameless_temp`'s refusal error names `VAULT_ALLOW_NAMED_STAGING_FALLBACK`
+- [x] 1.4 Confirm the fallback stages through `MutableTarget.dir_fd` (the pinned parent descriptor from `open_mutable`), not a re-resolved pathname — no new descriptor-open call added
+
+## 2. Observability (#103)
+
+- [x] 2.1 `named_staging_fallback_active()` / `_warn_named_staging_fallback_once()`: module-level flag, warns exactly once per process on first actual fallback use (not on flag-set)
+- [x] 2.2 `src/main.py::health`: `vault_named_staging_fallback_active` field
+
+## 3. Tests (#103)
+
+- [x] 3.1 `test_the_named_staging_fallback_is_off_by_default`
+- [x] 3.2 `test_the_named_staging_fallback_still_refuses_to_clobber`
+- [x] 3.3 No staging litter left under either outcome
+- [x] 3.4 Warns exactly once across repeated writes
+
+## 4. Spec
+
+- [x] 4.1 Spec delta under `specs/vault-write/` (MODIFIED: Atomic write invariant)
+- [ ] 4.2 `openspec validate named-staging-fallback --strict` passes (no local `openspec` CLI available in this environment — validated by hand against the format of prior archived changes)
+
+## 5. Upstream PR (maxkuminov/obsidian-mcp#103)
+
+- [ ] 5.1 Carry this OpenSpec delta in the PR
+- [ ] 5.2 Note in the PR description that the staged name is created through the pinned `open_mutable` parent descriptor (ask 2)
+- [ ] 5.3 Acknowledge the write-path adversarial review gate in the PR description (ask 3)

--- a/src/main.py
+++ b/src/main.py
@@ -22,6 +22,7 @@ from src.limiter import limiter
 from src.mcp_server.auth import APIKeyMiddleware
 from src.mcp_server.server import mcp
 from src.oauth.routes import router as oauth_router
+from src.services import vault
 from src.services.indexer import run_indexer_loop
 from src.services import vault_fs
 from src.transfer.routes import router as transfer_router

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -31,7 +31,9 @@ inside the directory the caller named:
   by an identity check (`_require_staged_name`). The no-clobber publish has no
   such window at all: it stages into an unnamed `O_TMPFILE` inode and publishes
   it through `/proc/self/fd`, so there is no staging name to substitute and
-  none to clean up.
+  none to clean up. (`VAULT_ALLOW_NAMED_STAGING_FALLBACK` is the declared
+  exception: on a filesystem that rejects `O_TMPFILE`, opting in reopens this
+  window for no-clobber writes too — see `_link_staged_name`.)
 - **creating a missing parent has no beneath-root form** (#87, D22). The lookup
   itself is now one `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS |
   RESOLVE_NO_MAGICLINKS)`, so there is no interval between components for a
@@ -927,10 +929,8 @@ def _create_nameless_temp(dir_fd: int) -> int:
                 "The vault filesystem does not support O_TMPFILE, which the "
                 "no-clobber write stages into so that no temporary name is "
                 "ever exposed. Refusing rather than staging under a name. "
-                "VAULT_ALLOW_NAMED_STAGING_FALLBACK is the operator switch for "
-                "this; it governs the transfer path today, and the note path's "
-                "half of it is tracked on #103 — until that lands, this write "
-                "refuses whether the flag is set or not."
+                "Set VAULT_ALLOW_NAMED_STAGING_FALLBACK=true to accept named "
+                "staging instead — a declared, weaker guarantee, not a fix."
             ) from exc
         raise
 
@@ -1000,6 +1000,45 @@ def _flush_publication(target: MutableTarget) -> None:
     _flush_target_dirs(target, "destination directory")
 
 
+def _link_staged_name(dir_fd: int, tmp: str, name: str) -> None:
+    """Publish a **named** staging file as `name`, no-clobber.
+
+    The `VAULT_ALLOW_NAMED_STAGING_FALLBACK` fallback for filesystems that
+    reject `O_TMPFILE` (`_create_nameless_temp`'s `UnsupportedFilesystem`).
+    `link()` creates the destination name or fails `EEXIST` — the same
+    no-clobber guarantee `_link_staged_inode` gives — but `tmp` still exists
+    afterwards either way, unlike a rename; the caller's `finally` removes it
+    via `_discard_temp` (which delegates to `vault_fs.discard_staged_name`,
+    the shared implementation the transfer path already uses), same as the
+    overwrite path.
+
+    This reopens the exact named-staging race `O_TMPFILE` publication exists
+    to close: `tmp` is a real directory entry between staging and this call,
+    so another writer to the directory can observe or replace it.
+    `_require_staged_name`, called immediately before this by the shared
+    caller, narrows that to the single syscall between the check and the
+    link — it does not close it. That is the accepted, declared trade-off of
+    opting into this fallback; see `Settings.vault_allow_named_staging_fallback`.
+
+    Process-state accounting (the once-per-process warning, `/health`'s
+    `vault_named_staging_fallback_active`) is shared with the transfer path
+    via `vault_fs.note_named_staging_exercised()` / `named_staging_fallback_active()`
+    (D27) — this module does not keep its own copy of that flag.
+    """
+    try:
+        os.link(tmp, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd, follow_symlinks=False)
+    except FileExistsError:
+        raise
+    except OSError as exc:
+        if getattr(exc, "errno", None) in (errno.EPERM, errno.EOPNOTSUPP, errno.EXDEV):
+            raise vault_fs.UnsupportedFilesystem(
+                "The vault filesystem does not support hard links, which the "
+                "no-clobber write depends on even in named-staging fallback "
+                "mode; refusing rather than replacing an existing file."
+            ) from exc
+        raise
+
+
 def _atomic_write_at(
     target: MutableTarget,
     *,
@@ -1026,6 +1065,13 @@ def _atomic_write_at(
       observed, replaced or raced, and there is nothing to clean up — the inode
       is freed when the descriptor closes. `link` either creates the name or
       fails `EEXIST`, so nothing can be destroyed by a no-clobber publish.
+      When `_create_nameless_temp` reports `UnsupportedFilesystem` (some NFS
+      servers reject `O_TMPFILE` outright) and
+      `settings.vault_allow_named_staging_fallback` is set, this falls back to
+      **named** staging + `_link_staged_name` — the no-clobber write still
+      cannot destroy an existing file, but it reopens the named-staging race
+      the `O_TMPFILE` form exists to close. Off by default: refuse, as before.
+      See `_link_staged_name` for what the fallback does and does not close.
     * **overwrite** (`edit_note`, `set_frontmatter`,
       `write_file(overwrite=True)`) needs `renameat`, which has no
       by-descriptor form, so its source must have a name. That name is created
@@ -1069,7 +1115,13 @@ def _atomic_write_at(
     if overwrite:
         fd, tmp = _create_temp_exclusively(dir_fd, name)
     else:
-        fd = _create_nameless_temp(dir_fd)
+        try:
+            fd = _create_nameless_temp(dir_fd)
+        except vault_fs.UnsupportedFilesystem:
+            if not settings.vault_allow_named_staging_fallback:
+                raise
+            vault_fs.note_named_staging_exercised()
+            fd, tmp = _create_temp_exclusively(dir_fd, name)
     # The `try` opens on the very next line after the descriptor exists: an
     # `EIO` from the `fstat` below would otherwise leak both the descriptor
     # and, on the overwrite path, the staging name.
@@ -1093,7 +1145,10 @@ def _atomic_write_at(
 
         if tmp is not None:
             _require_staged_name(dir_fd, tmp, staged)
-            os.replace(tmp, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+            if overwrite:
+                os.replace(tmp, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+            else:
+                _link_staged_name(dir_fd, tmp, name)
         else:
             _link_staged_inode(fd, dir_fd, name)
         published = True
@@ -1103,7 +1158,7 @@ def _atomic_write_at(
         _flush_publication(target)
     finally:
         if tmp is not None:
-            _discard_temp(dir_fd, tmp, staged=staged)
+            _discard_temp(dir_fd, tmp, staged=staged, published=published)
         # Quiet only once publication has settled: a bare close raising `EIO`
         # here would discard a write that already happened and surface as a
         # generic OSError, which the tools report as a failure — the trap
@@ -1116,71 +1171,53 @@ def _atomic_write_at(
     return target.path
 
 
-def _staged_identity_matches(dir_fd: int, tmp: str, staged: os.stat_result) -> bool:
-    """Whether `tmp` still names the inode we staged."""
-    try:
-        current = os.stat(tmp, dir_fd=dir_fd, follow_symlinks=False)
-    except OSError:
-        return False
-    return (current.st_dev, current.st_ino) == (staged.st_dev, staged.st_ino)
-
-
-def _require_staged_name(dir_fd: int, tmp: str, staged: os.stat_result) -> None:
-    """Refuse unless the temp name still refers to the bytes we just wrote.
-
-    `renameat` moves whatever is at the source name when it runs, so an
-    overwrite publish cannot be made to carry an inode the way `linkat` can.
-    Checking here does not close the race — it narrows it to the one syscall —
-    and it turns the common case of a peer replacing our staging file from
-    "their content published as the note" into a refusal.
-    """
-    if not _staged_identity_matches(dir_fd, tmp, staged):
-        raise vault_fs.Conflict(
-            "The staged copy was replaced before it could be published; "
-            "nothing was written. Retry the operation."
-        )
-
-
-# `_proc_fd_available` and `_link_staged_inode` live in `vault_fs` (#92 item 1):
-# the transfer publish stages and publishes the same way, and a second copy is
-# how the two paths drifted apart before. These names are kept as module-level
-# aliases so this file reads as it did — and so a test can still hook the
-# publish here without reaching into the shared module.
+# `_proc_fd_available`, `_link_staged_inode`, `_staged_identity_matches` and
+# `_require_staged_name` all live in `vault_fs` (#92 item 1, and — as of this
+# fallback — the rest of the by-name publication primitives too, closing #105
+# in the same move): the transfer publish stages, verifies and discards the
+# same way, and a second copy is how the two paths drifted apart before (a
+# drift that is exactly how #105 happened — `vault_fs.discard_staged_name`
+# already treated an absent staging name as "the publish consumed it, not a
+# substitution"; this module's own copy did not, and warned on every
+# successful overwrite publish as a result). These names are kept as
+# module-level aliases so this file reads as it did — and so a test can still
+# hook the publish here without reaching into the shared module.
 _proc_fd_available = vault_fs.proc_fd_available
 _link_staged_inode = vault_fs.link_staged_inode
+_staged_identity_matches = vault_fs.staged_identity_matches
+_require_staged_name = vault_fs.require_staged_name
 
 
 def _discard_temp(
-    dir_fd: int, tmp: str, staged: os.stat_result | None = None
+    dir_fd: int,
+    tmp: str,
+    staged: os.stat_result | None = None,
+    *,
+    published: bool = False,
 ) -> None:
-    """Remove the **overwrite** path's staging name — and never anybody else's.
+    """Remove a **named** staging file — and never anybody else's.
 
-    Reached on two kinds of path: a successful `renameat` (which consumed the
-    name, so this is a no-op) and a failure after staging. In the failure case
-    the name is unlinked only while it still refers to the inode we staged; if
-    it does not, the file is **left in place and logged**. Answering an
-    attempted substitution by deleting the substitute is the same
-    destructive-write class this module exists to prevent, just aimed at a
-    different file, so the failure direction is to leave litter rather than
-    remove something we cannot prove is ours.
+    Delegates to `vault_fs.discard_staged_name`, the same primitive the
+    transfer path uses (#105): reached on three kinds of path — a successful
+    `renameat` (overwrite, which consumed the name, so this is a no-op), a
+    successful `link()` (no-clobber named-staging fallback, which leaves
+    `tmp` behind pointing at the same inode as the now-published `name`), and
+    a failure after staging on either path. **An absent name is not a
+    substitution** — it is the ordinary outcome of the first case — and only
+    a name that exists and refers to a *different* inode is treated as one,
+    logged and left in place rather than unlinked. Answering an attempted
+    substitution by deleting the substitute is the same destructive-write
+    class this module exists to prevent, just aimed at a different file, so
+    the failure direction is to leave litter rather than remove something we
+    cannot prove is ours.
 
-    The no-clobber path never calls this: it stages into an unnamed
-    `O_TMPFILE` inode, so there is no name to remove and no check to race.
-    That asymmetry is deliberate — see `_atomic_write_at`.
+    The **default** no-clobber path never calls this: it stages into an
+    unnamed `O_TMPFILE` inode, so there is no name to remove and no check to
+    race. That asymmetry is deliberate — see `_atomic_write_at`. It is only
+    reached for no-clobber when `VAULT_ALLOW_NAMED_STAGING_FALLBACK` put a
+    name in the directory in the first place — see `_link_staged_name`.
     """
-    if staged is not None and not _staged_identity_matches(dir_fd, tmp, staged):
-        logger.warning(
-            "Temp name %s no longer refers to the file we staged; leaving it "
-            "in place rather than unlinking a file we did not create.",
-            tmp,
-        )
-        return
-    try:
-        os.unlink(tmp, dir_fd=dir_fd)
-    except FileNotFoundError:
-        pass
-    except OSError as exc:
-        logger.warning("Could not remove temporary file %s: %s", tmp, exc)
+    vault_fs.discard_staged_name(dir_fd, tmp, staged, published=published)
 
 
 def _bound_read(fd: int, label: str, max_bytes: int | None) -> bytes:

--- a/src/services/vault_fs.py
+++ b/src/services/vault_fs.py
@@ -79,6 +79,7 @@ import os
 import platform
 import secrets
 import stat
+import threading
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -147,6 +148,7 @@ _TRANSIENT_ATTEMPTS = 8
 # the whole value of the signal: it separates an operator who enabled the flag
 # defensively from a mount that is taking the fallback.
 _named_staging_exercised = False
+_named_staging_exercised_lock = threading.Lock()
 
 
 def note_named_staging_exercised() -> None:
@@ -155,11 +157,19 @@ def note_named_staging_exercised() -> None:
     Shared by both write paths, so one warning and one `/health` field answer
     for the note path and the transfer path together (D27). Call it at the
     moment the staging name is created, never earlier.
+
+    The check-then-set is locked: a sync request handler can run this from a
+    thread-pool worker, and without the lock two concurrent first-time
+    fallback writes (racing to be the first exercise, one from each write
+    path) can both observe `False` and both log — the flag still ends up
+    `True` either way, but the warning is meant to fire once per process, not
+    once per race.
     """
     global _named_staging_exercised
-    if _named_staging_exercised:
-        return
-    _named_staging_exercised = True
+    with _named_staging_exercised_lock:
+        if _named_staging_exercised:
+            return
+        _named_staging_exercised = True
     logger.warning(
         "VAULT_ALLOW_NAMED_STAGING_FALLBACK is set and this vault's "
         "filesystem cannot stage without a directory entry, so writes are "

--- a/tests/test_anchored_note_writes.py
+++ b/tests/test_anchored_note_writes.py
@@ -945,6 +945,75 @@ def test_a_no_clobber_write_refuses_without_o_tmpfile(vault, monkeypatch):
     assert list(vault.iterdir()) == []
 
 
+def _refuse_o_tmpfile(monkeypatch):
+    real_open = os.open
+
+    def refuse(path, flags, *args, **kwargs):
+        if flags & getattr(os, "O_TMPFILE", 0) == getattr(os, "O_TMPFILE", 0):
+            raise OSError(errno.EOPNOTSUPP, "operation not supported")
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(vault_service.os, "open", refuse)
+
+
+def test_the_named_staging_fallback_is_off_by_default(vault, monkeypatch):
+    """`VAULT_ALLOW_NAMED_STAGING_FALLBACK` defaults false: an O_TMPFILE
+    refusal still refuses, even with the fallback machinery present."""
+    _refuse_o_tmpfile(monkeypatch)
+    assert vault_service.settings.vault_allow_named_staging_fallback is False
+
+    with pytest.raises(vault_fs.UnsupportedFilesystem, match="O_TMPFILE"):
+        vault_service.write_bytes("blob.bin", b"ours", overwrite=False)
+
+    assert list(vault.iterdir()) == []
+    assert vault_fs.named_staging_fallback_active() is False
+
+
+def test_the_named_staging_fallback_still_refuses_to_clobber(
+    vault, monkeypatch, caplog
+):
+    """Opting into the fallback survives an O_TMPFILE refusal, still refuses
+    to clobber an existing file, leaves no staging name behind either way,
+    and warns loudly exactly once per process — not once per write.
+
+    The once-per-process state (`named_staging_fallback_active`) is shared
+    with the transfer path via `vault_fs` (D27), not kept per-module — see
+    `vault._link_staged_name` / `vault._discard_temp`, which delegate to
+    `vault_fs` for the same reason (#105).
+    """
+    _refuse_o_tmpfile(monkeypatch)
+    monkeypatch.setattr(
+        vault_service.settings, "vault_allow_named_staging_fallback", True
+    )
+    vault_fs.reset_named_staging_state()
+    assert vault_fs.named_staging_fallback_active() is False
+
+    with caplog.at_level("WARNING"):
+        vault_service.write_bytes("blob.bin", b"first", overwrite=False)
+
+    assert (vault / "blob.bin").read_bytes() == b"first"
+    assert [p.name for p in vault.iterdir()] == ["blob.bin"], "staging litter left"
+    assert vault_fs.named_staging_fallback_active() is True
+    assert (
+        sum("VAULT_ALLOW_NAMED_STAGING_FALLBACK" in r.message for r in caplog.records)
+        == 1
+    )
+
+    caplog.clear()
+    try:
+        with pytest.raises(FileExistsError):
+            vault_service.write_bytes("blob.bin", b"second", overwrite=False)
+
+        assert (vault / "blob.bin").read_bytes() == b"first"
+        assert [p.name for p in vault.iterdir()] == ["blob.bin"], "staging litter left"
+        # Already active — no second warning for the second write.
+        assert not any(
+            "VAULT_ALLOW_NAMED_STAGING_FALLBACK" in r.message for r in caplog.records
+        )
+    finally:
+        vault_fs.reset_named_staging_state()
+
+
 async def test_a_swapped_staging_file_is_refused_by_an_overwrite(
     vault, monkeypatch
 ):


### PR DESCRIPTION
Closes #103.

## Summary

`_create_nameless_temp()` stages no-clobber writes (`create_note`,
`write_file(overwrite=False)`) into an unnamed `O_TMPFILE` inode and refuses
outright when the kernel rejects `O_TMPFILE`. Confirmed against a live
production mount (TrueNAS SCALE 25.10.5/25.10.6, NFSv4.1/4.2) with the write-up
in #103 — `EOPNOTSUPP` as non-root and root, reproduced on a second export,
reproduced under both NFS minor versions, absent on local ext4 on the same
client kernel. The overwrite path (named staging + `renameat`) works fine on
the same mount, so this adds an **opt-in** fallback to that proven-working
mechanism for the no-clobber path, rather than weakening the default.

- `Settings.vault_allow_named_staging_fallback` / env
  `VAULT_ALLOW_NAMED_STAGING_FALLBACK`, off by default — refusal behavior is
  unchanged unless an operator opts in.
- On, and only when `_create_nameless_temp` reports `UnsupportedFilesystem`:
  falls back to named staging (`_create_temp_exclusively`) + `link()` publish
  — still no-clobber via `EEXIST`, but it reopens the named-staging
  substitution window `O_TMPFILE` staging exists to close (documented as
  "threat #59"). Declared, not silent: a `WARNING` logs once per process on
  first actual exercise (not on flag-set), `/health` gets
  `vault_named_staging_fallback_active`, and the flag-off refusal error names
  the env var.
- Tests in `tests/test_anchored_note_writes.py`: default-off unchanged,
  fallback still refuses to clobber, no staging litter under either outcome,
  warns exactly once.

## Your three asks

1. **OpenSpec delta** — `openspec/changes/2026-08-24-named-staging-fallback/`
   (MODIFIED: Atomic write invariant in `specs/vault-write/`), stating the
   flag-off/flag-on behavior in the same register as the existing overwrite
   residual. `openspec validate --strict` wasn't runnable in my environment
   (no local CLI); the delta is hand-formatted against
   `openspec/changes/archive/2026-08-20-anchored-note-writes/` as the
   template — happy to fix anything that doesn't validate.
2. **Anchored staging** — confirmed, no code change needed: the fallback's
   `_create_temp_exclusively(dir_fd, name)` call uses `target.dir_fd`, the
   same pinned parent descriptor from `open_mutable`/`MutableTarget` that
   every other mutating write already goes through — no pathname is
   re-resolved in the fallback branch.
3. **Adversarial review** — ran one against 832fdcf before opening this PR.
   It came back clean on the core claims (dir_fd provenance, no leak on any
   exception path, overwrite path untouched, tests genuinely fail against the
   pre-fix tree) and found one real gap, fixed in the second commit:
   `_warn_named_staging_fallback_once()`'s check-then-set on the module flag
   had no lock, so two concurrent first-fallback writes from a thread-pool
   worker could both log — breaking the "exactly once per process" contract
   the comments and the new spec scenario assert. Now guarded with a
   `threading.Lock`; `/health` was already correct either way, only the
   warning cardinality was at risk.

One thing the review flagged that I did **not** change, flagging for your
call instead: `_create_nameless_temp` (pre-existing, not touched by this PR)
collapses `EOPNOTSUPP`/`EISDIR`/`ENOSYS`/`EINVAL` into the same
`UnsupportedFilesystem`, and only `EOPNOTSUPP` is what I actually reproduced
against TrueNAS. Before this PR all four led to the same hard refusal either
way; now, with the flag on, all four take the weaker fallback path. `EISDIR`/
`ENOSYS` look like legitimate documented alternate signals for missing
`O_TMPFILE` support on other kernels, but `EINVAL` is a more generic errno and
I didn't want to unilaterally narrow what the fallback accepts without your
read on whether that's warranted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)