### PR TITLE
fix(make): honor a changed .env in reset-embeddings / rebuild-tsvectors (#142)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -269,16 +269,23 @@ reindex:
 	@echo ""
 	@echo "  To restart the indexer instead: make restart"
 
+# `run --rm`, not `exec` (#142): `exec` runs inside the LIVE container, whose
+# environment was baked at creation — a changed .env (EMBEDDING_DIMENSIONS,
+# FTS_CONFIGS) is invisible to it, so the reset recreated the column at the
+# OLD dim and the rebuild indexed under the OLD configs. `run --rm` starts a
+# fresh container that re-reads .env, and also works while the service is
+# down — which matters here, because a dim-mismatched container exits at
+# startup and a dead container cannot be exec'd into.
 reset-embeddings:
 	@echo "$(YELLOW)Resetting embeddings — column will be recreated at EMBEDDING_DIMENSIONS$(NC)"
 	@echo "Press Ctrl+C to cancel, waiting 5s..."
 	@sleep 5
-	$(COMPOSE) exec obsidian-mcp python -m scripts.reset_embeddings
+	$(COMPOSE) run --rm obsidian-mcp python -m scripts.reset_embeddings
 	@echo "$(GREEN)Done. The next indexer pass will re-embed all notes.$(NC)"
 
 rebuild-tsvectors:
 	@echo "$(YELLOW)Rebuilding keyword (FTS) index for the configured FTS_CONFIGS...$(NC)"
-	$(COMPOSE) exec obsidian-mcp python -m scripts.rebuild_tsvectors
+	$(COMPOSE) run --rm obsidian-mcp python -m scripts.rebuild_tsvectors
 	@echo "$(GREEN)Done. Keyword search now reflects FTS_CONFIGS (embeddings untouched, no API calls).$(NC)"
 
 status:

--- a/README.md
+++ b/README.md
@@ -765,28 +765,22 @@ the transport limit follows.
 Different models produce non-comparable vectors, so a provider switch
 requires reindexing.
 
-**Same `EMBEDDING_DIMENSIONS`** (just a different provider or model):
+Whether or not `EMBEDDING_DIMENSIONS` changes, the steps are the same:
 
-1. Update `.env` — `EMBEDDING_PROVIDER`, credentials, model name.
-2. `make reset-embeddings`, **while the old container is still up**. The
-   target is `docker compose exec`, so it needs a running container;
-   `make down` first and it fails.
+1. Update `.env` — `EMBEDDING_PROVIDER`, credentials, model name, and
+   `EMBEDDING_DIMENSIONS` if it differs.
+2. `make reset-embeddings`. The target is `docker compose run --rm`, so
+   it starts a one-off container that reads your edited `.env` — it
+   works whether the service is up or down, and recreates the column at
+   the *new* dimension.
 3. `make deploy` (or `docker compose up -d --force-recreate`). The next
    indexer pass re-embeds the vault.
 
-**Also changing `EMBEDDING_DIMENSIONS`** — one extra wrinkle, because
-`docker compose exec` runs inside the *existing* container and sees the
-environment baked in when that container was created, not your edited
-`.env`. Use a one-off container, which does read the new `.env`:
-
-1. Update `.env`, including `EMBEDDING_DIMENSIONS`.
-2. `docker compose run --rm obsidian-mcp python -m scripts.reset_embeddings`
-3. `make deploy` (or `docker compose up -d --force-recreate`).
-
-Do **not** recreate the container before the reset. The startup
-dimension guard compares the live column width against
-`EMBEDDING_DIMENSIONS` and `sys.exit(1)`s on a mismatch, and a container
-that has exited cannot be `exec`ed into.
+When changing `EMBEDDING_DIMENSIONS`, run the reset **before**
+recreating the container: the startup dimension guard compares the live
+column width against `EMBEDDING_DIMENSIONS` and `sys.exit(1)`s on a
+mismatch, so a recreated-first container just exits until the reset has
+run.
 
 You can also use Settings → Danger zone → Reset embeddings in the
 control panel, which performs the same SQL while the server is running


### PR DESCRIPTION
`compose exec` uses the live container's baked env, so `make reset-embeddings` with a changed `EMBEDDING_DIMENSIONS` recreated the column at the old dim, and — same class, found while fixing — `make rebuild-tsvectors` with a changed `FTS_CONFIGS` rebuilt under the old configs (silently wrong keyword search). Both now use `compose run --rm` (re-reads `.env`, works with the service down, verified semantics per #131's empirical test). README provider-switch steps collapse to one flow.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VBWJ5NiAGc2MQ9U5NSzrW