### PR TITLE
fix(traefik): scope the Bearer root router to Path(`/`) so it can't bypass OAuth on /admin and /api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,9 +76,17 @@ services:
       - "traefik.http.routers.obsidian-mcp-apirest-rtr.tls.certresolver=dns-namecheap"
       - "traefik.http.routers.obsidian-mcp-apirest-rtr.middlewares=chain-oauth@file"
       - "traefik.http.routers.obsidian-mcp-apirest-rtr.service=obsidian-mcp-svc"
-      # Root MCP router — bypass OAuth when any Bearer header present (priority=100)
+      # Root MCP router — bypass OAuth for a bare `/` carrying a Bearer token
+      # (clients like OpenWebUI strip the /mcp prefix; RootMCPProxyMiddleware
+      # rewrites exactly `/` → `/mcp/` and nothing else). The `Path(`/`)` scope
+      # is load-bearing security, not tidiness: without it this rule's
+      # priority=100 outranks the OAuth-protected panel/api routers (whose
+      # default priority is their rule length, ~52–78) for EVERY path, so any
+      # request to `/admin/*` or `/api/*` carrying any `Authorization: Bearer`
+      # header would reach the app with the `chain-oauth@file` middleware
+      # bypassed. Keep the path scope on any future header-matched root rule.
       - "traefik.http.routers.obsidian-mcp-root-rtr.entrypoints=https"
-      - "traefik.http.routers.obsidian-mcp-root-rtr.rule=Host(`${MCP_HOSTNAME:-obsidian-mcp.localhost}`) && HeaderRegexp(`Authorization`, `^Bearer `)"
+      - "traefik.http.routers.obsidian-mcp-root-rtr.rule=Host(`${MCP_HOSTNAME:-obsidian-mcp.localhost}`) && Path(`/`) && HeaderRegexp(`Authorization`, `^Bearer `)"
       - "traefik.http.routers.obsidian-mcp-root-rtr.tls=true"
       - "traefik.http.routers.obsidian-mcp-root-rtr.tls.certresolver=dns-namecheap"
       - "traefik.http.routers.obsidian-mcp-root-rtr.priority=100"


### PR DESCRIPTION
**Security fix** found by the #122 review campaign and verified by an independent adversarial pass.

The Traefik `obsidian-mcp-root-rtr` router (`priority=100`, rule `Host(...) && HeaderRegexp(Authorization, ^Bearer )`, **no** `chain-oauth@file` middleware) outranks the OAuth-protected panel and REST-API routers — which use default rule-length priority (~52–78) — for **every** path when a `Bearer` header is present. So `GET /admin/keys` or `POST /api/keys` with `Authorization: Bearer anything` routed to the unprotected root router, bypassing forward auth. `RootMCPProxyMiddleware` only rewrites a bare `/`, so the request reached the real panel/api routes.

**Severity by mode** (verified): Critical in single-user (the documented default — `require_user_panel` returns an admin sentinel) and in fresh/unbootstrapped multi-user (`/admin/register` mints the first admin); Medium in established multi-user, where the DB-backed app session check still blocks direct admin.

**Fix**: add `Path(\`/\`)` to the rule. The router only ever needs to catch a bare `/` with a Bearer token (MCP clients that strip the `/mcp` prefix); `RootMCPProxyMiddleware` rewrites exactly `/` → `/mcp/`, so the scoped rule is complete and can never match `/admin` or `/api`. Only `docker-compose.yml` carries this router; the simple/proxy variants don't.

After merge the deploy-dir copy of `docker-compose.yml` must be synced and the container recreated for the label change to take effect on the live Traefik.

Refs #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VBWJ5NiAGc2MQ9U5NSzrW