### PR TITLE
fix(indexer): unsanitized frontmatter title no longer freezes the index pass (#126)

### DIFF
--- a/src/services/indexer.py
+++ b/src/services/indexer.py
@@ -91,6 +91,20 @@ def _sanitize_frontmatter(fm: dict) -> dict:
     """Convert non-JSON-serializable values (dates, etc) to strings."""
     return _sanitize_value(fm)
 
+
+def _note_title(frontmatter: dict, filename: str) -> str:
+    """Frontmatter `title` coerced to a bounded string, or the filename stem.
+
+    YAML parses `title: 2026-08-25` into a date and `title: [a, b]` into a
+    list, and nothing bounds the length; `notes_metadata.title` is
+    VARCHAR(512). An unsanitized value makes the whole batch INSERT raise,
+    aborting the pass transaction — and since nothing commits, the content
+    hash never advances and every subsequent tick retries the same fatal
+    batch forever (#126).
+    """
+    value = _sanitize_value(frontmatter.get("title"))
+    return str(value or os.path.splitext(filename)[0])[:512]
+
 logger = logging.getLogger(__name__)
 
 
@@ -1068,7 +1082,7 @@ async def _index_vault_pinned(
                     skips.append(f"{rel_path} (parse: {e})")
                     continue
                 path_to_content[rel_path] = content
-                title = frontmatter.get("title") or os.path.splitext(found.name)[0]
+                title = _note_title(frontmatter, found.name)
 
                 to_upsert.append({
                     "user_id": user_id,

--- a/tests/test_issue_126_title_sanitize.py
+++ b/tests/test_issue_126_title_sanitize.py
@@ -1,0 +1,56 @@
+"""Regression test for GitHub issue #126.
+
+A frontmatter `title` that YAML parses into a date (`title: 2026-08-25`), a
+list, or a string longer than the column's VARCHAR(512) used to be assigned
+to the row unsanitized. The batch INSERT then raised, aborting the whole
+pass transaction — and because nothing committed, the content hash never
+advanced and every 5-minute tick retried the same fatal batch forever while
+search kept answering from the last good rows.
+
+Runs fully offline: imports the pure helper directly, no DB / network.
+"""
+
+import datetime
+
+from src.services.indexer import _note_title
+
+
+def test_plain_string_title_passes_through():
+    assert _note_title({"title": "My Note"}, "file.md") == "My Note"
+
+
+def test_missing_title_falls_back_to_stem():
+    assert _note_title({}, "Daily Plan.md") == "Daily Plan"
+
+
+def test_empty_title_falls_back_to_stem():
+    assert _note_title({"title": ""}, "note.md") == "note"
+
+
+def test_date_title_is_stringified():
+    # YAML parses `title: 2026-08-25` into datetime.date.
+    assert _note_title({"title": datetime.date(2026, 8, 25)}, "n.md") == "2026-08-25"
+
+
+def test_datetime_title_is_stringified():
+    out = _note_title({"title": datetime.datetime(2026, 8, 25, 1, 2, 3)}, "n.md")
+    assert isinstance(out, str) and out.startswith("2026-08-25")
+
+
+def test_list_title_is_stringified():
+    out = _note_title({"title": ["a", "b"]}, "n.md")
+    assert isinstance(out, str) and len(out) <= 512
+
+
+def test_dict_title_is_stringified():
+    out = _note_title({"title": {"weird": True}}, "n.md")
+    assert isinstance(out, str) and len(out) <= 512
+
+
+def test_overlong_title_is_bounded_to_512():
+    out = _note_title({"title": "x" * 2000}, "n.md")
+    assert out == "x" * 512
+
+
+def test_int_title_is_stringified():
+    assert _note_title({"title": 42}, "n.md") == "42"


### PR DESCRIPTION
An unsanitized frontmatter `title` (YAML date, list, or >512 chars) aborted the whole pass transaction at the batch INSERT, and because nothing committed the same fatal batch was retried every tick forever (#126, found by #122 tier 1b, adversarially verified CONFIRMED BLOCKER).

Fix: `_note_title()` runs the value through `_sanitize_value`, stringifies anything non-string, falls back to the filename stem for falsy values (unchanged semantics), and bounds the result to the column's VARCHAR(512).

Offline regression tests cover date/datetime/list/dict/int/overlong titles plus the fallback paths.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VBWJ5NiAGc2MQ9U5NSzrW