### PR TITLE
fix(caddy): route /transfer* through the bundled Caddyfile's public matcher

### DIFF
--- a/Caddyfile.example
+++ b/Caddyfile.example
@@ -6,8 +6,15 @@
     encode gzip
 
     # ── Public MCP endpoint (API-key auth at the application layer) ──
+    # /transfer* is public by design: the capability token in the
+    # Authorization header is what authorises a redemption, and precise
+    # status is only ever reported to the authenticated side. Do NOT move
+    # it behind the basic_auth block below — the person redeeming a link
+    # has no panel credentials. Caddy does not log request headers by
+    # default and streams request bodies; keep both defaults, or upload
+    # links stop working and live capabilities end up in your logs.
     @mcp {
-        path /mcp* /health /.well-known* /register /token /revoke
+        path /mcp* /transfer* /health /.well-known* /register /token /revoke
     }
     handle @mcp {
         reverse_proxy obsidian-mcp:8000

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -113,19 +113,12 @@ Before starting Caddy, generate a password hash and replace the
 docker run --rm caddy:2 caddy hash-password --plaintext 'your-password'
 ```
 
-The bundled configuration protects `/admin`, `/api`, and `/authorize` and
-fails closed while the placeholder remains. Everything it does not name
-is answered 404, so if you want the file-transfer tools, add
-`/transfer*` to the public matcher alongside `/mcp*`:
-
-```caddyfile
-@mcp {
-    path /mcp* /transfer* /health /.well-known* /register /token /revoke
-}
-```
-
-`/transfer/*` is public by design — the capability token in the request
-is what authorises it — so it must not go behind the basic-auth block.
+The bundled configuration protects `/admin`, `/api`, and `/authorize`,
+fails closed while the placeholder remains, and answers everything it
+does not name with 404. Its public matcher already forwards
+`/transfer*`: those routes are public by design — the capability token
+in the request is what authorises them — so if you customise the file,
+keep them out of the basic-auth block.
 
 > Leave `MCP_SANDBOX_MODE` unset (it appears commented-out in
 > `.env.example`). It exists only for the Glama registry's automated


### PR DESCRIPTION
One-line matcher fix for #118 plus the matching DEPLOYMENT.md trim. The bundled Caddy config answered `/transfer*` with its default 404, so transfer links minted on the simple deployment never worked in the browser. Validated with `caddy validate` (caddy:2, hostname env set).

The comment above the matcher records why the route is public (capability token in the `Authorization` header) and which Caddy defaults must be kept (no header logging, streaming bodies). DEPLOYMENT.md's step-2 paragraph — which told the operator to add the matcher by hand — now says the bundled file forwards it.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VBWJ5NiAGc2MQ9U5NSzrW