### PR TITLE
Merge #104: opt-in named-staging fallback, gate-hardened (#103)

### DIFF
--- a/openspec/changes/2026-08-24-named-staging-fallback/proposal.md
+++ b/openspec/changes/2026-08-24-named-staging-fallback/proposal.md
@@ -50,6 +50,25 @@ escape valve rather than weakening the default guarantee.
   unchanged, fallback still refuses to clobber, no staging litter under
   either outcome, warns exactly once across repeated writes.
 
+Hardening applied at this repo's pre-merge adversarial gate (#104 review),
+all of it in the shared cleanup primitive both write paths already use, so the
+transfer path gets the same treatment:
+
+- the cleanup **never unlinks a staging name it cannot prove is its own**. An
+  `fstat` that failed after the exclusive creation leaves no identity to
+  compare against, and unlinking on that basis let a no-clobber write that
+  published nothing destroy a file that had taken the name over. It now warns
+  and leaves the litter, the same direction an identified substitute already
+  got.
+- an **absent** staging name is quiet only when the write published (a
+  `renameat` consumed it); a name that vanished mid-flight is warned about and
+  reported as a failed discard.
+- the once-per-process signal is spent **after** the staging name exists, so a
+  creation that failed every attempt neither warns nor flips `/health`.
+- the one warning no longer attributes `.transfer-tmp` to the note path: it
+  takes the exercising path kind and names where each path stages, the note
+  path's window being the wider of the two.
+
 Filed as maxkuminov/obsidian-mcp#103 first (design conversation before a PR);
 accepted as shaped, with three follow-ups this change also covers: (1) this
 OpenSpec delta, (2) confirming the fallback stages through the pinned parent

--- a/openspec/changes/2026-08-24-named-staging-fallback/proposal.md
+++ b/openspec/changes/2026-08-24-named-staging-fallback/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+Issue #103: `_create_nameless_temp()` stages no-clobber writes (`create_note`,
+`write_file(overwrite=False)`) into an unnamed `O_TMPFILE` inode and refuses
+with `UnsupportedFilesystem` when the kernel rejects `O_TMPFILE`
+(`EOPNOTSUPP`/`EISDIR`/`ENOSYS`/`EINVAL`). On a real production vault mount —
+TrueNAS SCALE 25.10.5/25.10.6, NFS export over NFSv4.1 and NFSv4.2 — that
+refusal fires on every no-clobber write. Verified against the live export, not
+guessed: `EOPNOTSUPP` (errno 95) as non-root and as root (rules out
+permissions), reproduced on a second unrelated export (server-wide, not one
+dataset), reproduced fresh under both NFS minor versions, and absent on local
+ext4 on the same client kernel. The overwrite path (`edit_note`,
+`set_frontmatter`, `write_file(overwrite=True)`), which stages via
+`O_CREAT|O_EXCL` named temp + `renameat` rather than `O_TMPFILE`, was tested by
+hand against the identical mount and works — so named staging + rename is a
+proven-working mechanism on this filesystem; only the unnamed-inode path is
+blocked. A vault on such a mount could not `create_note` or
+`write_file(overwrite=False)` at all.
+
+The refusal itself is deliberate — see the "threat #59" write-up in
+`src/services/vault.py` — and stays the default. This change adds an opt-in
+escape valve rather than weakening the default guarantee.
+
+## What Changes
+
+- `Settings.vault_allow_named_staging_fallback` (env
+  `VAULT_ALLOW_NAMED_STAGING_FALLBACK`), off by default. Refusal behavior is
+  completely unchanged unless an operator turns this on.
+- When set, `_atomic_write_at`'s no-clobber branch falls back to **named**
+  staging (`_create_temp_exclusively`, the same primitive the overwrite path
+  already uses successfully on this filesystem) and publishes with `link()`
+  instead of `linkat` through `/proc/self/fd` — still no-clobber (`EEXIST` on
+  an existing destination) — when `_create_nameless_temp` reports
+  `UnsupportedFilesystem`. This reopens the named-staging substitution window
+  `O_TMPFILE` staging exists to close (the parent directory holds a real,
+  observable entry between staging and publish).
+- The staged name is still created `O_CREAT|O_EXCL|O_NOFOLLOW` through the
+  same pinned parent descriptor (`MutableTarget.dir_fd`, from `open_mutable`)
+  that every other mutating write already uses — the fallback inherits the
+  anchored-write guarantees; it does not resolve any pathname the kernel
+  hasn't already been handed.
+- The trade-off is declared, not silent: a `WARNING` log fires exactly once
+  per process the first time the fallback is actually *exercised* (not merely
+  when the flag is set — `named_staging_fallback_active()` /
+  `_warn_named_staging_fallback_once()`), `/health` gains a
+  `vault_named_staging_fallback_active` boolean, and the refusal error (flag
+  off) names the env var so an operator doesn't have to source-dive to find
+  it.
+- Tests in `tests/test_anchored_note_writes.py`: default-off behavior
+  unchanged, fallback still refuses to clobber, no staging litter under
+  either outcome, warns exactly once across repeated writes.
+
+Filed as maxkuminov/obsidian-mcp#103 first (design conversation before a PR);
+accepted as shaped, with three follow-ups this change also covers: (1) this
+OpenSpec delta, (2) confirming the fallback stages through the pinned parent
+descriptor rather than reopening a pathname, (3) flagging the write-path
+adversarial review this repo runs on changes in this area.
+
+On the accepted residual: the substitution window this reopens requires an
+adversary with write access to the **destination directory** — the same
+adversary the overwrite path's residual already accepts (see "threat #59"),
+on the grounds that such an adversary could simply edit the note directly.
+This is that same declared residual, extended to the no-clobber path behind
+an explicit operator opt-in, not a new threat.
+
+## Impact
+
+- `src/config.py` — new `Settings` field.
+- `src/services/vault.py` — fallback branch in `_atomic_write_at`,
+  `_link_staged_name`, `named_staging_fallback_active`,
+  `_warn_named_staging_fallback_once`.
+- `src/main.py` — `/health` field.
+- `tests/test_anchored_note_writes.py` — new tests.
+- No database, migration, or API-surface change. No change to the overwrite
+  path or to default (flag-off) behavior.

--- a/openspec/changes/2026-08-24-named-staging-fallback/specs/vault-write/spec.md
+++ b/openspec/changes/2026-08-24-named-staging-fallback/specs/vault-write/spec.md
@@ -2,16 +2,35 @@
 
 ### Requirement: Atomic write invariant
 
-The system SHALL perform all file writes from MCP write tools via a temporary file created in the same directory as the destination, whose contents are flushed to durable storage before publication, followed by an atomic same-directory rename (overwrite) or hard link (no-clobber) relative to the destination's directory descriptor. The applicable tools are `create_note`, `edit_note`, `move_note`, `delete_note`, and `set_frontmatter`. Direct writes that could leave the destination truncated on crash SHALL NOT be used, and the temporary file SHALL be created with exclusive, non-symlink-following semantics so a pre-created name cannot be written through.
+The system SHALL perform all file writes from MCP write tools by staging the payload in the destination's own directory, flushing it to durable storage before publication, publishing it with an atomic same-directory rename (overwrite) or hard link (no-clobber) relative to the destination's directory descriptor, and flushing that directory once the publication has happened. The applicable tools are `create_note`, `edit_note`, `move_note`, `delete_note`, `set_frontmatter`, and `write_file`. Payload and directory durability are properties of the shared atomic-write helper, so **every** caller of it inherits them, including `write_file` in both its no-clobber and its `overwrite=True` mode; an implementation SHALL NOT satisfy this requirement for the note tools while omitting the flush for a raw-byte write that goes through the same helper. Direct writes that could leave the destination truncated on crash SHALL NOT be used. Where staging carries a name — the overwrite path, whose replacing rename has no by-descriptor form — that name SHALL be created with exclusive, non-symlink-following semantics so a pre-created name cannot be written through; the no-clobber path SHALL have no name at all, unless `vault_allow_named_staging_fallback` is set and the filesystem cannot stage an unnamed inode, which is the one opted-in case where it too stages under an exclusively created name.
 
-#### Scenario: Crash mid-write does not truncate the destination
+The destination directory SHALL be flushed **after** the publishing rename or link, so that the directory entry the write created or replaced is durable and not only its contents. Flushing only the immediate parent leaves the entry that names *it* unflushed, so a crash can lose the whole new folder and with it a note the tool reported written. The directories to flush SHALL be the **complete ancestor chain** from the destination parent up to the vault root, innermost first — not only the directories the publishing call itself created. Per-call creation provenance is insufficient and SHALL NOT be relied on: a call that creates a directory and then aborts before publication flushes nothing, correctly, because it published nothing; the call that later succeeds finds that directory already present, records no creation of it, and would leave the entry naming it made durable by nobody. The obligation outlives the call that incurred it, and outlives the process, so no in-memory record of "who created what" can discharge it. The chain is bounded by path depth and a directory flush is metadata-only, so the conservative rule is also the cheap one. A failure of the destination-directory flush, or of any of those ancestor flushes, SHALL be logged and SHALL NOT turn a write that already landed into a reported failure: the payload was already durable, the previous content survives either way, and a note tool that reports a false failure is retried — `edit_note(append=True)` retried after a write that landed appends the same block twice. This is deliberately the opposite failure direction from the transfer path, where the source bytes are gone and the ambiguity must be surfaced instead.
 
-- **WHEN** the server process is killed between the tmp-file write and the
-  publication
+**Durability is a property of every publication, not only of the staged-payload helper — and of every *caller* of it, not only the ones a tool name makes obvious.** A note tool publishes in three ways and all three write a directory entry that a crash can lose, so the requirement names them rather than scoping itself to the shared atomic-write helper: the staged-payload `rename`/`link` above; `move_note`'s `renameat2`, which writes **two** entries — the destination's new one and the source's removal — so **both** parent directories SHALL be flushed after it lands, and so SHALL both parents of a rollback rename that puts a source back; and the soft delete's `renameat2` into the trash, which SHALL flush the source's parent **and** the trash directory. A permanent delete's `unlink` SHALL flush the parent directory it removed the entry from. The soft delete's flushes belong to the shared primitive the note and file tools both reach it through, so `delete_file`'s soft delete SHALL get them too. In each case a crash that makes only one of the two entries durable leaves the vault holding the note twice or not at all, or holding an entry for a note the tool reported deleted.
+
+**A link rewrite is one of those callers and SHALL NOT be exempt.** `move_note(rewrite_links=True)` publishes a rewritten body into every backlink source, through the same staged-payload helper, and each of those publications owes the same complete ancestor chain — a rewrite target may sit under directories an external writer created and never made durable, which is exactly the case the chain rule exists for. An implementation SHALL therefore keep a usable vault-root anchor available to every target it publishes through: without one the ancestor lookup is impossible and the flush silently degrades to the leaf's parent alone, which is a *quiet* exemption from this requirement rather than a visible one.
+
+That anchor SHALL be reconciled with the descriptor budget rather than allowed to defeat it. The rewrite phase holds one target per planned rewrite and the number of backlink sources is unbounded, so giving each target its own root descriptor doubles the per-source cost and halves how large a move the process can afford. Since every rewrite target resolves the same vault root, a **single shared root descriptor** for the phase SHALL be permitted, and it SHALL be adopted by a target only after verifying that it names the same root inode that target's parent was proved beneath — a mismatch means the vault root pathname was repointed mid-call, which SHALL abort the whole move before any mutation rather than being reported as one source failing to rewrite. Whatever descriptors the phase retains SHALL be charged against the documented budget.
+
+Every one of these flushes SHALL take the same failure direction as the write path's: **logged, and never turned into a reported failure**, for the same reason expressed for the operation at hand. The rename or the unlink has already happened; a tool that reports it as failed is retried, and a retried move or delete finds the source gone and either contradicts the vault or acts on whatever has since taken the name. Nothing is lost by absorbing the failure except a warning.
+
+#### Scenario: Crash mid-write of an overwrite does not truncate the destination
+
+- **WHEN** the server process is killed between the staging write and the
+  publication of an **overwrite** write, whose staging carries a name
 - **THEN** the destination file SHALL retain its prior content unchanged
 - **AND** the orphaned `.tmp-*` file SHALL be discoverable for cleanup by
   the next reindex (it lives in a dot-prefixed name, so the indexer
   ignores it)
+
+#### Scenario: Crash mid-write of a no-clobber write leaves nothing behind
+
+- **WHEN** the server process is killed between the staging write and the
+  publication of a **no-clobber** write, whose staging has no directory entry
+- **THEN** nothing SHALL exist at the destination path
+- **AND** no `.tmp-*` entry or any other directory entry SHALL be left in the
+  destination directory for a sweep or a reindex to find, because the unnamed
+  inode is reclaimed when the last descriptor closes
 
 #### Scenario: Crash immediately after publication does not publish empty content
 
@@ -20,6 +39,18 @@ The system SHALL perform all file writes from MCP write tools via a temporary fi
 - **THEN** the destination SHALL hold either the full prior content or the full
   new content, because the payload was flushed to durable storage before the
   rename was issued
+
+#### Scenario: The publishing rename is made durable
+
+- **WHEN** a note write publishes its payload
+- **THEN** the destination directory SHALL be flushed after the rename or link and before the tool returns
+
+#### Scenario: A failed directory flush does not report a landed write as failed
+
+- **WHEN** the destination directory's flush fails after the payload has been published
+- **THEN** the tool SHALL report the write as successful
+- **AND** the failure SHALL be logged
+- **AND** the tool SHALL NOT return an error that would invite the caller to retry the write
 
 #### Scenario: Successful write atomically replaces existing content
 
@@ -30,8 +61,8 @@ The system SHALL perform all file writes from MCP write tools via a temporary fi
 #### Scenario: A no-clobber write exposes no staging name
 
 - **WHEN** `create_note` or `write_file` (without `overwrite`) stages its payload
-  on a filesystem that supports `O_TMPFILE`, or on any filesystem when
-  `vault_allow_named_staging_fallback` is not set
+  on a filesystem that supports staging an unnamed inode, or on any filesystem
+  when `vault_allow_named_staging_fallback` is not set
 - **THEN** no directory entry for the staged content SHALL exist at any point before publication
 - **AND** the staged content SHALL be published by descriptor, so that no name a third party could take over is consulted
 - **AND** no cleanup of a staging name SHALL be required or performed
@@ -48,8 +79,8 @@ The system SHALL perform all file writes from MCP write tools via a temporary fi
 - **WHEN** the vault filesystem does not support staging an unnamed file
   and `vault_allow_named_staging_fallback` is not set (the default)
 - **THEN** a no-clobber write SHALL be refused with an error naming the
-  unsupported capability and the `VAULT_ALLOW_NAMED_STAGING_FALLBACK`
-  setting that would opt into the fallback
+  unsupported capability and the `VAULT_ALLOW_NAMED_STAGING_FALLBACK` setting
+  that would opt into the fallback
 - **AND** SHALL NOT fall back to staging under a name
 
 #### Scenario: Named-staging fallback, opted in
@@ -67,15 +98,96 @@ The system SHALL perform all file writes from MCP write tools via a temporary fi
   staging exists to close: a directory entry for the staged content exists,
   observable and replaceable, between staging and publication
 - **AND** a `WARNING` SHALL be logged exactly once per process, the first
-  time the fallback is actually exercised (not merely when the setting is
-  enabled)
+  time the fallback is actually exercised — that is, once a staging name has
+  been created, and not when the setting is enabled, not when a probe selects
+  the mode, and not when the creation of that name failed every attempt
+- **AND** that warning SHALL state where the exercising path stages, and
+  SHALL NOT attribute one path's staging location to the other: a note write
+  stages beside its destination in an ordinary vault directory, a transfer
+  stages in its own hidden staging directory, and the note path's window is
+  the wider of the two
 - **AND** `/health` SHALL report `vault_named_staging_fallback_active: true`
-  once the fallback has been exercised in that process
+  once the fallback has been exercised in that process, and SHALL NOT report
+  it for a process whose only attempt to stage under a name failed
+
+#### Scenario: A staging name is not removed unless it is provably ours
+
+- **WHEN** a write that staged under a name reaches its cleanup without an
+  identity for what it staged — the `fstat` of the staged descriptor failed
+  after the exclusive creation, or the name was already gone when the
+  publication looked for it
+- **THEN** the cleanup SHALL NOT unlink the name
+- **AND** the file at that name SHALL be left in place and the fact logged,
+  because a no-clobber write that published nothing must not destroy a file
+  that took the name over — the same destructive-write class as unlinking an
+  identified substitute
+- **AND** this SHALL hold for both write paths, since they clean up through
+  the same primitive
+
+#### Scenario: A staging name disappears before publication
+
+- **WHEN** a write's staging name is absent at cleanup time and the write did
+  **not** publish
+- **THEN** the cleanup SHALL report the disappearance rather than treating it
+  as the ordinary consumed-by-publication case
+- **AND** an absent staging name SHALL be quiet only when the write published,
+  because that is the `renameat` that consumed it
 
 #### Scenario: Staging happens in the destination directory
 
 - **WHEN** any note or file write stages its payload
-- **THEN** the temporary file SHALL be created in the destination's own
+- **THEN** the staged inode SHALL be allocated in the destination's own
   directory, so publication is a same-directory operation
-- **AND** the temporary file SHALL be removed whether the write succeeds or
-  fails
+- **AND** where that staging carries a name — the overwrite path, and the
+  no-clobber path under the opted-in named-staging fallback — the name SHALL
+  be removed whether the write succeeds or fails, and only while it still
+  refers to the inode this call staged
+
+#### Scenario: A move's rename is made durable at both ends
+
+- **WHEN** `move_note` publishes its `renameat2` from one directory to another
+- **THEN** the destination's parent directory SHALL be flushed after the rename, and so SHALL the source's
+- **AND** every directory above each end, up to the vault root, SHALL be flushed as well — not only the ones this call created
+- **AND** a failure of any of those flushes SHALL be logged and SHALL NOT turn a move that already landed into a reported failure
+
+#### Scenario: A move that is rolled back is made durable too
+
+- **WHEN** a move is refused after its rename landed — the destination held the caller's inode but is a directory or a symbolic link — and the tool renames it back
+- **THEN** both parent directories SHALL be flushed after the rollback rename lands
+- **AND** the refusal SHALL still be reported to the caller, unchanged by whether those flushes succeeded
+
+#### Scenario: A soft delete's rename is made durable
+
+- **WHEN** a note or a file is soft-deleted by renaming it into the trash directory
+- **THEN** the source's parent directory SHALL be flushed after the rename, and so SHALL the trash directory
+- **AND** a failure of either flush SHALL be logged and the delete SHALL still be reported as the success it is
+- **AND** the same SHALL hold for the rollback rename that puts back a directory the soft delete refuses to take
+
+#### Scenario: A permanent delete's unlink is made durable
+
+- **WHEN** a note or a file is deleted permanently
+- **THEN** the parent directory the entry was removed from SHALL be flushed after the unlink
+- **AND** a failure of that flush SHALL be logged and SHALL NOT be reported as a failed delete, because the file is already unlinked and a retry would act on whatever now holds the name
+
+#### Scenario: A backlink rewrite is made durable to the same depth as any other write
+
+- **WHEN** `move_note(rewrite_links=True)` rewrites a backlink in a source note that lives several directories deep, and an outer directory on that source's path was created by another writer and never flushed
+- **THEN** the rewrite's publication SHALL flush every directory above that source's parent, up to the vault root, innermost first — exactly as a `create_note` into the same path would
+- **AND** the descriptor arrangement that makes the lookup possible SHALL NOT pin one root descriptor per rewritten source
+
+#### Scenario: The vault root is repointed while rewrites are being planned
+
+- **WHEN** a rewrite target cannot be shown to have been validated against the same vault root the move is anchored to
+- **THEN** the move SHALL be aborted before its rename runs, so nothing is moved, rewritten or reindexed
+- **AND** it SHALL NOT be reported as a single source failing to rewrite, because the root itself moved and every remaining target is equally suspect
+
+#### Scenario: A newly created folder is durable too
+
+- **WHEN** `create_note("New/Folder/x.md", …)` creates `New` and `Folder` and
+  then publishes the note
+- **THEN** every directory above the destination parent, up to the vault root,
+  SHALL be flushed as well — not only the ones this call created, because a
+  directory an aborted attempt created and never flushed is indistinguishable
+  from one this call found
+- **AND** a failure of any of those flushes SHALL be logged and SHALL NOT be
+  reported to the caller as a failed write

--- a/openspec/changes/2026-08-24-named-staging-fallback/specs/vault-write/spec.md
+++ b/openspec/changes/2026-08-24-named-staging-fallback/specs/vault-write/spec.md
@@ -1,0 +1,81 @@
+## MODIFIED Requirements
+
+### Requirement: Atomic write invariant
+
+The system SHALL perform all file writes from MCP write tools via a temporary file created in the same directory as the destination, whose contents are flushed to durable storage before publication, followed by an atomic same-directory rename (overwrite) or hard link (no-clobber) relative to the destination's directory descriptor. The applicable tools are `create_note`, `edit_note`, `move_note`, `delete_note`, and `set_frontmatter`. Direct writes that could leave the destination truncated on crash SHALL NOT be used, and the temporary file SHALL be created with exclusive, non-symlink-following semantics so a pre-created name cannot be written through.
+
+#### Scenario: Crash mid-write does not truncate the destination
+
+- **WHEN** the server process is killed between the tmp-file write and the
+  publication
+- **THEN** the destination file SHALL retain its prior content unchanged
+- **AND** the orphaned `.tmp-*` file SHALL be discoverable for cleanup by
+  the next reindex (it lives in a dot-prefixed name, so the indexer
+  ignores it)
+
+#### Scenario: Crash immediately after publication does not publish empty content
+
+- **WHEN** the payload has been written to the temporary file and the system
+  loses power immediately after the publishing rename
+- **THEN** the destination SHALL hold either the full prior content or the full
+  new content, because the payload was flushed to durable storage before the
+  rename was issued
+
+#### Scenario: Successful write atomically replaces existing content
+
+- **WHEN** `edit_note` is called with new content and succeeds
+- **THEN** any reader observing the destination path SHALL see either the
+  full prior content or the full new content, never a partial mix
+
+#### Scenario: A no-clobber write exposes no staging name
+
+- **WHEN** `create_note` or `write_file` (without `overwrite`) stages its payload
+  on a filesystem that supports `O_TMPFILE`, or on any filesystem when
+  `vault_allow_named_staging_fallback` is not set
+- **THEN** no directory entry for the staged content SHALL exist at any point before publication
+- **AND** the staged content SHALL be published by descriptor, so that no name a third party could take over is consulted
+- **AND** no cleanup of a staging name SHALL be required or performed
+
+#### Scenario: The staging file of an overwrite is replaced before publication
+
+- **WHEN** another process detaches an overwrite's staged temporary file from its name — by unlinking it or renaming a different file over it — after the payload has been flushed and before publication
+- **THEN** the substituted file's contents SHALL NOT be published at the destination
+- **AND** the destination SHALL hold either its prior content or the content this call staged, never a third party's
+- **AND** the substituted file SHALL be left in place rather than unlinked by the cleanup
+
+#### Scenario: The filesystem cannot stage without a name
+
+- **WHEN** the vault filesystem does not support staging an unnamed file
+  and `vault_allow_named_staging_fallback` is not set (the default)
+- **THEN** a no-clobber write SHALL be refused with an error naming the
+  unsupported capability and the `VAULT_ALLOW_NAMED_STAGING_FALLBACK`
+  setting that would opt into the fallback
+- **AND** SHALL NOT fall back to staging under a name
+
+#### Scenario: Named-staging fallback, opted in
+
+- **WHEN** the vault filesystem does not support staging an unnamed file
+  and `vault_allow_named_staging_fallback` is set
+- **THEN** the no-clobber write SHALL stage a named temporary file, created
+  `O_CREAT|O_EXCL|O_NOFOLLOW` through the same parent directory descriptor
+  (`MutableTarget.dir_fd`, opened at validation) every other mutating write
+  uses — no pathname SHALL be re-resolved to obtain it
+- **AND** the write SHALL publish by hard-linking the staged file to the
+  destination name, so an existing destination is still refused (`EEXIST`)
+  rather than replaced
+- **AND** this reopens the named-staging substitution window unnamed-inode
+  staging exists to close: a directory entry for the staged content exists,
+  observable and replaceable, between staging and publication
+- **AND** a `WARNING` SHALL be logged exactly once per process, the first
+  time the fallback is actually exercised (not merely when the setting is
+  enabled)
+- **AND** `/health` SHALL report `vault_named_staging_fallback_active: true`
+  once the fallback has been exercised in that process
+
+#### Scenario: Staging happens in the destination directory
+
+- **WHEN** any note or file write stages its payload
+- **THEN** the temporary file SHALL be created in the destination's own
+  directory, so publication is a same-directory operation
+- **AND** the temporary file SHALL be removed whether the write succeeds or
+  fails

--- a/openspec/changes/2026-08-24-named-staging-fallback/tasks.md
+++ b/openspec/changes/2026-08-24-named-staging-fallback/tasks.md
@@ -20,10 +20,31 @@
 ## 4. Spec
 
 - [x] 4.1 Spec delta under `specs/vault-write/` (MODIFIED: Atomic write invariant)
-- [ ] 4.2 `openspec validate named-staging-fallback --strict` passes (no local `openspec` CLI available in this environment — validated by hand against the format of prior archived changes)
+- [x] 4.2 `openspec validate 2026-08-24-named-staging-fallback --strict` passes (run at the merge gate, where the CLI is available)
+- [x] 4.3 The MODIFIED requirement is rebased onto the **current** `openspec/specs/vault-write/spec.md` text, not the base the PR was written against: every paragraph and scenario promoted since (complete ancestor-chain durability, move/delete/rollback flushes, backlink-rewrite root sharing, `write_file` coverage, the split crash scenarios) is preserved verbatim, and only the unconditional no-name/refusal clauses change
 
 ## 5. Upstream PR (maxkuminov/obsidian-mcp#103)
 
 - [ ] 5.1 Carry this OpenSpec delta in the PR
 - [ ] 5.2 Note in the PR description that the staged name is created through the pinned `open_mutable` parent descriptor (ask 2)
 - [ ] 5.3 Acknowledge the write-path adversarial review gate in the PR description (ask 3)
+
+## 6. Pre-merge adversarial gate (this repo's write-path review)
+
+- [x] 6.1 BLOCKER: `vault_fs.discard_staged_name` refuses to unlink when
+  `staged is None` — an `fstat` that failed after the exclusive creation left
+  the cleanup with no identity, and unlinking on that basis let a no-clobber
+  write destroy a concurrent replacement. Fail closed: warn, leave the litter.
+  Fixed in the shared primitive, so the transfer path's own `staged=None`
+  shapes (`discard_temp` after a failed `fstat`, `publish`'s fallback `lstat`)
+  are covered by the same change
+- [x] 6.2 MINOR: an absent staging name is quiet only when `published` — an
+  unpublished disappearance is warned about and reported as a failed discard
+- [x] 6.3 MINOR: `note_named_staging_exercised()` is called **after**
+  `_create_temp_exclusively` succeeds, so a creation that failed every attempt
+  neither spends the warn-once budget nor flips `/health`
+- [x] 6.4 MINOR: the shared warning no longer claims `.transfer-tmp` for the
+  note path — it takes the exercising path kind and names both locations,
+  keeping warn-once semantics
+- [x] 6.5 Regression tests for each, including the concurrent replacement over
+  the staging name on the fallback path

--- a/openspec/changes/2026-08-24-named-staging-fallback/tasks.md
+++ b/openspec/changes/2026-08-24-named-staging-fallback/tasks.md
@@ -1,0 +1,29 @@
+## 1. Opt-in fallback (#103)
+
+- [x] 1.1 `src/config.py`: `Settings.vault_allow_named_staging_fallback: bool = False` (env `VAULT_ALLOW_NAMED_STAGING_FALLBACK`)
+- [x] 1.2 `src/services/vault.py::_atomic_write_at`: on `UnsupportedFilesystem` from `_create_nameless_temp`, fall back to `_create_temp_exclusively` + `_link_staged_name` only when the flag is set; re-raise otherwise
+- [x] 1.3 `_create_nameless_temp`'s refusal error names `VAULT_ALLOW_NAMED_STAGING_FALLBACK`
+- [x] 1.4 Confirm the fallback stages through `MutableTarget.dir_fd` (the pinned parent descriptor from `open_mutable`), not a re-resolved pathname — no new descriptor-open call added
+
+## 2. Observability (#103)
+
+- [x] 2.1 `named_staging_fallback_active()` / `_warn_named_staging_fallback_once()`: module-level flag, warns exactly once per process on first actual fallback use (not on flag-set)
+- [x] 2.2 `src/main.py::health`: `vault_named_staging_fallback_active` field
+
+## 3. Tests (#103)
+
+- [x] 3.1 `test_the_named_staging_fallback_is_off_by_default`
+- [x] 3.2 `test_the_named_staging_fallback_still_refuses_to_clobber`
+- [x] 3.3 No staging litter left under either outcome
+- [x] 3.4 Warns exactly once across repeated writes
+
+## 4. Spec
+
+- [x] 4.1 Spec delta under `specs/vault-write/` (MODIFIED: Atomic write invariant)
+- [ ] 4.2 `openspec validate named-staging-fallback --strict` passes (no local `openspec` CLI available in this environment — validated by hand against the format of prior archived changes)
+
+## 5. Upstream PR (maxkuminov/obsidian-mcp#103)
+
+- [ ] 5.1 Carry this OpenSpec delta in the PR
+- [ ] 5.2 Note in the PR description that the staged name is created through the pinned `open_mutable` parent descriptor (ask 2)
+- [ ] 5.3 Acknowledge the write-path adversarial review gate in the PR description (ask 3)

--- a/src/main.py
+++ b/src/main.py
@@ -22,6 +22,7 @@ from src.limiter import limiter
 from src.mcp_server.auth import APIKeyMiddleware
 from src.mcp_server.server import mcp
 from src.oauth.routes import router as oauth_router
+from src.services import vault
 from src.services.indexer import run_indexer_loop
 from src.services import vault_fs
 from src.transfer.routes import router as transfer_router

--- a/src/services/transfer.py
+++ b/src/services/transfer.py
@@ -1478,8 +1478,11 @@ async def _stream_locked(
             # payload flush, the gate and its lock order, the size caps, the
             # deadline and the token state machine below are the same code.
             staged_fd, tmp_name = vault_fs.create_temp(staging_fd)
-            # First *exercise*, which is the moment the warning means something.
-            vault_fs.note_named_staging_exercised()
+            # First *exercise*, which is the moment the warning means something
+            # — after the name exists, never before.
+            vault_fs.note_named_staging_exercised(
+                vault_fs.NAMED_STAGING_TRANSFER_PATH
+            )
         try:
             # The identity the publish's check compares against. Taken from the
             # descriptor, so it names the inode this call staged whatever

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -31,7 +31,9 @@ inside the directory the caller named:
   by an identity check (`_require_staged_name`). The no-clobber publish has no
   such window at all: it stages into an unnamed `O_TMPFILE` inode and publishes
   it through `/proc/self/fd`, so there is no staging name to substitute and
-  none to clean up.
+  none to clean up. (`VAULT_ALLOW_NAMED_STAGING_FALLBACK` is the declared
+  exception: on a filesystem that rejects `O_TMPFILE`, opting in reopens this
+  window for no-clobber writes too — see `_link_staged_name`.)
 - **creating a missing parent has no beneath-root form** (#87, D22). The lookup
   itself is now one `openat2(RESOLVE_BENEATH | RESOLVE_NO_SYMLINKS |
   RESOLVE_NO_MAGICLINKS)`, so there is no interval between components for a
@@ -927,10 +929,8 @@ def _create_nameless_temp(dir_fd: int) -> int:
                 "The vault filesystem does not support O_TMPFILE, which the "
                 "no-clobber write stages into so that no temporary name is "
                 "ever exposed. Refusing rather than staging under a name. "
-                "VAULT_ALLOW_NAMED_STAGING_FALLBACK is the operator switch for "
-                "this; it governs the transfer path today, and the note path's "
-                "half of it is tracked on #103 — until that lands, this write "
-                "refuses whether the flag is set or not."
+                "Set VAULT_ALLOW_NAMED_STAGING_FALLBACK=true to accept named "
+                "staging instead — a declared, weaker guarantee, not a fix."
             ) from exc
         raise
 
@@ -1000,6 +1000,45 @@ def _flush_publication(target: MutableTarget) -> None:
     _flush_target_dirs(target, "destination directory")
 
 
+def _link_staged_name(dir_fd: int, tmp: str, name: str) -> None:
+    """Publish a **named** staging file as `name`, no-clobber.
+
+    The `VAULT_ALLOW_NAMED_STAGING_FALLBACK` fallback for filesystems that
+    reject `O_TMPFILE` (`_create_nameless_temp`'s `UnsupportedFilesystem`).
+    `link()` creates the destination name or fails `EEXIST` — the same
+    no-clobber guarantee `_link_staged_inode` gives — but `tmp` still exists
+    afterwards either way, unlike a rename; the caller's `finally` removes it
+    via `_discard_temp` (which delegates to `vault_fs.discard_staged_name`,
+    the shared implementation the transfer path already uses), same as the
+    overwrite path.
+
+    This reopens the exact named-staging race `O_TMPFILE` publication exists
+    to close: `tmp` is a real directory entry between staging and this call,
+    so another writer to the directory can observe or replace it.
+    `_require_staged_name`, called immediately before this by the shared
+    caller, narrows that to the single syscall between the check and the
+    link — it does not close it. That is the accepted, declared trade-off of
+    opting into this fallback; see `Settings.vault_allow_named_staging_fallback`.
+
+    Process-state accounting (the once-per-process warning, `/health`'s
+    `vault_named_staging_fallback_active`) is shared with the transfer path
+    via `vault_fs.note_named_staging_exercised()` / `named_staging_fallback_active()`
+    (D27) — this module does not keep its own copy of that flag.
+    """
+    try:
+        os.link(tmp, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd, follow_symlinks=False)
+    except FileExistsError:
+        raise
+    except OSError as exc:
+        if getattr(exc, "errno", None) in (errno.EPERM, errno.EOPNOTSUPP, errno.EXDEV):
+            raise vault_fs.UnsupportedFilesystem(
+                "The vault filesystem does not support hard links, which the "
+                "no-clobber write depends on even in named-staging fallback "
+                "mode; refusing rather than replacing an existing file."
+            ) from exc
+        raise
+
+
 def _atomic_write_at(
     target: MutableTarget,
     *,
@@ -1026,6 +1065,13 @@ def _atomic_write_at(
       observed, replaced or raced, and there is nothing to clean up — the inode
       is freed when the descriptor closes. `link` either creates the name or
       fails `EEXIST`, so nothing can be destroyed by a no-clobber publish.
+      When `_create_nameless_temp` reports `UnsupportedFilesystem` (some NFS
+      servers reject `O_TMPFILE` outright) and
+      `settings.vault_allow_named_staging_fallback` is set, this falls back to
+      **named** staging + `_link_staged_name` — the no-clobber write still
+      cannot destroy an existing file, but it reopens the named-staging race
+      the `O_TMPFILE` form exists to close. Off by default: refuse, as before.
+      See `_link_staged_name` for what the fallback does and does not close.
     * **overwrite** (`edit_note`, `set_frontmatter`,
       `write_file(overwrite=True)`) needs `renameat`, which has no
       by-descriptor form, so its source must have a name. That name is created
@@ -1069,7 +1115,13 @@ def _atomic_write_at(
     if overwrite:
         fd, tmp = _create_temp_exclusively(dir_fd, name)
     else:
-        fd = _create_nameless_temp(dir_fd)
+        try:
+            fd = _create_nameless_temp(dir_fd)
+        except vault_fs.UnsupportedFilesystem:
+            if not settings.vault_allow_named_staging_fallback:
+                raise
+            vault_fs.note_named_staging_exercised()
+            fd, tmp = _create_temp_exclusively(dir_fd, name)
     # The `try` opens on the very next line after the descriptor exists: an
     # `EIO` from the `fstat` below would otherwise leak both the descriptor
     # and, on the overwrite path, the staging name.
@@ -1093,7 +1145,10 @@ def _atomic_write_at(
 
         if tmp is not None:
             _require_staged_name(dir_fd, tmp, staged)
-            os.replace(tmp, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+            if overwrite:
+                os.replace(tmp, name, src_dir_fd=dir_fd, dst_dir_fd=dir_fd)
+            else:
+                _link_staged_name(dir_fd, tmp, name)
         else:
             _link_staged_inode(fd, dir_fd, name)
         published = True
@@ -1103,7 +1158,7 @@ def _atomic_write_at(
         _flush_publication(target)
     finally:
         if tmp is not None:
-            _discard_temp(dir_fd, tmp, staged=staged)
+            _discard_temp(dir_fd, tmp, staged=staged, published=published)
         # Quiet only once publication has settled: a bare close raising `EIO`
         # here would discard a write that already happened and surface as a
         # generic OSError, which the tools report as a failure — the trap
@@ -1116,71 +1171,53 @@ def _atomic_write_at(
     return target.path
 
 
-def _staged_identity_matches(dir_fd: int, tmp: str, staged: os.stat_result) -> bool:
-    """Whether `tmp` still names the inode we staged."""
-    try:
-        current = os.stat(tmp, dir_fd=dir_fd, follow_symlinks=False)
-    except OSError:
-        return False
-    return (current.st_dev, current.st_ino) == (staged.st_dev, staged.st_ino)
-
-
-def _require_staged_name(dir_fd: int, tmp: str, staged: os.stat_result) -> None:
-    """Refuse unless the temp name still refers to the bytes we just wrote.
-
-    `renameat` moves whatever is at the source name when it runs, so an
-    overwrite publish cannot be made to carry an inode the way `linkat` can.
-    Checking here does not close the race — it narrows it to the one syscall —
-    and it turns the common case of a peer replacing our staging file from
-    "their content published as the note" into a refusal.
-    """
-    if not _staged_identity_matches(dir_fd, tmp, staged):
-        raise vault_fs.Conflict(
-            "The staged copy was replaced before it could be published; "
-            "nothing was written. Retry the operation."
-        )
-
-
-# `_proc_fd_available` and `_link_staged_inode` live in `vault_fs` (#92 item 1):
-# the transfer publish stages and publishes the same way, and a second copy is
-# how the two paths drifted apart before. These names are kept as module-level
-# aliases so this file reads as it did — and so a test can still hook the
-# publish here without reaching into the shared module.
+# `_proc_fd_available`, `_link_staged_inode`, `_staged_identity_matches` and
+# `_require_staged_name` all live in `vault_fs` (#92 item 1, and — as of this
+# fallback — the rest of the by-name publication primitives too, closing #105
+# in the same move): the transfer publish stages, verifies and discards the
+# same way, and a second copy is how the two paths drifted apart before (a
+# drift that is exactly how #105 happened — `vault_fs.discard_staged_name`
+# already treated an absent staging name as "the publish consumed it, not a
+# substitution"; this module's own copy did not, and warned on every
+# successful overwrite publish as a result). These names are kept as
+# module-level aliases so this file reads as it did — and so a test can still
+# hook the publish here without reaching into the shared module.
 _proc_fd_available = vault_fs.proc_fd_available
 _link_staged_inode = vault_fs.link_staged_inode
+_staged_identity_matches = vault_fs.staged_identity_matches
+_require_staged_name = vault_fs.require_staged_name
 
 
 def _discard_temp(
-    dir_fd: int, tmp: str, staged: os.stat_result | None = None
+    dir_fd: int,
+    tmp: str,
+    staged: os.stat_result | None = None,
+    *,
+    published: bool = False,
 ) -> None:
-    """Remove the **overwrite** path's staging name — and never anybody else's.
+    """Remove a **named** staging file — and never anybody else's.
 
-    Reached on two kinds of path: a successful `renameat` (which consumed the
-    name, so this is a no-op) and a failure after staging. In the failure case
-    the name is unlinked only while it still refers to the inode we staged; if
-    it does not, the file is **left in place and logged**. Answering an
-    attempted substitution by deleting the substitute is the same
-    destructive-write class this module exists to prevent, just aimed at a
-    different file, so the failure direction is to leave litter rather than
-    remove something we cannot prove is ours.
+    Delegates to `vault_fs.discard_staged_name`, the same primitive the
+    transfer path uses (#105): reached on three kinds of path — a successful
+    `renameat` (overwrite, which consumed the name, so this is a no-op), a
+    successful `link()` (no-clobber named-staging fallback, which leaves
+    `tmp` behind pointing at the same inode as the now-published `name`), and
+    a failure after staging on either path. **An absent name is not a
+    substitution** — it is the ordinary outcome of the first case — and only
+    a name that exists and refers to a *different* inode is treated as one,
+    logged and left in place rather than unlinked. Answering an attempted
+    substitution by deleting the substitute is the same destructive-write
+    class this module exists to prevent, just aimed at a different file, so
+    the failure direction is to leave litter rather than remove something we
+    cannot prove is ours.
 
-    The no-clobber path never calls this: it stages into an unnamed
-    `O_TMPFILE` inode, so there is no name to remove and no check to race.
-    That asymmetry is deliberate — see `_atomic_write_at`.
+    The **default** no-clobber path never calls this: it stages into an
+    unnamed `O_TMPFILE` inode, so there is no name to remove and no check to
+    race. That asymmetry is deliberate — see `_atomic_write_at`. It is only
+    reached for no-clobber when `VAULT_ALLOW_NAMED_STAGING_FALLBACK` put a
+    name in the directory in the first place — see `_link_staged_name`.
     """
-    if staged is not None and not _staged_identity_matches(dir_fd, tmp, staged):
-        logger.warning(
-            "Temp name %s no longer refers to the file we staged; leaving it "
-            "in place rather than unlinking a file we did not create.",
-            tmp,
-        )
-        return
-    try:
-        os.unlink(tmp, dir_fd=dir_fd)
-    except FileNotFoundError:
-        pass
-    except OSError as exc:
-        logger.warning("Could not remove temporary file %s: %s", tmp, exc)
+    vault_fs.discard_staged_name(dir_fd, tmp, staged, published=published)
 
 
 def _bound_read(fd: int, label: str, max_bytes: int | None) -> bytes:

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -1867,11 +1867,19 @@ def _atomic_write_at(
         except vault_fs.UnsupportedFilesystem:
             if not settings.vault_allow_named_staging_fallback:
                 raise
-            vault_fs.note_named_staging_exercised()
             fd, tmp = _create_temp_exclusively(dir_fd, name)
+            # **After** the name exists, exactly as the transfer path does it:
+            # the signal is "a call actually staged under a name", so a
+            # creation that failed every attempt must not spend the warn-once
+            # budget or flip `/health` to a fallback this process never took.
+            vault_fs.note_named_staging_exercised(vault_fs.NAMED_STAGING_NOTE_PATH)
     # The `try` opens on the very next line after the descriptor exists: an
-    # `EIO` from the `fstat` below would otherwise leak both the descriptor
-    # and, on the overwrite path, the staging name.
+    # `EIO` from the `fstat` below would otherwise leak the descriptor.
+    # `staged` stays `None` until that `fstat` succeeds, and a `None` there is
+    # what makes the cleanup **leave** any staging name instead of unlinking
+    # it: with no identity, nothing can prove the name still refers to the
+    # inode we created, and a write that published nothing must not remove a
+    # file that took the name over. Litter, deliberately — see `_discard_temp`.
     staged: os.stat_result | None = None
     published = False
     try:
@@ -1956,7 +1964,13 @@ def _discard_temp(
     substitution by deleting the substitute is the same destructive-write
     class this module exists to prevent, just aimed at a different file, so
     the failure direction is to leave litter rather than remove something we
-    cannot prove is ours.
+    cannot prove is ours. A `staged` of `None` — the `fstat` after the
+    exclusive creation failed — is the same refusal with even less evidence:
+    nothing is unlinked, and the name is left and logged.
+
+    An absent name is quiet only when the write **published**; a staging name
+    that disappeared while the write was still in flight is warned about,
+    because that is a substitution's first half and not an ordinary outcome.
 
     The **default** no-clobber path never calls this: it stages into an
     unnamed `O_TMPFILE` inode, so there is no name to remove and no check to

--- a/src/services/vault_fs.py
+++ b/src/services/vault_fs.py
@@ -79,6 +79,7 @@ import os
 import platform
 import secrets
 import stat
+import threading
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -147,6 +148,7 @@ _TRANSIENT_ATTEMPTS = 8
 # the whole value of the signal: it separates an operator who enabled the flag
 # defensively from a mount that is taking the fallback.
 _named_staging_exercised = False
+_named_staging_exercised_lock = threading.Lock()
 
 
 def note_named_staging_exercised() -> None:
@@ -155,11 +157,19 @@ def note_named_staging_exercised() -> None:
     Shared by both write paths, so one warning and one `/health` field answer
     for the note path and the transfer path together (D27). Call it at the
     moment the staging name is created, never earlier.
+
+    The check-then-set is locked: a sync request handler can run this from a
+    thread-pool worker, and without the lock two concurrent first-time
+    fallback writes (racing to be the first exercise, one from each write
+    path) can both observe `False` and both log — the flag still ends up
+    `True` either way, but the warning is meant to fire once per process, not
+    once per race.
     """
     global _named_staging_exercised
-    if _named_staging_exercised:
-        return
-    _named_staging_exercised = True
+    with _named_staging_exercised_lock:
+        if _named_staging_exercised:
+            return
+        _named_staging_exercised = True
     logger.warning(
         "VAULT_ALLOW_NAMED_STAGING_FALLBACK is set and this vault's "
         "filesystem cannot stage without a directory entry, so writes are "

--- a/src/services/vault_fs.py
+++ b/src/services/vault_fs.py
@@ -151,12 +151,32 @@ _named_staging_exercised = False
 _named_staging_exercised_lock = threading.Lock()
 
 
-def note_named_staging_exercised() -> None:
+# Which write path took the fallback, for the one warning below. The two
+# staging *locations* are not equivalent (D27): a transfer stages in
+# `.transfer-tmp` — `0700`, owner-checked, dot-prefixed, hidden from every
+# vault tool — while a note write stages beside its destination, in an
+# ordinary vault directory the vault's own write tools can reach, which is
+# the wider of the two windows. One warning that named only `.transfer-tmp`
+# was therefore false for every note-path exercise, so the warning names both
+# locations and says which path fired it.
+NAMED_STAGING_NOTE_PATH = "note write"
+NAMED_STAGING_TRANSFER_PATH = "transfer upload"
+
+
+def note_named_staging_exercised(path_kind: str) -> None:
     """Record that a call has staged under a name, warning once per process.
 
     Shared by both write paths, so one warning and one `/health` field answer
     for the note path and the transfer path together (D27). Call it at the
-    moment the staging name is created, never earlier.
+    moment the staging name **has been created**, never earlier: a creation
+    that failed every attempt staged nothing, and must neither spend the
+    warn-once budget nor flip `/health` to a fallback this process never took.
+
+    `path_kind` is `NAMED_STAGING_NOTE_PATH` or `NAMED_STAGING_TRANSFER_PATH`
+    — the path that reached here *first*. The warning states both locations
+    regardless, because it fires once and the other path may well exercise the
+    fallback afterwards with no second warning; that is the declared
+    warn-once semantic, not an accident to correct with a second message.
 
     The check-then-set is locked: a sync request handler can run this from a
     thread-pool worker, and without the lock two concurrent first-time
@@ -173,10 +193,15 @@ def note_named_staging_exercised() -> None:
     logger.warning(
         "VAULT_ALLOW_NAMED_STAGING_FALLBACK is set and this vault's "
         "filesystem cannot stage without a directory entry, so writes are "
-        "staging under a name in %s. The staged name exists for the whole "
-        "write, which reopens the substitution window unnamed staging closes; "
-        "it is narrowed, not closed, by the identity check that precedes every "
-        "publish. Unset the flag to refuse instead.",
+        "staging under a name. The first exercise in this process was a %s; "
+        "note writes stage beside the destination, in an ordinary vault "
+        "directory, and transfer uploads stage in %s/. The staged name exists "
+        "for the whole write, which reopens the substitution window unnamed "
+        "staging closes; it is narrowed, not closed, by the identity check "
+        "that precedes every publish, and the note path's window is the wider "
+        "of the two. This fires once per process, so a later exercise by the "
+        "other path is not announced again. Unset the flag to refuse instead.",
+        path_kind,
         STAGING_DIR,
     )
 
@@ -1531,7 +1556,10 @@ def publish(
     reads at entry, which still refuses a substitution landing during the
     publish but cannot see one that landed before `publish` was called; the
     transfer path always passes the real one. In unnamed mode it is derived from
-    `staged_fd` and the parameter is ignored.
+    `staged_fd` and the parameter is ignored. If the name is already gone when
+    that fallback `lstat` runs, the identity stays `None` and the `finally`
+    below **leaves** whatever now holds the name rather than unlinking it —
+    `discard_staged_name` will not remove a name it cannot prove is ours.
 
     Raises `Conflict` when the target is not in the committed state or the
     staged file was substituted, and `UnsafePath` when the target is a symlink.
@@ -1744,32 +1772,61 @@ def discard_staged_name(
     somebody having taken the name over. Only a name that exists and refers to
     a different inode is a substitution.
 
-    `staged is None` means the caller could not establish an identity to compare
-    against — the name is then removed unguarded, which is the pre-change
-    behaviour and is why every production caller passes one.
+    **`staged is None` refuses to unlink at all.** It means the caller could
+    not establish what it staged — an `fstat` that failed after the exclusive
+    creation, or a name already gone when `publish` looked for it — so nothing
+    here can prove the name still refers to our inode, and a concurrent
+    replacement would be destroyed by a write that published nothing. That is
+    the same destructive-write class the identity check above refuses, reached
+    by a path that has *less* evidence rather than more, so it takes the same
+    direction: warn, leave the litter, return False. The pre-change transfer
+    path removed it unguarded; the fallback deliberately does not inherit
+    that (#104 review).
+
+    **An absent name is ordinary only after a publish that consumes it.** With
+    `published=True` a `renameat` took the name and there is nothing to do.
+    With `published=False` the staging name disappeared while the write was
+    still in flight — a substitution's first half, or somebody else's cleanup
+    — which is exactly the kind of event this function exists to surface, so
+    it is warned about and reported as a failed discard.
     """
-    if staged is not None:
-        try:
-            current = os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
-        except FileNotFoundError:
-            # The publish consumed it, or it is already gone. Nothing to do.
+    if staged is None:
+        logger.warning(
+            "Cannot confirm what was staged under %s, so it is left in place "
+            "rather than unlinked: removing a name whose inode we cannot "
+            "prove is ours is the destructive write this guard exists to "
+            "refuse.",
+            name,
+        )
+        return False
+    try:
+        current = os.stat(name, dir_fd=dir_fd, follow_symlinks=False)
+    except FileNotFoundError:
+        if published:
+            # The publish consumed it. The ordinary case.
             return True
-        except OSError as exc:
-            logger.warning(
-                "Could not confirm that staging name %s is still ours (%s); "
-                "leaving it in place.",
-                name,
-                exc,
-            )
-            return False
-        if (current.st_dev, current.st_ino) != (staged.st_dev, staged.st_ino):
-            logger.warning(
-                "Staging name %s no longer refers to the file we staged; "
-                "leaving it in place rather than unlinking a file we did not "
-                "create.",
-                name,
-            )
-            return False
+        logger.warning(
+            "Staging name %s disappeared before its write was published; "
+            "nothing was removed by this cleanup.",
+            name,
+        )
+        return False
+    except OSError as exc:
+        logger.warning(
+            "Could not confirm that staging name %s is still ours (%s); "
+            "leaving it in place.",
+            name,
+            exc,
+        )
+        return False
+    if (current.st_dev, current.st_ino) != (staged.st_dev, staged.st_ino):
+        logger.warning(
+            "Staging name %s no longer refers to the file we staged; "
+            "leaving it in place rather than unlinking a file we did not "
+            "create.",
+            name,
+        )
+        return False
     return _unlink_quietly(dir_fd, name, published=published)
 
 
@@ -1781,7 +1838,9 @@ def discard_temp(
     The abandon path of a failed upload in the named-staging mode. It must not
     be able to turn one failure (a 413, a disconnect) into a second, noisier
     one, so an unlink that itself fails is logged and swallowed — and it goes
-    through `discard_staged_name`, so a substitute is left alone.
+    through `discard_staged_name`, so a substitute is left alone, and so is
+    the name when `staged` is `None` (the caller never got an identity to
+    compare against, which is strictly less evidence, not more).
 
     The unnamed mode never calls this: there is no name to remove, and closing
     the descriptor frees the inode.

--- a/tests/test_anchored_note_writes.py
+++ b/tests/test_anchored_note_writes.py
@@ -945,6 +945,75 @@ def test_a_no_clobber_write_refuses_without_o_tmpfile(vault, monkeypatch):
     assert list(vault.iterdir()) == []
 
 
+def _refuse_o_tmpfile(monkeypatch):
+    real_open = os.open
+
+    def refuse(path, flags, *args, **kwargs):
+        if flags & getattr(os, "O_TMPFILE", 0) == getattr(os, "O_TMPFILE", 0):
+            raise OSError(errno.EOPNOTSUPP, "operation not supported")
+        return real_open(path, flags, *args, **kwargs)
+
+    monkeypatch.setattr(vault_service.os, "open", refuse)
+
+
+def test_the_named_staging_fallback_is_off_by_default(vault, monkeypatch):
+    """`VAULT_ALLOW_NAMED_STAGING_FALLBACK` defaults false: an O_TMPFILE
+    refusal still refuses, even with the fallback machinery present."""
+    _refuse_o_tmpfile(monkeypatch)
+    assert vault_service.settings.vault_allow_named_staging_fallback is False
+
+    with pytest.raises(vault_fs.UnsupportedFilesystem, match="O_TMPFILE"):
+        vault_service.write_bytes("blob.bin", b"ours", overwrite=False)
+
+    assert list(vault.iterdir()) == []
+    assert vault_fs.named_staging_fallback_active() is False
+
+
+def test_the_named_staging_fallback_still_refuses_to_clobber(
+    vault, monkeypatch, caplog
+):
+    """Opting into the fallback survives an O_TMPFILE refusal, still refuses
+    to clobber an existing file, leaves no staging name behind either way,
+    and warns loudly exactly once per process — not once per write.
+
+    The once-per-process state (`named_staging_fallback_active`) is shared
+    with the transfer path via `vault_fs` (D27), not kept per-module — see
+    `vault._link_staged_name` / `vault._discard_temp`, which delegate to
+    `vault_fs` for the same reason (#105).
+    """
+    _refuse_o_tmpfile(monkeypatch)
+    monkeypatch.setattr(
+        vault_service.settings, "vault_allow_named_staging_fallback", True
+    )
+    vault_fs.reset_named_staging_state()
+    assert vault_fs.named_staging_fallback_active() is False
+
+    with caplog.at_level("WARNING"):
+        vault_service.write_bytes("blob.bin", b"first", overwrite=False)
+
+    assert (vault / "blob.bin").read_bytes() == b"first"
+    assert [p.name for p in vault.iterdir()] == ["blob.bin"], "staging litter left"
+    assert vault_fs.named_staging_fallback_active() is True
+    assert (
+        sum("VAULT_ALLOW_NAMED_STAGING_FALLBACK" in r.message for r in caplog.records)
+        == 1
+    )
+
+    caplog.clear()
+    try:
+        with pytest.raises(FileExistsError):
+            vault_service.write_bytes("blob.bin", b"second", overwrite=False)
+
+        assert (vault / "blob.bin").read_bytes() == b"first"
+        assert [p.name for p in vault.iterdir()] == ["blob.bin"], "staging litter left"
+        # Already active — no second warning for the second write.
+        assert not any(
+            "VAULT_ALLOW_NAMED_STAGING_FALLBACK" in r.message for r in caplog.records
+        )
+    finally:
+        vault_fs.reset_named_staging_state()
+
+
 async def test_a_swapped_staging_file_is_refused_by_an_overwrite(
     vault, monkeypatch
 ):

--- a/tests/test_anchored_note_writes.py
+++ b/tests/test_anchored_note_writes.py
@@ -1014,6 +1014,219 @@ def test_the_named_staging_fallback_still_refuses_to_clobber(
         vault_fs.reset_named_staging_state()
 
 
+def test_the_fallback_warning_names_where_each_path_stages(vault, monkeypatch, caplog):
+    """The one warning is accurate for whichever path fired it.
+
+    It used to say writes were staging "under a name in `.transfer-tmp`",
+    which is false for a note write: the note path stages **beside the
+    destination**, in an ordinary vault directory, which is the *wider* of the
+    two windows (D27). One warning per process is the declared semantic, so
+    the fix is a warning that names both locations and says which path
+    exercised it — not a second warning when the other path follows.
+    """
+    _refuse_o_tmpfile(monkeypatch)
+    monkeypatch.setattr(
+        vault_service.settings, "vault_allow_named_staging_fallback", True
+    )
+    vault_fs.reset_named_staging_state()
+    try:
+        with caplog.at_level("WARNING"):
+            vault_service.write_bytes("blob.bin", b"ours", overwrite=False)
+
+        warnings = [
+            r.message
+            for r in caplog.records
+            if "VAULT_ALLOW_NAMED_STAGING_FALLBACK" in r.message
+        ]
+        assert len(warnings) == 1
+        message = warnings[0]
+        assert vault_fs.NAMED_STAGING_NOTE_PATH in message, message
+        assert "beside the destination" in message, message
+        # And it still names the transfer path's own location, because the
+        # other path may take the fallback later with no second warning.
+        assert vault_fs.STAGING_DIR in message, message
+    finally:
+        vault_fs.reset_named_staging_state()
+
+
+def test_a_failed_staging_creation_neither_warns_nor_flips_health(
+    vault, monkeypatch, caplog
+):
+    """The signal is "a call actually staged under a name".
+
+    The exercised flag was set *before* `_create_temp_exclusively`, so a
+    creation that failed every attempt still spent the once-per-process
+    warning and made `/health` report a fallback this process never took
+    (#104 review). Every attempt fails here — the candidate name is fixed and
+    a symlink already sits at it, which `O_EXCL|O_NOFOLLOW` refuses.
+    """
+    _refuse_o_tmpfile(monkeypatch)
+    monkeypatch.setattr(
+        vault_service.settings, "vault_allow_named_staging_fallback", True
+    )
+    monkeypatch.setattr(vault_service, "_temp_candidate", lambda name: ".tmp-fixed")
+    (vault / ".tmp-fixed").symlink_to(vault / "decoy.bin")
+    vault_fs.reset_named_staging_state()
+    try:
+        with caplog.at_level("WARNING"):
+            with pytest.raises(RuntimeError, match="temporary file"):
+                vault_service.write_bytes("blob.bin", b"ours", overwrite=False)
+
+        assert vault_fs.named_staging_fallback_active() is False
+        assert not any(
+            "VAULT_ALLOW_NAMED_STAGING_FALLBACK" in r.message for r in caplog.records
+        )
+        assert not (vault / "blob.bin").exists()
+        assert not (vault / "decoy.bin").exists(), "wrote through the planted link"
+    finally:
+        vault_fs.reset_named_staging_state()
+
+
+def test_a_cleanup_without_an_identity_unlinks_nothing(vault, monkeypatch, caplog):
+    """The BLOCKER: a no-clobber write must not destroy somebody else's file.
+
+    On the fallback path the staging name exists for the whole write. If the
+    `fstat` that establishes *what we staged* fails afterwards, the cleanup
+    has no identity to compare against — and unlinking the name on that basis
+    destroys whatever has since taken it. Here another writer renames its
+    sole-link file over the staging name inside exactly that window: the file
+    must survive a write that published nothing, and the litter must be
+    reported rather than removed.
+    """
+    _refuse_o_tmpfile(monkeypatch)
+    monkeypatch.setattr(
+        vault_service.settings, "vault_allow_named_staging_fallback", True
+    )
+    monkeypatch.setattr(vault_service, "_temp_candidate", lambda name: ".tmp-fixed")
+    (vault / "victim.bin").write_bytes(b"somebody else's bytes")
+    vault_fs.reset_named_staging_state()
+
+    real_fstat = os.fstat
+
+    def boom(fd):
+        info = real_fstat(fd)
+        if stat.S_ISDIR(info.st_mode):
+            return info
+        # The concurrent replacement lands in the window the failed `fstat`
+        # opens: the name now refers to the victim's inode, not ours.
+        os.rename(vault / "victim.bin", vault / ".tmp-fixed")
+        raise OSError(errno.EIO, "I/O error")
+
+    monkeypatch.setattr(vault_service.os, "fstat", boom)
+    try:
+        with caplog.at_level("WARNING"):
+            with pytest.raises(OSError):
+                vault_service.write_bytes("blob.bin", b"ours", overwrite=False)
+    finally:
+        monkeypatch.setattr(vault_service.os, "fstat", real_fstat)
+        vault_fs.reset_named_staging_state()
+
+    assert (vault / ".tmp-fixed").read_bytes() == b"somebody else's bytes"
+    assert not (vault / "blob.bin").exists(), "published despite the failure"
+    assert any(
+        ".tmp-fixed" in r.message and "left in place" in r.message
+        for r in caplog.records
+    ), [r.message for r in caplog.records]
+
+
+def test_a_staging_name_that_vanishes_before_publication_is_reported(
+    vault, monkeypatch, caplog
+):
+    """An absent staging name is ordinary only *after* a consuming publish.
+
+    Returning quietly regardless of `published` hid the other case entirely:
+    a staging name that disappeared while the write was still in flight is a
+    substitution's first half, and the cleanup is the only thing that sees it.
+    """
+    _refuse_o_tmpfile(monkeypatch)
+    monkeypatch.setattr(
+        vault_service.settings, "vault_allow_named_staging_fallback", True
+    )
+    monkeypatch.setattr(vault_service, "_temp_candidate", lambda name: ".tmp-fixed")
+    vault_fs.reset_named_staging_state()
+    real_require = vault_service._require_staged_name
+
+    def vanish(dir_fd, tmp, staged):
+        os.unlink(tmp, dir_fd=dir_fd)
+        return real_require(dir_fd, tmp, staged)
+
+    monkeypatch.setattr(vault_service, "_require_staged_name", vanish)
+    try:
+        with caplog.at_level("WARNING"):
+            with pytest.raises(vault_fs.Conflict):
+                vault_service.write_bytes("blob.bin", b"ours", overwrite=False)
+    finally:
+        vault_fs.reset_named_staging_state()
+
+    assert not (vault / "blob.bin").exists()
+    assert any(
+        ".tmp-fixed" in r.message and "disappeared before" in r.message
+        for r in caplog.records
+    ), [r.message for r in caplog.records]
+
+
+def test_the_shared_discard_is_quiet_only_for_a_consuming_publish(tmp_path, caplog):
+    """The primitive itself, in both directions and for both write paths.
+
+    `discard_staged_name` is what the note path and the transfer path both
+    clean up through (D27), and the transfer path reaches it with `staged=None`
+    on the same shape — an `fstat` that failed after `create_temp` — so the
+    refusal belongs in the primitive rather than in one caller.
+    """
+    dir_fd = os.open(str(tmp_path), os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        # 1. Consumed by a publish: absent, published, quiet.
+        with caplog.at_level("WARNING"):
+            assert (
+                vault_fs.discard_staged_name(
+                    dir_fd, ".tmp-gone", os.stat(tmp_path), published=True
+                )
+                is True
+            )
+        assert not caplog.records, [r.message for r in caplog.records]
+
+        # 2. Absent and *not* published: warned, and reported as a failure.
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            assert (
+                vault_fs.discard_staged_name(
+                    dir_fd, ".tmp-gone", os.stat(tmp_path), published=False
+                )
+                is False
+            )
+        assert any("disappeared before" in r.message for r in caplog.records)
+
+        # 3. No identity at all: nothing is unlinked, on either path.
+        (tmp_path / ".tmp-theirs").write_bytes(b"not ours")
+        caplog.clear()
+        with caplog.at_level("WARNING"):
+            assert (
+                vault_fs.discard_staged_name(
+                    dir_fd, ".tmp-theirs", None, published=False
+                )
+                is False
+            )
+            # The transfer path's abandon path is the same call.
+            assert vault_fs.discard_temp(dir_fd, ".tmp-theirs", None) is False
+        assert (tmp_path / ".tmp-theirs").read_bytes() == b"not ours"
+        assert len(
+            [r for r in caplog.records if "left in place" in r.message]
+        ) == 2
+
+        # 4. Ours, present, unpublished: removed, as it always was.
+        staged_path = tmp_path / ".tmp-ours"
+        staged_path.write_bytes(b"ours")
+        assert (
+            vault_fs.discard_staged_name(
+                dir_fd, ".tmp-ours", os.stat(staged_path), published=False
+            )
+            is True
+        )
+        assert not staged_path.exists()
+    finally:
+        os.close(dir_fd)
+
+
 async def test_a_swapped_staging_file_is_refused_by_an_overwrite(
     vault, monkeypatch
 ):
@@ -1067,10 +1280,19 @@ def test_publishing_by_descriptor_refuses_without_proc(vault, monkeypatch):
     assert not (vault / "blob.bin").exists()
 
 
-def test_an_fstat_failure_leaks_neither_descriptor_nor_staging_name(
-    vault, monkeypatch
+def test_an_fstat_failure_leaks_no_descriptor_and_unlinks_nothing(
+    vault, monkeypatch, caplog
 ):
-    """The `try` opens immediately after the descriptor exists (round-2 #4)."""
+    """The `try` opens immediately after the descriptor exists (round-2 #4).
+
+    The descriptor is closed on the way out. The staging **name** is
+    deliberately *not*: an `fstat` that failed left this call with no identity
+    to compare the name against, so the cleanup cannot prove the name still
+    refers to the inode it created, and unlinking it on that basis is the
+    destructive write the whole guard exists to refuse (#104 review). The
+    declared failure direction is to leave litter and say so — the next
+    lines assert exactly that, and the warning names what was left.
+    """
     (vault / "note.md").write_text("before\n", encoding="utf-8")
     before = _open_fds()
     real_fstat = os.fstat
@@ -1087,13 +1309,18 @@ def test_an_fstat_failure_leaks_neither_descriptor_nor_staging_name(
 
     monkeypatch.setattr(vault_service.os, "fstat", boom)
 
-    for _ in range(3):
-        with pytest.raises(OSError):
-            vault_service.write_file("note.md", "after\n", overwrite=True)
+    with caplog.at_level("WARNING"):
+        for _ in range(3):
+            with pytest.raises(OSError):
+                vault_service.write_file("note.md", "after\n", overwrite=True)
 
     monkeypatch.setattr(vault_service.os, "fstat", real_fstat)
     assert _open_fds() == before
-    assert [p.name for p in vault.iterdir()] == ["note.md"]
+    left = sorted(p.name for p in vault.iterdir() if p.name != "note.md")
+    assert len(left) == 3, left
+    assert all(name.startswith(".tmp-note.md-") for name in left), left
+    for name in left:
+        assert any(name in r.message for r in caplog.records), name
     assert (vault / "note.md").read_text(encoding="utf-8") == "before\n"
 
 

--- a/tests/test_issue_88_root_confirmed_before_publish.py
+++ b/tests/test_issue_88_root_confirmed_before_publish.py
@@ -1566,13 +1566,18 @@ DIR_FD_KEYWORDS = {"dir_fd", "src_dir_fd", "dst_dir_fd"}
 
 # The only functions permitted to reach one, and why each is a publish helper
 # rather than a call site that slipped the net:
-#   `_atomic_write_at`  — the overwrite publication (`os.replace`).
-#   `_discard_temp`     — removes the *staging* name it created, never the
-#                         target's, and only while that name still refers to the
-#                         inode it staged.
-#   `unlink_at`         — the permanent-unlink helper this change added; the
-#                         call site C.2a moved out of `delete_note`.
-PUBLISH_HELPERS = {"_atomic_write_at", "_discard_temp", "unlink_at"}
+#   `_atomic_write_at`   — the overwrite publication (`os.replace`).
+#   `_link_staged_name`  — the named-staging fallback's no-clobber publication
+#                          (#103/#104, `os.link` — creates the name or fails
+#                          `EEXIST`); called only from `_atomic_write_at`,
+#                          after `_require_confirmation` has run, with the same
+#                          standing as its `os.replace`.
+#   `unlink_at`          — the permanent-unlink helper #88 added; the call
+#                          site C.2a moved out of `delete_note`.
+# `_discard_temp` left this list when #104 delegated it to
+# `vault_fs.discard_staged_name` (the D27 consolidation): the unlink now lives
+# in the primitive module the scan deliberately does not police.
+PUBLISH_HELPERS = {"_atomic_write_at", "_link_staged_name", "unlink_at"}
 
 
 def _enclosing_function(tree: ast.AST, target: ast.AST) -> str | None:
@@ -1634,7 +1639,7 @@ def test_the_structural_scan_actually_sees_the_permitted_call_sites():
         for syscall, function, _ in _dir_fd_mutations(source)
     }
     assert ("vault.py", "replace", "_atomic_write_at") in seen
-    assert ("vault.py", "unlink", "_discard_temp") in seen
+    assert ("vault.py", "link", "_link_staged_name") in seen
     assert ("vault.py", "unlink", "unlink_at") in seen
     # And nothing under `src/mcp_server/` reaches one at all any more.
     assert not [entry for entry in seen if entry[0] != "vault.py"], seen


### PR DESCRIPTION
Merges timkjr's #104 (opt-in `VAULT_ALLOW_NAMED_STAGING_FALLBACK` for note-path no-clobber writes on O_TMPFILE-less filesystems — TrueNAS SCALE NFS) with two maintainer commits on top:

1. **Structural-scan reconciliation** — the PR's (correct) D27 consolidation moved `_discard_temp`'s unlink into `vault_fs.discard_staged_name`, and its new `_link_staged_name` publish primitive is admitted to the #88 scan inventory with the same standing as `_atomic_write_at`'s `os.replace`.
2. **Pre-merge adversarial gate findings, fixed forward** (1 BLOCKER + 1 MAJOR + 3 MINOR, round 2 PASS): fail-closed `staged=None` cleanup (never unlink an unproven name — this also closed the identical pre-existing shape on the transfer path); the PR's spec delta rebased onto the current base so archiving cannot erase the waves' promoted guarantees; unpublished-absence warning; exercised-state timing; accurate two-location warning text.

The contributor's design came through intact, including the #105 fix folded in as invited. One MINOR from the verification round ships and will be filed (false disappearance warning in fallback mode when a post-publication fsync fails).

Gates: unit 1729 / full-with-Postgres 1947 / `validate --strict` clean / negative controls firing.

Closes #103. Merging with a merge commit so #104's authorship lands intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VBWJ5NiAGc2MQ9U5NSzrW