### PR TITLE
chore(compose): restore mem_limit parity with the deploy copy (#132)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,11 @@ services:
       - apparmor=docker-default
     cap_drop:
       - ALL
+    # memory cap: applied LIVE on 2026-07-07 (docker update) but never written
+    # here, so any recreate silently dropped it -- persisted 2026-07-27.
+    # Peak 378M/2G = 18%, ample headroom.
+    mem_limit: 2g
+    memswap_limit: 2g
     deploy:
       resources:
         limits:


### PR DESCRIPTION
Adds the deploy-dir's `mem_limit: 2g` / `memswap_limit: 2g` block (same placement, same comment) to the repo `docker-compose.yml`, so the identical-copies invariant holds again and a repo→deploy copy no longer drops the cap production runs with. The simple/proxy reference stacks stay uncapped deliberately — memory policy in those generic stacks belongs to the operator.

After merge I'll sync the repo copy over the deploy dir (which also picks up the newer #125 router comment the deploy copy lacks).

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VBWJ5NiAGc2MQ9U5NSzrW