### PR TITLE
fix(panel/config/deploy): CORS wildcard refused, reset_password admin guard, backup gate, sandbox route guard (#129)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -414,8 +414,12 @@ is pennies a month.
   (kernel older than 5.6, or a blocking seccomp profile), pgvector older
   than 0.8.0 (`ALTER EXTENSION vector UPDATE`), or `EMBEDDING_DIMENSIONS`
   disagreeing with the live embedding column (`make reset-embeddings`).
-  A placeholder `SECRET_KEY`, and `MCP_SANDBOX_MODE` set together with a
-  public `MCP_HOSTNAME`, are refused the same way.
+  A placeholder `SECRET_KEY`, and `MCP_SANDBOX_MODE` set together with
+  any public route — `MCP_HOSTNAME`, a non-loopback `BASE_URL`, or a
+  non-loopback entry in `ALLOWED_HOSTS` — are refused the same way. A
+  `*` in `ALLOWED_ORIGINS` is refused outright, sandbox or not: CORS
+  runs with credentials enabled, so a wildcard origin would make the
+  server reflect any Origin.
 - Transfer links 404 in the browser. The reverse proxy is not forwarding
   `/transfer/*` — see Step 2 for the bundled Caddy config and the
   external-proxy notes above. If the tools themselves refuse to mint,

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,11 @@ REGISTRY ?= localhost:5000
 FULL_IMAGE := $(REGISTRY)/$(IMAGE_NAME):$(IMAGE_TAG)
 DEPLOY_DIR ?= .
 DATA_DIR ?= ./data
+# Container running PostgreSQL, for db-backup / db-restore. The bundled
+# compose stacks (docker-compose.simple.yml / .proxy.yml) name it
+# `obsidian-mcp-postgres`; a shared host instance is usually just `postgres`.
+# Override in Makefile.local to match the deployment.
+DB_CONTAINER ?= postgres
 COMPOSE_FILE := $(DEPLOY_DIR)/docker-compose.yml
 ENV_FILE := $(DEPLOY_DIR)/.env
 COMPOSE := docker compose --project-directory $(DEPLOY_DIR) -f $(COMPOSE_FILE)
@@ -109,7 +114,13 @@ image: build trivy push
 
 deploy: image
 	@echo "$(GREEN)Deploying Obsidian MCP...$(NC)"
-	@$(MAKE) db-backup 2>/dev/null || true
+	# A deploy runs `alembic upgrade head` against the live database, so the
+	# backup is the only way back from a bad migration. If it cannot be taken,
+	# stop here rather than migrate unprotected.
+	@$(MAKE) db-backup || { \
+		echo "$(RED)Deploy ABORTED: database backup failed — refusing to migrate without one.$(NC)"; \
+		exit 1; \
+	}
 	# Migrate with the newly built image before replacing the live container.
 	# Migrations are backward-compatible, avoiding a window where new code runs
 	# against the old schema (and matching README's documented deploy behavior).
@@ -188,12 +199,35 @@ test-schema:
 	else echo "$(RED)Schema gate FAILED — do not deploy$(NC)"; fi; \
 	exit $$status
 
+# The pre-migration safety net, so it must fail loudly. The previous recipe
+# `|| true`d both pg_dump and gzip and printed the green line unconditionally,
+# so a wrong container name, a dead database or a full disk produced a
+# zero-byte file, a success message, and a `deploy` that went straight on to
+# `alembic upgrade head` with nothing to roll back to. Three failure modes are
+# now distinguished and all of them abort: a non-zero pg_dump, an empty dump
+# with exit 0 (pg_dump can write nothing and still succeed when it is pointed
+# at the wrong thing), and a failed gzip. The partial file is removed so a
+# later `db-restore` cannot pick a truncated dump out of the backups directory.
 db-backup:
-	@mkdir -p $(DATA_DIR)/backups 2>/dev/null || true
+	@mkdir -p $(DATA_DIR)/backups
 	@TIMESTAMP=$$(date +%Y%m%d_%H%M%S); \
 	BACKUP_FILE="$(DATA_DIR)/backups/backup_$$TIMESTAMP.sql"; \
-	docker exec postgres pg_dump -U postgres obsidian_mcp > $$BACKUP_FILE 2>/dev/null || true; \
-	gzip $$BACKUP_FILE 2>/dev/null || true; \
+	if ! docker exec $(DB_CONTAINER) pg_dump -U postgres obsidian_mcp > $$BACKUP_FILE; then \
+		rm -f $$BACKUP_FILE; \
+		echo "$(RED)Backup FAILED: pg_dump against container '$(DB_CONTAINER)' returned non-zero$(NC)"; \
+		echo "$(YELLOW)Set DB_CONTAINER in Makefile.local if the database container is named differently.$(NC)"; \
+		exit 1; \
+	fi; \
+	if [ ! -s $$BACKUP_FILE ]; then \
+		rm -f $$BACKUP_FILE; \
+		echo "$(RED)Backup FAILED: pg_dump produced an empty dump$(NC)"; \
+		exit 1; \
+	fi; \
+	if ! gzip $$BACKUP_FILE; then \
+		rm -f $$BACKUP_FILE $$BACKUP_FILE.gz; \
+		echo "$(RED)Backup FAILED: could not gzip $$BACKUP_FILE$(NC)"; \
+		exit 1; \
+	fi; \
 	echo "$(GREEN)Backup: $$BACKUP_FILE.gz$(NC)"
 
 db-restore:
@@ -202,9 +236,9 @@ db-restore:
 	@echo "Press Ctrl+C to cancel, waiting 5s..."
 	@sleep 5
 	@if echo "$(FILE)" | grep -q ".gz$$"; then \
-		gunzip -c $(FILE) | docker exec -i postgres psql -U postgres obsidian_mcp; \
+		gunzip -c $(FILE) | docker exec -i $(DB_CONTAINER) psql -U postgres obsidian_mcp; \
 	else \
-		docker exec -i postgres psql -U postgres obsidian_mcp < $(FILE); \
+		docker exec -i $(DB_CONTAINER) psql -U postgres obsidian_mcp < $(FILE); \
 	fi
 	@echo "$(GREEN)Restored from $(FILE)$(NC)"
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,3 +1,4 @@
+import ipaddress
 import resource
 import sys
 from typing import Annotated, Any, Literal
@@ -6,6 +7,29 @@ from urllib.parse import urlparse
 from pydantic import Field, PrivateAttr, field_validator, model_validator
 from pydantic.fields import FieldInfo
 from pydantic_settings import BaseSettings, NoDecode, PydanticBaseSettingsSource
+
+
+# Hostnames that can only ever name this machine. Used by the sandbox guard
+# below, which must fail *closed*: anything this cannot prove is loopback —
+# a name it does not recognise, a `*` wildcard that matches every name — is
+# treated as public, because the cost of a false positive is a refused boot
+# and the cost of a false negative is an unauthenticated vault.
+_LOOPBACK_HOSTNAMES = frozenset({"localhost", "::1", "0:0:0:0:0:0:0:1"})
+
+
+def _is_loopback_host(host: str) -> bool:
+    """True when `host` names only this machine (localhost, 127/8, ::1)."""
+    name = (host or "").strip().lower().rstrip(".")
+    if not name or "*" in name:
+        return False
+    if name.startswith("[") and name.endswith("]"):
+        name = name[1:-1]
+    if name in _LOOPBACK_HOSTNAMES:
+        return True
+    try:
+        return ipaddress.ip_address(name).is_loopback
+    except ValueError:
+        return False
 
 
 # Maximum size of a single note, in bytes. Lives here (rather than in
@@ -419,6 +443,35 @@ class Settings(BaseSettings):
         return self
 
     @model_validator(mode="after")
+    def _reject_wildcard_cors_origin(self) -> "Settings":
+        """Refuse a `*` entry in ALLOWED_ORIGINS.
+
+        `src/main.py` installs `CORSMiddleware(..., allow_credentials=True)`,
+        and Starlette reads `allow_origins=["*"]` alongside credentials as
+        "reflect whatever Origin the request carried" — it echoes the caller's
+        origin back in `Access-Control-Allow-Origin` and sets
+        `Access-Control-Allow-Credentials: true`. Every site the operator has
+        open in the same browser could then make credentialed cross-site
+        requests to the panel, the API and the OAuth endpoints and read the
+        responses. A wildcard is therefore not a permissive setting here, it
+        is the removal of the same-origin boundary the session cookie relies on.
+
+        This runs after `_derive_public_urls`, so `allowed_origins` is always
+        populated; the derived values (`https://$MCP_HOSTNAME`, or the
+        localhost fallback) are never `*`, so the refusal can only ever fire
+        on an explicit ALLOWED_ORIGINS override.
+        """
+        for origin in self.allowed_origins or ():
+            if str(origin).strip() == "*":
+                raise ValueError(
+                    'ALLOWED_ORIGINS must not contain "*". CORS is configured '
+                    "with allow_credentials=True, so a wildcard origin makes "
+                    "the server reflect any Origin and accept credentialed "
+                    "cross-site requests. List the exact origins instead."
+                )
+        return self
+
+    @model_validator(mode="after")
     def _validate_public_transport(self) -> "Settings":
         """Permit plaintext OAuth only for loopback development."""
         base = self.base_url.rstrip("/")
@@ -470,15 +523,55 @@ class Settings(BaseSettings):
         """Refuse to boot a publicly-routed deployment with auth disabled.
 
         MCP_SANDBOX_MODE bypasses all authentication on /mcp (registry-eval
-        only). Combined with a public MCP_HOSTNAME that would expose the
-        vault unauthenticated to the internet, so reject the combination at
+        only). Combined with a public route that would expose the vault
+        unauthenticated to the internet, so reject the combination at
         startup — analogous to the SECRET_KEY placeholder guard above.
+
+        MCP_HOSTNAME is not the only way to declare a public route, so all
+        three of the settings that admit outside traffic are checked:
+
+        * MCP_HOSTNAME — the Traefik/Caddy hostname;
+        * BASE_URL — the origin OAuth redirects and transfer links are built
+          on, which an operator can set without MCP_HOSTNAME;
+        * ALLOWED_HOSTS — what TrustedHostMiddleware will answer for, i.e.
+          the `Host` headers this process accepts at all.
+
+        This validator runs after `_derive_public_urls`, so it sees the
+        *effective* values. That is deliberate: the derived ones are
+        loopback (`http://localhost:8000`, `["localhost"]`) and never trip
+        the check, while an explicit env override does. `_is_loopback_host`
+        fails closed, so an unrecognised name or a `*` wildcard entry — which
+        makes TrustedHostMiddleware answer for every hostname — counts as
+        public.
         """
-        if self.mcp_sandbox_mode and (self.mcp_hostname or "").strip():
+        if not self.mcp_sandbox_mode:
+            return self
+
+        def _refuse(setting: str, detail: str) -> None:
             raise ValueError(
                 "MCP_SANDBOX_MODE disables all authentication on /mcp and must "
-                "never run on a publicly-routed deployment. Either unset "
-                "MCP_SANDBOX_MODE or remove MCP_HOSTNAME."
+                f"never run on a publicly-routed deployment. {setting} {detail}. "
+                f"Either unset MCP_SANDBOX_MODE or remove {setting}."
+            )
+
+        if (self.mcp_hostname or "").strip():
+            _refuse("MCP_HOSTNAME", "declares a public hostname")
+
+        base_host = urlparse(self.base_url or "").hostname or ""
+        if not _is_loopback_host(base_host):
+            _refuse("BASE_URL", f"names the non-loopback host '{base_host}'")
+
+        public_hosts = [
+            str(h).strip()
+            for h in (self.allowed_hosts or ())
+            if not _is_loopback_host(str(h))
+        ]
+        if public_hosts:
+            _refuse(
+                "ALLOWED_HOSTS",
+                "accepts the non-loopback host(s) " + ", ".join(
+                    repr(h) for h in public_hosts
+                ),
             )
         return self
 

--- a/src/control_panel/users.py
+++ b/src/control_panel/users.py
@@ -576,6 +576,20 @@ async def reset_password(
     if len(new_password) < 8:
         return _back_with_error(user_id, "New password must be at least 8 characters.")
 
+    # Same critical section as `edit_user_submit` and `delete_user`. A password
+    # reset is a full account takeover of the target — it rewrites the hash and
+    # bumps `session_version`, invalidating every live session — so an actor
+    # whose own admin access was revoked while this request queued must not get
+    # to perform it. `require_admin_panel` authorised the request before the
+    # lock was requested, and the wait for the lock is precisely the window in
+    # which another admin's demotion of *this* actor commits.
+    #
+    # The lock is transaction-scoped: nothing may commit between it and the
+    # write below.
+    await _lock_admin_guard(session)
+    if not await _actor_still_privileged(session, user):
+        await session.rollback()
+        return _back_to_list_with_error(_ACTOR_REVOKED_MSG)
     result = await session.execute(select(User).where(User.id == user_id))
     target = result.scalar_one_or_none()
     if target is None:

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -106,3 +106,109 @@ def test_unknown_dotenv_key_does_not_leak_into_settings(tmp_path):
     )
     settings = Settings(_env_file=str(env_file))
     assert "some_compose_only_key" not in settings.model_dump()
+
+
+# A non-placeholder SECRET_KEY, so `_validate_multi_user_secret` (which runs
+# before the sandbox guard) never pre-empts the refusal under test. Passing it
+# explicitly also keeps these cases independent of the host environment.
+_SECRET = "0123456789abcdef0123456789abcdef"
+
+
+# ── CORS wildcard (#129) ────────────────────────────────────────────────────
+# `src/main.py` installs CORSMiddleware with `allow_credentials=True`, which
+# makes Starlette treat `allow_origins=["*"]` as "reflect any Origin". The
+# derived values are never `*`, so the refusal only fires on an override.
+
+
+def test_wildcard_allowed_origin_is_refused():
+    with pytest.raises(ValidationError) as exc:
+        Settings(allowed_origins=["*"], secret_key=_SECRET, _env_file=None)
+    assert "ALLOWED_ORIGINS" in str(exc.value)
+    assert "allow_credentials" in str(exc.value)
+
+
+def test_wildcard_among_other_allowed_origins_is_refused():
+    with pytest.raises(ValidationError):
+        Settings(
+            allowed_origins=["https://mcp.example.com", " * "],
+            secret_key=_SECRET, _env_file=None,
+        )
+
+
+def test_explicit_allowed_origins_without_wildcard_still_boot():
+    settings = Settings(
+        allowed_origins=["https://mcp.example.com"],
+        secret_key=_SECRET, _env_file=None,
+    )
+    assert settings.allowed_origins == ["https://mcp.example.com"]
+
+
+def test_derived_allowed_origins_never_trip_the_wildcard_guard():
+    settings = Settings(mcp_hostname="mcp.example.com", secret_key=_SECRET, _env_file=None)
+    assert settings.allowed_origins == ["https://mcp.example.com"]
+    assert Settings(secret_key=_SECRET, _env_file=None).allowed_origins == ["http://localhost:8000"]
+
+
+# ── Sandbox mode may only ever be loopback (#129) ───────────────────────────
+# MCP_SANDBOX_MODE bypasses authentication on /mcp, so every setting that can
+# admit outside traffic has to be loopback — not just MCP_HOSTNAME.
+
+
+def test_sandbox_mode_refuses_public_hostname():
+    with pytest.raises(ValidationError) as exc:
+        Settings(mcp_sandbox_mode=True, mcp_hostname="mcp.example.com", secret_key=_SECRET, _env_file=None)
+    assert "MCP_HOSTNAME" in str(exc.value)
+
+
+def test_sandbox_mode_refuses_public_base_url():
+    with pytest.raises(ValidationError) as exc:
+        Settings(
+            mcp_sandbox_mode=True,
+            base_url="https://mcp.example.com",
+            secret_key=_SECRET, _env_file=None,
+        )
+    assert "BASE_URL" in str(exc.value)
+
+
+def test_sandbox_mode_refuses_public_allowed_host():
+    with pytest.raises(ValidationError) as exc:
+        Settings(
+            mcp_sandbox_mode=True,
+            allowed_hosts=["mcp.example.com"],
+            secret_key=_SECRET, _env_file=None,
+        )
+    assert "ALLOWED_HOSTS" in str(exc.value)
+
+
+def test_sandbox_mode_refuses_wildcard_allowed_host():
+    # `*` makes TrustedHostMiddleware answer for every hostname, which is the
+    # most public setting there is.
+    with pytest.raises(ValidationError) as exc:
+        Settings(mcp_sandbox_mode=True, allowed_hosts=["*"], secret_key=_SECRET, _env_file=None)
+    assert "ALLOWED_HOSTS" in str(exc.value)
+
+
+def test_sandbox_mode_with_defaults_still_boots():
+    settings = Settings(mcp_sandbox_mode=True, secret_key=_SECRET, _env_file=None)
+    assert settings.base_url == "http://localhost:8000"
+    assert settings.allowed_hosts == ["localhost"]
+
+
+@pytest.mark.parametrize("base_url", ["http://localhost:8000", "http://127.0.0.1:9000"])
+def test_sandbox_mode_with_loopback_base_url_still_boots(base_url):
+    settings = Settings(mcp_sandbox_mode=True, base_url=base_url, secret_key=_SECRET, _env_file=None)
+    assert settings.mcp_sandbox_mode is True
+
+
+def test_sandbox_mode_with_loopback_allowed_hosts_still_boots():
+    settings = Settings(
+        mcp_sandbox_mode=True,
+        allowed_hosts=["127.0.0.1", "::1"],
+        secret_key=_SECRET, _env_file=None,
+    )
+    assert settings.allowed_hosts == ["127.0.0.1", "::1", "localhost"]
+
+
+def test_public_hostname_without_sandbox_mode_is_unaffected():
+    settings = Settings(mcp_hostname="mcp.example.com", secret_key=_SECRET, _env_file=None)
+    assert settings.allowed_hosts == ["mcp.example.com", "localhost"]

--- a/tests/test_nested_mount_publication.py
+++ b/tests/test_nested_mount_publication.py
@@ -444,7 +444,13 @@ def test_nested_mount_cases_pass_in_a_mount_namespace(tmp_path):
         "HOME": str(tmp_path),
         "MCP_SANDBOX_MODE": "true",
         "VAULT_PATH": str(vault),
-        "BASE_URL": "https://vault.example.test",
+        # Loopback, and explicitly set: the mint tools only need
+        # `public_base_url` to be non-None (they assert nothing about the
+        # host), while MCP_SANDBOX_MODE — which this harness needs to skip
+        # auth and Postgres — refuses to boot beside a *public* BASE_URL
+        # (#129). A non-loopback value here would abort the subprocess at
+        # import of `src.config`.
+        "BASE_URL": "http://localhost:8000",
         "DATABASE_URL": "postgresql+asyncpg://test:test@localhost/test",
         "SECRET_KEY": "test",
         "MCP_HOSTNAME": "",

--- a/tests/test_security_review_followups.py
+++ b/tests/test_security_review_followups.py
@@ -6,6 +6,7 @@ import pytest
 from src.auth.session import get_current_user
 from src.control_panel import users as panel_users
 from src.mcp_server import tools
+from src.models.db import User
 from src.oauth import routes as oauth_routes
 from src.services import embeddings, search
 
@@ -109,6 +110,73 @@ async def test_password_reset_bumps_session_version(monkeypatch):
     assert target.password_hash == "new-hash"
     assert target.session_version == 4
     db.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_password_reset_takes_the_admin_guard_lock(monkeypatch):
+    """#129: the reset enters the same critical section as edit/delete.
+
+    A password reset rewrites the target's hash and bumps `session_version`,
+    which is a full account takeover — it must not run for an actor whose own
+    admin access was revoked while the request waited for the lock.
+    """
+    actor = User(id=1, username="admin", is_admin=True, is_active=True)
+    lock = MagicMock()
+    actor_row = MagicMock()
+    actor_row.one_or_none.return_value = SimpleNamespace(
+        is_admin=True, is_active=True
+    )
+    target = SimpleNamespace(
+        id=7, password_hash="old", session_version=3, username="alice"
+    )
+    target_row = MagicMock()
+    target_row.scalar_one_or_none.return_value = target
+    db = AsyncMock()
+    db.execute.side_effect = [lock, actor_row, target_row]
+    monkeypatch.setattr(panel_users, "hash_password", lambda _password: "new-hash")
+
+    response = await panel_users.reset_password(
+        user_id=7,
+        new_password="new-password",
+        session=db,
+        user=actor,
+    )
+
+    assert response.status_code == 303
+    # The advisory lock is the *first* statement, before the actor is re-read
+    # and before the target row is loaded.
+    assert "pg_advisory_xact_lock" in str(db.execute.await_args_list[0].args[0])
+    assert target.password_hash == "new-hash"
+    db.commit.assert_awaited_once()
+    db.rollback.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_password_reset_refuses_an_actor_demoted_while_queued(monkeypatch):
+    """#129: `_actor_still_privileged` runs inside the lock, and refuses."""
+    actor = User(id=1, username="admin", is_admin=True, is_active=True)
+    lock = MagicMock()
+    actor_row = MagicMock()
+    actor_row.one_or_none.return_value = SimpleNamespace(
+        is_admin=False, is_active=True
+    )
+    db = AsyncMock()
+    db.execute.side_effect = [lock, actor_row]
+    monkeypatch.setattr(panel_users, "hash_password", lambda _password: "new-hash")
+
+    response = await panel_users.reset_password(
+        user_id=7,
+        new_password="new-password",
+        session=db,
+        user=actor,
+    )
+
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/admin/users/?error=")
+    # Nothing was written and the target was never even loaded.
+    assert db.execute.await_count == 2
+    db.rollback.assert_awaited_once()
+    db.commit.assert_not_awaited()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Four verified findings from #129 (found by #122 tiers 1a/2/3, adversarially verified):

- **CORS `*` refused at startup** — `allow_credentials=True` makes Starlette reflect any Origin for `allow_origins=["*"]`; a new model validator refuses a wildcard entry. Derived origins can never trip it.
- **`reset_password` takes `_lock_admin_guard` + `_actor_still_privileged`** — same critical-section idiom as `edit_user_submit`/`delete_user`; a demoted actor's in-flight reset now refuses instead of committing an account takeover.
- **`make deploy` aborts when the backup fails** — `db-backup` no longer `|| true`s pg_dump/gzip: non-zero pg_dump, empty dump, and failed gzip all abort and remove the partial file; `deploy` refuses to migrate without a backup. New `DB_CONTAINER ?= postgres` (bundled stacks use `obsidian-mcp-postgres`; override in Makefile.local).
- **Sandbox guard widened** — `MCP_SANDBOX_MODE` now also refuses a non-loopback `BASE_URL` or `ALLOWED_HOSTS` entry (fail-closed loopback classifier; `*` counts as public), not just `MCP_HOSTNAME`.

Collateral: the nested-mount harness's `BASE_URL` moves to loopback (it only needs a non-None public_base_url); DEPLOYMENT.md updated. +17 tests, no regressions (1784 passed vs 1769 baseline).

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VBWJ5NiAGc2MQ9U5NSzrW