### PR TITLE
test(fts): stable Norwegian inflection pair + enable the module in CI (#124)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,19 +80,12 @@ jobs:
           # Real Postgres for tests/integration/*. The harness creates and drops
           # its own databases on this server.
           PGVECTOR_TEST_ADMIN_URL: postgresql+asyncpg://postgres:test@localhost:5432/postgres
-          # TEST_DATABASE_URL is deliberately NOT set, so
-          # tests/test_fts_integration.py stays skipped as it is everywhere
-          # else today. Pointing it at the service container was tried and
-          # surfaced two pre-existing failures that are a property of the
-          # Norwegian snowball stemmer, not of the runner: PostgreSQL 16 stems
-          # the document word "datasenteret" to `datasenter` and the *query*
-          # word "datasenter" to `datasent`, so
-          # test_norwegian_stemmer_matches_inflected_form and
-          # test_multi_config_matches_either_language assert a match the
-          # stemmer does not produce. Reproduced identically against this
-          # project's own production Postgres 16.15, so it is a latent bug in
-          # the module's expectations rather than anything CI can fix here.
-          # Enable this variable once that module is corrected.
+          # tests/test_fts_integration.py runs read-only SELECTs and rolls
+          # back, so pointing it at the service's maintenance database is
+          # safe. Enabled after #124 corrected the module's Norwegian
+          # inflection pair to one the snowball stemmer collapses in both
+          # directions (huset/hus; datasenteret/datasenter was not).
+          TEST_DATABASE_URL: postgresql+asyncpg://postgres:test@localhost:5432/postgres
         run: pytest -q -rs --junitxml=pytest-report.xml
 
       # House rule: a gate that silently skips is not a gate. The namespace

--- a/tests/test_fts_integration.py
+++ b/tests/test_fts_integration.py
@@ -1,9 +1,16 @@
 """Integration tests for configurable FTS — exercises real PostgreSQL stemming.
 
 These verify the end-to-end semantics the unit tests can't: that the Norwegian
-stemmer matches `datasenter` against `datasenteret`, that `english` does not,
-that `simple` matches only exact forms, and that a multi-config list matches
-across languages.
+stemmer matches `hus` against `huset`, that `english` does not, that `simple`
+matches only exact forms, and that a multi-config list matches across
+languages.
+
+The inflection pair must stem identically on the document side and the query
+side — snowball is not idempotent, so not every pair does. The original
+`datasenteret`/`datasenter` pair fails exactly that way on PostgreSQL 16:
+the document form stems `datasenteret` -> `datasenter` but the query form
+stems `datasenter` -> `datasent`, so the asserted match never existed (#124).
+`huset` -> `hus` and `hus` -> `hus` are stable in both directions.
 
 The index side is built through the real `index_tsvector_sql` helper; the query
 side mirrors `combined_tsquery`'s OR-of-`websearch_to_tsquery` shape in raw SQL
@@ -87,31 +94,32 @@ async def _matches(conn, configs, body, query):
     return bool(row.scalar())
 
 
-# "datasenteret" = "the data center" (definite form); stem is "datasenter".
-NORWEGIAN = "Vi bygde datasenteret i fjor."
+# "huset" = "the house" (definite form); stems to "hus", and the query form
+# "hus" also stems to "hus" — stable both ways, which "datasenteret" was not.
+NORWEGIAN = "Vi bygde huset i fjor."
 
 
 @pytest.mark.asyncio
 async def test_norwegian_stemmer_matches_inflected_form(conn):
-    assert await _matches(conn, ["norwegian"], NORWEGIAN, "datasenter")
+    assert await _matches(conn, ["norwegian"], NORWEGIAN, "hus")
 
 
 @pytest.mark.asyncio
 async def test_english_config_misses_norwegian_inflection(conn):
-    assert not await _matches(conn, ["english"], NORWEGIAN, "datasenter")
+    assert not await _matches(conn, ["english"], NORWEGIAN, "hus")
 
 
 @pytest.mark.asyncio
 async def test_simple_matches_exact_form_only(conn):
-    assert await _matches(conn, ["simple"], NORWEGIAN, "datasenteret")
-    assert not await _matches(conn, ["simple"], NORWEGIAN, "datasenter")
+    assert await _matches(conn, ["simple"], NORWEGIAN, "huset")
+    assert not await _matches(conn, ["simple"], NORWEGIAN, "hus")
 
 
 @pytest.mark.asyncio
 async def test_multi_config_matches_either_language(conn):
-    body = "The servers run fast. Vi bygde datasenteret."
+    body = "The servers run fast. Vi bygde huset."
     assert await _matches(conn, ["english", "norwegian"], body, "server")
-    assert await _matches(conn, ["english", "norwegian"], body, "datasenter")
+    assert await _matches(conn, ["english", "norwegian"], body, "hus")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The module asserted `datasenter` matches `datasenteret` under the `norwegian` config, but PG16's snowball stemmer stems the document form to `datasenter` and the query form to `datasent` — the match never existed (the module was silently skipped everywhere until #123's CI surfaced it).

- Replaces the pair with `huset`/`hus`, which stems to `hus` in both directions (verified empirically against `pgvector/pgvector:pg16`: doc `huset`→`hus`, query `hus`→`hus`, english keeps `huset` literal, simple matches exact form only). All 5 tests pass locally against a throwaway pg16.
- Sets `TEST_DATABASE_URL` in the CI tests job (read-only SELECTs + rollback, so the service's maintenance DB is safe), replacing the deliberately-not-set comment.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VBWJ5NiAGc2MQ9U5NSzrW