### PR TITLE
fix(panel): flash/error messages travel in the session, not the query string (#138)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,6 +332,22 @@ vanished from the page, so the operator saw a blank space that read as success.
 - API keys use `omcp_` prefix, stored as SHA-256 hashes
 - Panel/OAuth passwords: direct `bcrypt` (`$2b$`, cost 12); both hash and verify truncate the UTF-8 encoding at 72 bytes and reject NUL bytes — passlib's historical semantics — so existing hashes stay valid; don't "fix" the truncation.
 - **OAuth consent preselects "Read only" unconditionally — never bind `checked` to the requested scope.** On an HTML form the checked radio *is* the submitted value, so the preselect is the default grant, not a display detail. `/register` is unauthenticated and a DCR client that omits `scope` is registered `read readwrite offline_access`, so a requested-scope preselect lets one unchanged **Approve** click hand vault-wide write to any self-registered client (#63; #62 introduced exactly that and it was reverted). What #62 was right about is kept as *prose*: `authorize_get` passes `requested_write` (from the validated scope alone, ungated by the registered scope — display only) and `write_unavailable`, and the request box names the level asked for and says when the client cannot hold it. `_clamp_scope` in `authorize_post` is the enforcement boundary and is unrelated to any of this. The markup default is not enough on its own: Firefox restores a control's dynamic checked state across page loads in preference to it, so the form **and** every `name="scope"` radio carry `autocomplete="off"` — without them a user who once picked write gets that radio re-checked on a repeat visit to the same `/authorize` URL (clients reuse `state`/PKCE) and one Approve re-grants write after a revocation. The `.scope-option:has(:checked)` highlight lives in standalone rule blocks: a selector list is dropped wholesale when any part fails to parse, so grouping it would take the native-radio fallback down with it.
+- **Panel flash messages ride the session, never the query string** (#138,
+  A6 of #130). `src/control_panel/flash.py` holds the pair — `flash(request,
+  message, kind)` before the redirect, `pop_flash` called from *one* place,
+  `_panel_context`, so every panel render pops exactly once and a message is
+  shown once and gone on reload. The old `?flash=` / `?error=` /
+  `&flash_kind=err` was escaped by Jinja and so was never an XSS; the defect
+  is that a crafted link chose what an authenticated admin read, on the page
+  whose controls delete accounts, and survived every reload and re-share of
+  the URL. Templates must render the context variable and never
+  `request.query_params` — `tests/test_issue_138_session_flash.py` sweeps
+  `src/control_panel`, `src/api` and `src/auth` for both halves. Untouched by
+  this: the login and bootstrap pages, which pass `error` straight into the
+  same response they render (no redirect, nothing in a URL), and every OAuth
+  `error=` — those are protocol parameters on a redirect to the *client*, not
+  panel flash. The pre-existing `flash_new_key` / `flash_key_error` /
+  `flash_oauth_error` session entries keep their own dedicated render slots.
 - Vault mounted read-write at /obsidian in container
 - Read responses are capped in characters (`MAX_READ_RESPONSE_CHARS`, default
   40,000) independently of the byte caps on disk I/O — see "Three kinds of size

--- a/src/control_panel/flash.py
+++ b/src/control_panel/flash.py
@@ -1,0 +1,79 @@
+"""One-shot panel flash messages, carried in the session and not the URL.
+
+The panel's post-redirect-get messages used to ride the query string
+(`/admin/users/?flash=…`, `?error=…`, `&flash_kind=err`) and the templates
+rendered whatever was there. Jinja escapes it, so there was no XSS — but the
+*text* an authenticated admin reads was chosen by whoever composed the link.
+A crafted `/admin/users/?flash=Vault reassigned — click Delete to finish` is
+a message from the server as far as the page is concerned, on the one surface
+whose controls delete accounts (#138, A6 of #130).
+
+So the message travels in the session cookie instead, which only this server
+can write:
+
+- `flash(request, message, kind=…)` stores it, immediately before returning
+  the redirect;
+- `pop_flash(request)` takes it back out, and `_panel_context` in
+  `src/control_panel/routes.py` is the only caller — every panel render pops
+  exactly once, so a flash is shown once and is gone on reload. A query
+  parameter survived every reload and every re-share of the URL.
+
+Two shapes are deliberate. **One entry, last write wins**: no handler emits
+two messages, and a queue would let an abandoned redirect's message surface
+on an unrelated page much later. And **the session may be absent**: some unit
+-test harnesses build an app with no `SessionMiddleware`, where
+`request.session` raises. Both helpers swallow that, exactly as
+`create_key_form` and `_flash_oauth_error` already do — a message going
+unshown must never turn a completed action into a 500.
+"""
+from typing import Any
+
+from starlette.requests import Request
+
+# The session key. Namespaced so it cannot collide with `user_id`,
+# `session_version`, `flash_new_key` or anything else parked in the cookie.
+FLASH_SESSION_KEY = "panel_flash"
+
+# `ok` renders as a success alert, `err` as a warning one. Anything else is
+# read as `ok` on the way out rather than rendered as an unknown class.
+OK = "ok"
+ERR = "err"
+
+
+def flash(request: Request | None, message: str, kind: str = OK) -> None:
+    """Park `message` for the next panel render of this session.
+
+    `request` is tolerated as `None` because a handler may be called without
+    one (unit tests, and `update_oauth_token_scope`'s `Request | None`
+    signature): there is then nowhere to put the message, and the redirect
+    still happens. The refusal itself never depends on the flash.
+    """
+    if request is None or not message:
+        return
+    if kind not in (OK, ERR):
+        kind = OK
+    try:
+        request.session[FLASH_SESSION_KEY] = {"message": str(message), "kind": kind}
+    except (AssertionError, AttributeError):
+        # No SessionMiddleware in this app (some unit-test harnesses).
+        pass
+
+
+def pop_flash(request: Request | None) -> tuple[str | None, str]:
+    """Return `(message, kind)` and remove it. `(None, "ok")` if there is none."""
+    if request is None:
+        return None, OK
+    try:
+        raw: Any = request.session.pop(FLASH_SESSION_KEY, None)
+    except (AssertionError, AttributeError):
+        return None, OK
+    if not isinstance(raw, dict):
+        # A shape written by an older deploy, or nothing at all. The cookie is
+        # signed, so this is never attacker-chosen — but it must not 500 the
+        # page either.
+        return None, OK
+    message = raw.get("message")
+    if not isinstance(message, str) or not message:
+        return None, OK
+    kind = raw.get("kind")
+    return message, kind if kind in (OK, ERR) else OK

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.auth.session import _SingleUserSentinel, get_current_user
 from src.config import settings
+from src.control_panel.flash import pop_flash
 from src.csrf import generate_csrf_token, verify_csrf
 from src.database import async_session, get_session
 from src.mcp_server.auth import hash_key
@@ -205,12 +206,21 @@ def _panel_context(
     user sentinel has `username="admin"` and `is_admin=True`, so
     `base.html`'s `{% if multi_user_mode and username %}` user-badge block
     stays hidden in single-user mode regardless of how it's rendered.
+
+    It is also the **only** place a panel flash is read (#138). Every render
+    pops the session entry, so a message set before a redirect is shown once
+    and is gone on reload — and, because it comes from the session, nothing
+    a link can carry ever reaches the page. An `extra` may still override
+    `flash`/`flash_kind` explicitly; nothing does today.
     """
+    flash_message, flash_kind = pop_flash(request)
     ctx: dict[str, Any] = {
         "is_admin": bool(user.is_admin),
         "username": user.username,
         "multi_user_mode": bool(settings.multi_user_mode),
         "csrf_token": generate_csrf_token(request),
+        "flash": flash_message,
+        "flash_kind": flash_kind,
     }
     if extra:
         ctx.update(extra)

--- a/src/control_panel/templates/user_edit.html
+++ b/src/control_panel/templates/user_edit.html
@@ -11,11 +11,11 @@
 
 <div class="page-body">
 
+    {# One session-backed flash (#138), never a query parameter. `flash_kind`
+       picks the styling — `err` is the refusal case the old `?error=` param
+       carried. Both come from `_panel_context`, which pops them. #}
     {% if flash %}
-    <div class="alert alert-success anim-1">{{ flash }}</div>
-    {% endif %}
-    {% if error %}
-    <div class="alert alert-warning anim-1">{{ error }}</div>
+    <div class="alert {% if flash_kind == 'err' %}alert-warning{% else %}alert-success{% endif %} anim-1">{{ flash }}</div>
     {% endif %}
 
     <div class="split-2">

--- a/src/control_panel/templates/users.html
+++ b/src/control_panel/templates/users.html
@@ -16,11 +16,11 @@
 
 <div class="page-body">
 
+    {# One session-backed flash (#138), never a query parameter. `flash_kind`
+       picks the styling — `err` is the refusal case the old `?error=` param
+       carried. Both come from `_panel_context`, which pops them. #}
     {% if flash %}
-    <div class="alert alert-success anim-1">{{ flash }}</div>
-    {% endif %}
-    {% if error %}
-    <div class="alert alert-warning anim-1">{{ error }}</div>
+    <div class="alert {% if flash_kind == 'err' %}alert-warning{% else %}alert-success{% endif %} anim-1">{{ flash }}</div>
     {% endif %}
 
     <div class="card anim-1">

--- a/src/control_panel/users.py
+++ b/src/control_panel/users.py
@@ -37,6 +37,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.auth.passwords import hash_password
 from src.auth.session import _SingleUserSentinel
 from src.config import settings
+from src.control_panel.flash import ERR, flash
 from src.control_panel.routes import _panel_context, require_admin_panel
 from src.csrf import verify_csrf
 from src.database import get_session
@@ -226,21 +227,19 @@ async def list_users(
             "notes": note_counts.get(u.id, 0),
         })
 
-    flash = request.query_params.get("flash")
-    flash_kind = request.query_params.get("flash_kind", "ok")
-    error = request.query_params.get("error")
-
+    # `flash` / `flash_kind` come from the session, through `_panel_context`
+    # (#138). Reading them from `request.query_params` let a crafted link
+    # choose what an authenticated admin read on the page whose controls
+    # delete accounts.
     return templates.TemplateResponse(request, "users.html", _panel_context(request, user, {
         "active": "users",
         "users": users,
-        "flash": flash,
-        "flash_kind": flash_kind,
-        "error": error,
     }))
 
 
 @router.post("/create")
 async def create_user(
+    request: Request,
     username: str = Form(...),
     initial_password: str = Form(...),
     session: AsyncSession = Depends(get_session),
@@ -248,21 +247,19 @@ async def create_user(
 ):
     normalized = (username or "").strip().lower()
     if not _USERNAME_RE.match(normalized):
-        return RedirectResponse(
-            "/admin/users/?error=" + _q("Username must be 1–64 chars, lowercase letters / digits / underscores only."),
-            status_code=303,
+        return _back_to_list_with_error(
+            request,
+            "Username must be 1–64 chars, lowercase letters / digits / underscores only.",
         )
     if len(initial_password) < 8:
-        return RedirectResponse(
-            "/admin/users/?error=" + _q("Initial password must be at least 8 characters."),
-            status_code=303,
+        return _back_to_list_with_error(
+            request, "Initial password must be at least 8 characters."
         )
 
     existing = (await session.execute(select(User.id).where(User.username == normalized))).scalar_one_or_none()
     if existing is not None:
-        return RedirectResponse(
-            "/admin/users/?error=" + _q(f"Username '{normalized}' already exists."),
-            status_code=303,
+        return _back_to_list_with_error(
+            request, f"Username '{normalized}' already exists."
         )
 
     new_user = User(
@@ -277,14 +274,12 @@ async def create_user(
         await session.commit()
     except IntegrityError:
         await session.rollback()
-        return RedirectResponse(
-            "/admin/users/?error=" + _q("Could not create user (DB integrity error)."),
-            status_code=303,
+        return _back_to_list_with_error(
+            request, "Could not create user (DB integrity error)."
         )
 
-    return RedirectResponse(
-        f"/admin/users/?flash=" + _q(f"User '{normalized}' created. Set their vault path next."),
-        status_code=303,
+    return _back_to_list(
+        request, f"User '{normalized}' created. Set their vault path next."
     )
 
 
@@ -306,8 +301,7 @@ async def edit_user_form(
     if target.vault_path and target.vault_path not in available_vaults:
         available_vaults.insert(0, target.vault_path)
 
-    error = request.query_params.get("error")
-    flash = request.query_params.get("flash")
+    # Same as `list_users`: the flash rides the session, not the URL (#138).
     return templates.TemplateResponse(request, "user_edit.html", _panel_context(request, user, {
         "active": "users",
         "target": {
@@ -319,14 +313,13 @@ async def edit_user_form(
         },
         "available_vaults": available_vaults,
         "is_self": (isinstance(user, User) and user.id == target.id),
-        "error": error,
-        "flash": flash,
     }))
 
 
 @router.post("/{user_id}/edit")
 async def edit_user_submit(
     user_id: int,
+    request: Request,
     vault_path: str = Form(""),
     vault_path_custom: str = Form(""),
     # `None` means the field was **absent** from the submission; "" means it
@@ -348,7 +341,7 @@ async def edit_user_submit(
     await _lock_admin_guard(session)
     if not await _actor_still_privileged(session, user):
         await session.rollback()
-        return _back_to_list_with_error(_ACTOR_REVOKED_MSG)
+        return _back_to_list_with_error(request, _ACTOR_REVOKED_MSG)
     result = await session.execute(select(User).where(User.id == user_id))
     target = result.scalar_one_or_none()
     if target is None:
@@ -382,11 +375,13 @@ async def edit_user_submit(
     if is_self:
         if is_admin is not None and target.is_admin and not new_admin:
             return _back_with_error(
+                request,
                 user_id,
                 "You can't remove your own admin role. Ask another admin to do it.",
             )
         if is_active is not None and target.is_active and not new_active:
             return _back_with_error(
+                request,
                 user_id,
                 "You can't deactivate your own account. Ask another admin to do it.",
             )
@@ -411,22 +406,25 @@ async def edit_user_submit(
             # flags; kept as a backstop if that guard is ever relaxed.
             if is_self:
                 return _back_with_error(
+                    request,
                     user_id,
                     "Refusing to remove the last admin (yourself). Promote another user to admin first.",
                 )
             return _back_with_error(
-                user_id, "Refusing to demote or deactivate the last active admin."
+                request,
+                user_id,
+                "Refusing to demote or deactivate the last active admin.",
             )
 
     normalized, err = _validate_vault_path(vault_path)
     if err:
-        return _back_with_error(user_id, err)
+        return _back_with_error(request, user_id, err)
     if normalized:
         uniq_err = await _check_vault_path_unique(
             session, normalized, exclude_user_id=target.id
         )
         if uniq_err:
-            return _back_with_error(user_id, uniq_err)
+            return _back_with_error(request, user_id, uniq_err)
 
     old_vault = target.vault_path
     target.vault_path = normalized
@@ -437,17 +435,14 @@ async def edit_user_submit(
         await session.commit()
     except IntegrityError:
         await session.rollback()
-        return _back_with_error(user_id, "Database integrity error (vault path may not be unique).")
+        return _back_with_error(request, user_id, "Database integrity error (vault path may not be unique).")
 
     # Invalidate the in-process vault cache so the next indexer pass and
     # any authenticated request resolves the new path.
     if old_vault != normalized:
         clear_user_vault_cache(target.id)
 
-    return RedirectResponse(
-        f"/admin/users/?flash=" + _q(f"Updated user '{target.username}'."),
-        status_code=303,
-    )
+    return _back_to_list(request, f"Updated user '{target.username}'.")
 
 
 @router.post("/{user_id}/delete")
@@ -498,7 +493,7 @@ async def delete_user(
     await _lock_admin_guard(session)
     if not await _actor_still_privileged(session, user):
         await session.rollback()
-        return _back_to_list_with_error(_ACTOR_REVOKED_MSG)
+        return _back_to_list_with_error(request, _ACTOR_REVOKED_MSG)
     result = await session.execute(select(User).where(User.id == user_id))
     target = result.scalar_one_or_none()
     if target is None:
@@ -517,6 +512,7 @@ async def delete_user(
     # is the same `isinstance` test `edit_user_submit` uses.
     if isinstance(user, User) and user.id == target.id:
         return _back_to_list_with_error(
+            request,
             "You can't delete or deactivate your own account — neither the "
             "soft delete nor the permanent one. Ask another admin to remove it."
         )
@@ -545,6 +541,7 @@ async def delete_user(
         )).scalar() or 0
         if remaining_admins == 0:
             return _back_to_list_with_error(
+                request,
                 "Refusing to delete the last active admin — promote someone else first."
             )
 
@@ -569,29 +566,26 @@ async def delete_user(
         await session.delete(target)
         await session.commit()
         clear_user_vault_cache(target.id)
-        return RedirectResponse(
-            f"/admin/users/?flash=" + _q(f"User '{target.username}' permanently deleted."),
-            status_code=303,
+        return _back_to_list(
+            request, f"User '{target.username}' permanently deleted."
         )
 
     target.is_active = False
     await session.commit()
     clear_user_vault_cache(target.id)
-    return RedirectResponse(
-        f"/admin/users/?flash=" + _q(f"User '{target.username}' deactivated."),
-        status_code=303,
-    )
+    return _back_to_list(request, f"User '{target.username}' deactivated.")
 
 
 @router.post("/{user_id}/reset-password")
 async def reset_password(
     user_id: int,
+    request: Request,
     new_password: str = Form(...),
     session: AsyncSession = Depends(get_session),
     user: User | _SingleUserSentinel = Depends(require_admin_panel),
 ):
     if len(new_password) < 8:
-        return _back_with_error(user_id, "New password must be at least 8 characters.")
+        return _back_with_error(request, user_id, "New password must be at least 8 characters.")
 
     # Same critical section as `edit_user_submit` and `delete_user`. A password
     # reset is a full account takeover of the target — it rewrites the hash and
@@ -606,7 +600,7 @@ async def reset_password(
     await _lock_admin_guard(session)
     if not await _actor_still_privileged(session, user):
         await session.rollback()
-        return _back_to_list_with_error(_ACTOR_REVOKED_MSG)
+        return _back_to_list_with_error(request, _ACTOR_REVOKED_MSG)
     result = await session.execute(select(User).where(User.id == user_id))
     target = result.scalar_one_or_none()
     if target is None:
@@ -616,30 +610,23 @@ async def reset_password(
     target.session_version += 1
     await session.commit()
 
-    return RedirectResponse(
-        f"/admin/users/?flash=" + _q(f"Password reset for '{target.username}'."),
-        status_code=303,
-    )
+    return _back_to_list(request, f"Password reset for '{target.username}'.")
 
 
 # --- Internal helpers -----------------------------------------------------
 
 
-def _q(s: str) -> str:
-    """Minimal URL-encode for the flash/error querystrings."""
-    from urllib.parse import quote
-    return quote(s)
+def _back_to_list(request: Request | None, msg: str) -> RedirectResponse:
+    """Success redirect to the list, with the message in the session (#138)."""
+    flash(request, msg)
+    return RedirectResponse("/admin/users/", status_code=303)
 
 
-def _back_with_error(user_id: int, msg: str) -> RedirectResponse:
-    return RedirectResponse(
-        f"/admin/users/{user_id}/edit?error={_q(msg)}",
-        status_code=303,
-    )
+def _back_with_error(request: Request | None, user_id: int, msg: str) -> RedirectResponse:
+    flash(request, msg, ERR)
+    return RedirectResponse(f"/admin/users/{user_id}/edit", status_code=303)
 
 
-def _back_to_list_with_error(msg: str) -> RedirectResponse:
-    return RedirectResponse(
-        f"/admin/users/?error={_q(msg)}&flash_kind=err",
-        status_code=303,
-    )
+def _back_to_list_with_error(request: Request | None, msg: str) -> RedirectResponse:
+    flash(request, msg, ERR)
+    return RedirectResponse("/admin/users/", status_code=303)

--- a/tests/test_issue_138_session_flash.py
+++ b/tests/test_issue_138_session_flash.py
@@ -1,0 +1,454 @@
+"""Regression test (#138): panel flash messages live in the session, not the URL.
+
+The panel's post-redirect-get messages used to travel as `?flash=` / `?error=`
+(with `&flash_kind=err` for a refusal) and the templates rendered whatever the
+query string carried. Jinja escapes it, so there was never an XSS — the defect
+is that the *text* an authenticated admin reads was chosen by whoever composed
+the link, on the one page whose controls delete accounts. A crafted
+`/admin/users/?flash=…` is indistinguishable from a message the server wrote.
+
+What must hold now:
+
+- a handler parks the message in `request.session` and redirects to a bare
+  path — nothing about the message is in the URL;
+- `_panel_context` pops it, so it renders exactly once and is gone on reload;
+- a `?flash=` / `?error=` / `?flash_kind=` a link carries is rendered nowhere.
+
+The requests here are real `starlette.requests.Request` objects over a
+hand-built scope, with the `session` dict `SessionMiddleware` would install —
+so `request.query_params` parses the query string exactly as it does in
+production, which is the half a plain fake object cannot exercise.
+"""
+import ast
+import asyncio
+import os
+import re
+from datetime import datetime, timezone
+
+import pydantic_settings
+
+_orig_init = pydantic_settings.BaseSettings.__init__
+
+
+def _no_env_file_init(self, *args, **kwargs):
+    kwargs.setdefault("_env_file", None)
+    _orig_init(self, *args, **kwargs)
+
+
+pydantic_settings.BaseSettings.__init__ = _no_env_file_init
+try:
+    from starlette.requests import Request
+
+    from src.control_panel import routes as panel_routes
+    from src.control_panel import users as users_mod
+    from src.control_panel.flash import (
+        ERR,
+        FLASH_SESSION_KEY,
+        OK,
+        flash,
+        pop_flash,
+    )
+    from src.models.db import User
+finally:
+    pydantic_settings.BaseSettings.__init__ = _orig_init
+
+
+PANEL_DIR = os.path.dirname(users_mod.__file__)
+
+
+# --- Fakes ----------------------------------------------------------------
+
+
+def _request(path: str = "/admin/users/", query: str = "", session=None) -> Request:
+    """A real `Request` carrying the session dict SessionMiddleware installs."""
+    scope = {
+        "type": "http",
+        "http_version": "1.1",
+        "method": "GET",
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "path": path,
+        "root_path": "",
+        "query_string": query.encode(),
+        "headers": [],
+        "session": {} if session is None else session,
+    }
+    return Request(scope)
+
+
+class _NoSessionRequest:
+    """An app built without SessionMiddleware — `request.session` raises."""
+
+    @property
+    def session(self):
+        raise AssertionError("SessionMiddleware must be installed")
+
+
+class _Rows:
+    """Serves both `.all()` and `.scalars().all()`."""
+
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+    def scalars(self):
+        return self
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+
+class _FakeSession:
+    """Answers `list_users`' three queries: key counts, note counts, users."""
+
+    def __init__(self, users):
+        self._users = users
+        self._n = 0
+
+    async def execute(self, *_a, **_k):
+        self._n += 1
+        if self._n <= 2:
+            return _Rows([])
+        return _Rows(self._users)
+
+
+class _EditSession:
+    async def execute(self, *_a, **_k):
+        return _Rows([_a_user()])
+
+
+def _a_user() -> User:
+    u = User(
+        username="bob",
+        password_hash="x",
+        is_admin=False,
+        is_active=True,
+        vault_path=None,
+    )
+    u.id = 2
+    u.created_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    u.last_login_at = None
+    return u
+
+
+def _an_admin() -> User:
+    u = User(
+        username="max",
+        password_hash="x",
+        is_admin=True,
+        is_active=True,
+        vault_path=None,
+    )
+    u.id = 1
+    return u
+
+
+def _render_users(request: Request) -> str:
+    response = asyncio.run(
+        users_mod.list_users(
+            request=request, session=_FakeSession([_a_user()]), user=_an_admin()
+        )
+    )
+    return response.body.decode()
+
+
+def _render_user_edit(request: Request) -> str:
+    response = asyncio.run(
+        users_mod.edit_user_form(
+            user_id=2, request=request, session=_EditSession(), user=_an_admin()
+        )
+    )
+    return response.body.decode()
+
+
+# --- The message is set on the redirect, and the redirect carries nothing --
+
+
+def test_a_refusal_parks_the_message_and_redirects_to_a_bare_path():
+    request = _request()
+
+    response = asyncio.run(
+        users_mod.create_user(
+            request=request,
+            username="Not A Username",
+            initial_password="long-enough",
+            session=_FakeSession([]),
+            user=_an_admin(),
+        )
+    )
+
+    assert response.status_code == 303
+    # Nothing about the message is in the URL — that is the whole change.
+    assert response.headers["location"] == "/admin/users/"
+    assert request.session[FLASH_SESSION_KEY] == {
+        "message": (
+            "Username must be 1–64 chars, lowercase letters / digits / "
+            "underscores only."
+        ),
+        "kind": "err",
+    }
+
+
+def test_the_success_message_is_a_session_flash_too():
+    request = _request()
+
+    response = users_mod._back_to_list(request, "User 'bob' created.")
+
+    assert response.headers["location"] == "/admin/users/"
+    assert "flash" not in response.headers["location"]
+    assert request.session[FLASH_SESSION_KEY] == {
+        "message": "User 'bob' created.",
+        "kind": "ok",
+    }
+
+
+# --- Rendered exactly once ------------------------------------------------
+
+
+def test_the_flash_renders_once_and_is_gone_on_reload():
+    """A browser keeps one session across both requests; the message must
+    survive the redirect and not the reload after it."""
+    session: dict = {}
+    flash(_request(session=session), "User bob deactivated.")
+
+    first = _render_users(_request(session=session))
+    assert "User bob deactivated." in first
+    assert FLASH_SESSION_KEY not in session, "the flash was not popped"
+
+    second = _render_users(_request(session=session))
+    assert "deactivated." not in second
+
+
+# The rendered alert, not the stylesheet: `base.html` defines both classes in
+# its CSS, so a bare `"alert-warning" in body` is true of every page.
+_WARNING_ALERT = '<div class="alert alert-warning anim-1">'
+_SUCCESS_ALERT = '<div class="alert alert-success anim-1">'
+
+
+def test_an_err_flash_renders_as_a_warning_and_ok_as_a_success():
+    err_session: dict = {}
+    flash(_request(session=err_session), "Refusing to demote", ERR)
+    err_body = _render_users(_request(session=err_session))
+    assert _WARNING_ALERT in err_body
+    assert "Refusing to demote" in err_body
+
+    ok_session: dict = {}
+    flash(_request(session=ok_session), "Updated user", OK)
+    ok_body = _render_users(_request(session=ok_session))
+    assert _SUCCESS_ALERT in ok_body
+    assert "Updated user" in ok_body
+
+
+def test_the_edit_page_pops_the_same_one_flash():
+    session: dict = {}
+    flash(_request(session=session), "You can't remove your own admin role.", ERR)
+
+    first = _render_user_edit(_request(session=session))
+    assert "remove your own admin role" in first
+    assert _WARNING_ALERT in first
+
+    assert "remove your own admin role" not in _render_user_edit(
+        _request(session=session)
+    )
+
+
+# --- A crafted link renders nothing ---------------------------------------
+
+
+def test_a_crafted_flash_query_parameter_is_not_rendered():
+    """The #138 vector: a link an admin is sent, planting server-looking text
+    on the page whose controls delete accounts."""
+    query = (
+        "flash=Vault%20reassigned%20-%20click%20Permanent%20delete%20to%20finish"
+        "&error=EVIL_ERROR&flash_kind=err"
+    )
+    for render in (_render_users, _render_user_edit):
+        body = render(_request(query=query))
+        assert "Vault reassigned" not in body
+        assert "EVIL_ERROR" not in body
+        assert _WARNING_ALERT not in body
+        assert _SUCCESS_ALERT not in body
+
+
+def test_a_crafted_query_parameter_cannot_override_a_real_flash():
+    session: dict = {}
+    flash(_request(session=session), "User bob deactivated.")
+
+    body = _render_users(_request(query="flash=EVIL&flash_kind=ok", session=session))
+
+    assert "EVIL" not in body
+    assert "deactivated." in body
+
+
+def _code_string_literals(source: str) -> list[str]:
+    """Every string literal in `source` except the docstrings.
+
+    Prose is allowed to *describe* the old `?flash=` transport — this file and
+    `src/control_panel/flash.py` both do — so the sweep below looks at what
+    the code can actually build, not at what it says.
+    """
+    tree = ast.parse(source)
+    docstrings = set()
+    for node in ast.walk(tree):
+        if isinstance(
+            node,
+            (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef),
+        ):
+            if ast.get_docstring(node, clean=False) is not None:
+                docstrings.add(id(node.body[0].value))
+    return [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and id(node) not in docstrings
+    ]
+
+
+def test_no_panel_module_builds_a_flash_or_error_query_string():
+    """The sweep half: one converted handler is not the property — a redirect
+    anywhere in the panel that still carries the message in its URL puts the
+    vector straight back."""
+    offenders = []
+    for root in ("src/control_panel", "src/api", "src/auth"):
+        for dirpath, _dirs, files in os.walk(root):
+            for name in files:
+                if not name.endswith(".py"):
+                    continue
+                path = os.path.join(dirpath, name)
+                with open(path, encoding="utf-8") as fh:
+                    source = fh.read()
+                for literal in _code_string_literals(source):
+                    if re.search(r"[?&](flash|error|flash_kind)=", literal):
+                        offenders.append(f"{path}: {literal!r}")
+    assert offenders == [], f"flash/error still travels in a URL: {offenders}"
+
+
+def test_no_panel_handler_reads_a_flash_out_of_the_query_string():
+    offenders = []
+    for dirpath, _dirs, files in os.walk("src/control_panel"):
+        for name in files:
+            if not name.endswith(".py"):
+                continue
+            path = os.path.join(dirpath, name)
+            with open(path, encoding="utf-8") as fh:
+                for line in fh:
+                    if "query_params" in line and re.search(
+                        r"query_params.*(flash|error)", line
+                    ):
+                        offenders.append(f"{path}: {line.strip()}")
+    assert offenders == [], offenders
+
+
+def test_no_panel_template_renders_a_query_parameter():
+    offenders = []
+    for name in sorted(os.listdir(os.path.join(PANEL_DIR, "templates"))):
+        if not name.endswith(".html"):
+            continue
+        path = os.path.join(PANEL_DIR, "templates", name)
+        with open(path, encoding="utf-8") as fh:
+            if "query_params" in fh.read():
+                offenders.append(path)
+    assert offenders == [], offenders
+
+
+# --- Through the real middleware stack ------------------------------------
+#
+# The tests above call the handlers directly, which cannot show the one thing
+# the transport change actually depends on: `SessionMiddleware` carrying the
+# message across the redirect in a signed cookie, and rewriting that cookie
+# without it once the render has popped it. This exercises the round trip —
+# no database, the two dependencies stubbed.
+
+
+def _panel_app():
+    from fastapi import FastAPI
+    from starlette.middleware.sessions import SessionMiddleware
+
+    from src.control_panel.routes import require_admin_panel
+    from src.control_panel.users import router as users_router
+    from src.csrf import verify_csrf
+    from src.database import get_session
+
+    app = FastAPI()
+    app.add_middleware(SessionMiddleware, secret_key="k" * 32)
+    app.include_router(users_router)
+    app.dependency_overrides[get_session] = lambda: _FakeSession([])
+    app.dependency_overrides[require_admin_panel] = _an_admin
+    # CSRF is unrelated to the message transport and has its own tests (#3).
+    app.dependency_overrides[verify_csrf] = lambda: None
+    return app
+
+
+def test_the_message_survives_the_redirect_and_dies_on_the_reload():
+    from fastapi.testclient import TestClient
+
+    client = TestClient(_panel_app())
+
+    posted = client.post(
+        "/admin/users/create",
+        data={"username": "Bad Name", "initial_password": "longenough"},
+        follow_redirects=False,
+    )
+    assert posted.status_code == 303
+    assert posted.headers["location"] == "/admin/users/"
+
+    # …and a crafted parameter on the very request that renders it changes
+    # nothing about what the admin reads.
+    first = client.get("/admin/users/?flash=EVIL&flash_kind=ok")
+    assert "EVIL" not in first.text
+    assert _WARNING_ALERT in first.text
+    assert "lowercase letters / digits / underscores" in first.text
+
+    second = client.get("/admin/users/")
+    assert '<div class="alert' not in second.text, "the flash survived a reload"
+
+
+# --- The helper's own contract --------------------------------------------
+
+
+def test_pop_returns_nothing_when_no_flash_was_set():
+    assert pop_flash(_request()) == (None, OK)
+
+
+def test_an_unknown_kind_is_stored_and_read_as_ok():
+    request = _request()
+    flash(request, "hello", "catastrophe")
+    assert request.session[FLASH_SESSION_KEY]["kind"] == OK
+    assert pop_flash(request) == ("hello", OK)
+
+
+def test_an_empty_message_is_not_stored():
+    request = _request()
+    flash(request, "")
+    assert FLASH_SESSION_KEY not in request.session
+
+
+def test_a_malformed_entry_is_ignored_rather_than_rendered():
+    """A shape written by an older deploy must not 500 the page."""
+    for junk in ("a bare string", {"kind": "err"}, {"message": 7}, None):
+        request = _request(session={FLASH_SESSION_KEY: junk})
+        assert pop_flash(request) == (None, OK)
+
+
+def test_the_helpers_survive_an_app_without_session_middleware():
+    """Single-user harnesses build apps with no session; a message going
+    unshown must never turn a completed action into a 500."""
+    request = _NoSessionRequest()
+    flash(request, "nowhere to put this", ERR)  # must not raise
+    assert pop_flash(request) == (None, OK)
+    assert flash(None, "nor here") is None
+    assert pop_flash(None) == (None, OK)
+
+
+def test_panel_context_supplies_the_flash_to_every_template():
+    session = {FLASH_SESSION_KEY: {"message": "hi", "kind": ERR}}
+    request = _request(session=session)
+
+    ctx = panel_routes._panel_context(request, _an_admin(), {"active": "users"})
+
+    assert ctx["flash"] == "hi"
+    assert ctx["flash_kind"] == ERR
+    assert FLASH_SESSION_KEY not in session

--- a/tests/test_issue_69_self_edit_role_lock.py
+++ b/tests/test_issue_69_self_edit_role_lock.py
@@ -36,6 +36,7 @@ try:
     from starlette.templating import Jinja2Templates
 
     from src.control_panel import users as users_mod
+    from src.control_panel.flash import FLASH_SESSION_KEY
     from src.models.db import User
 finally:
     pydantic_settings.BaseSettings.__init__ = _orig_init
@@ -134,6 +135,26 @@ def _user(**overrides) -> User:
     return u
 
 
+class _Req:
+    """The `Request` the handlers now take (#138).
+
+    Only two attributes are ever touched: `session`, where the flash lands,
+    and `query_params`, which `delete_user` reads for `?permanent=true`.
+    """
+
+    def __init__(self, query_params: dict | None = None):
+        self.session: dict = {}
+        self.query_params = query_params if query_params is not None else {}
+
+
+def _flash_of(request: _Req) -> tuple[str | None, str]:
+    """`(message, kind)` the handler parked in the session, or `(None, "ok")`."""
+    entry = request.session.get(FLASH_SESSION_KEY)
+    if not entry:
+        return None, "ok"
+    return entry["message"], entry["kind"]
+
+
 def _submit(actor: User, target: User, *, is_admin: str | None,
             is_active: str | None, remaining_admins: int = 1,
             actor_after_lock=None):
@@ -141,9 +162,11 @@ def _submit(actor: User, target: User, *, is_admin: str | None,
         target, remaining_admins=remaining_admins,
         actor_after_lock=actor_after_lock,
     )
+    request = _Req()
     response = asyncio.run(
         users_mod.edit_user_submit(
             user_id=target.id,
+            request=request,
             vault_path="",
             vault_path_custom="",
             is_admin=is_admin,
@@ -152,11 +175,17 @@ def _submit(actor: User, target: User, *, is_admin: str | None,
             user=actor,
         )
     )
+    # The refusal is no longer visible in the redirect target (#138) — the
+    # message rides the session — so the request that carried it has to reach
+    # the assertions. Every call site already unpacks two values.
+    response.flash_request = request
     return response, session
 
 
 def _is_error_redirect(response) -> bool:
-    return "error=" in response.headers["location"]
+    """A refusal: an `err`-kind flash was set for the next panel render."""
+    message, kind = _flash_of(response.flash_request)
+    return message is not None and kind == "err"
 
 
 # --- The bug: self-demotion with a second admin present -------------------
@@ -277,18 +306,16 @@ def _delete(actor: User, target: User, *, permanent=False, remaining_admins=1,
         target, remaining_admins=remaining_admins,
         actor_after_lock=actor_after_lock,
     )
-
-    class _Req:
-        query_params = {"permanent": "true"} if permanent else {}
-
+    request = _Req({"permanent": "true"} if permanent else {})
     response = asyncio.run(
         users_mod.delete_user(
             user_id=target.id,
-            request=_Req(),
+            request=request,
             session=session,
             user=actor,
         )
     )
+    response.flash_request = request
     return response, session
 
 
@@ -314,7 +341,7 @@ def test_delete_still_refuses_the_last_active_admin():
     bob.id = 2
     response, session = _delete(me, bob, remaining_admins=0)
     assert bob.is_active is True
-    assert "error=" in response.headers["location"]
+    assert _is_error_redirect(response)
     assert session.committed is False
 
 
@@ -333,7 +360,7 @@ def test_edit_refuses_when_the_actor_was_demoted_while_waiting():
     assert bob.is_admin is True, "a demoted actor still performed the mutation"
     assert session.committed is False
     assert session.rolled_back is True, "the advisory lock must be released"
-    assert "error=" in response.headers["location"]
+    assert _is_error_redirect(response)
 
 
 def test_edit_refuses_when_the_actor_was_deactivated_while_waiting():
@@ -346,7 +373,7 @@ def test_edit_refuses_when_the_actor_was_deactivated_while_waiting():
     )
     assert bob.is_admin is True
     assert session.committed is False
-    assert "error=" in response.headers["location"]
+    assert _is_error_redirect(response)
 
 
 def test_edit_refuses_when_the_actor_row_is_gone():
@@ -361,7 +388,7 @@ def test_edit_refuses_when_the_actor_row_is_gone():
     )
     assert bob.is_admin is True
     assert session.committed is False
-    assert "error=" in response.headers["location"]
+    assert _is_error_redirect(response)
 
 
 def test_edit_actor_recheck_happens_after_the_lock():
@@ -390,7 +417,7 @@ def test_delete_refuses_when_the_actor_was_demoted_while_waiting():
     assert bob.is_active is True, "a demoted actor still deleted a user"
     assert session.committed is False
     assert session.rolled_back is True
-    assert "error=" in response.headers["location"]
+    assert _is_error_redirect(response)
 
 
 def test_delete_actor_recheck_happens_after_the_lock():
@@ -421,7 +448,7 @@ def test_single_user_sentinel_is_not_re_read():
         _Sentinel(), bob, is_admin=None, is_active="on", remaining_admins=1
     )
     assert session.committed is True
-    assert "error=" not in response.headers["location"]
+    assert not _is_error_redirect(response)
     assert not any(
         sql.startswith("SELECT users.is_admin, users.is_active")
         for sql in session.statements
@@ -455,8 +482,12 @@ def test_absent_checkboxes_on_a_self_edit_mean_unchanged_not_unchecked():
     assert me.is_admin is True
     assert me.is_active is True
     assert session.committed is True
-    assert "error=" not in response.headers["location"]
-    assert "flash=" in response.headers["location"]
+    assert not _is_error_redirect(response)
+    # The success message is a session flash now, not a query parameter (#138).
+    assert _flash_of(response.flash_request) == (
+        f"Updated user '{me.username}'.", "ok"
+    )
+    assert response.headers["location"] == "/admin/users/"
 
 
 # --- Editing somebody else is unchanged -----------------------------------
@@ -471,7 +502,7 @@ def test_demoting_another_admin_still_works_when_admins_remain():
     )
     assert bob.is_admin is False
     assert session.committed is True
-    assert "error=" not in response.headers["location"]
+    assert not _is_error_redirect(response)
 
 
 def test_demoting_the_last_active_admin_is_still_refused():

--- a/tests/test_issue_90_self_delete_refused.py
+++ b/tests/test_issue_90_self_delete_refused.py
@@ -46,6 +46,7 @@ try:
 
     from src.auth.session import _SingleUserSentinel
     from src.control_panel import users as users_mod
+    from src.control_panel.flash import FLASH_SESSION_KEY
     from src.models.db import User
 finally:
     pydantic_settings.BaseSettings.__init__ = _orig_init
@@ -142,41 +143,63 @@ def _user(**overrides) -> User:
     return u
 
 
+class _Req:
+    """The `Request` the handler now takes (#138).
+
+    Only `session` (where the flash lands) and `query_params` are read.
+    """
+
+    def __init__(self, query_params: dict | None = None):
+        self.session: dict = {}
+        self.query_params = query_params if query_params is not None else {}
+
+
 def _delete(actor, target: User, *, permanent=False, remaining_admins=1,
             actor_after_lock=None):
     session = _FakeSession(
         target, remaining_admins=remaining_admins,
         actor_after_lock=actor_after_lock,
     )
-
-    class _Req:
-        query_params = {"permanent": "true"} if permanent else {}
-
+    request = _Req({"permanent": "true"} if permanent else {})
     response = asyncio.run(
         users_mod.delete_user(
             user_id=target.id,
-            request=_Req(),
+            request=request,
             session=session,
             user=actor,
         )
     )
+    # The message no longer rides the redirect target (#138); it is parked in
+    # the session for the next panel render, so the assertions need the
+    # request that carried it.
+    response.flash_request = request
     return response, session
 
 
-def _location(response) -> str:
-    return response.headers["location"]
+def _flash(response) -> tuple[str | None, str]:
+    """`(message, kind)` the handler parked in the session."""
+    entry = response.flash_request.session.get(FLASH_SESSION_KEY)
+    if not entry:
+        return None, "ok"
+    return entry["message"], entry["kind"]
+
+
+def _flash_message(response) -> str:
+    message, _kind = _flash(response)
+    assert message is not None, "the handler set no flash"
+    return message
 
 
 def _is_error_redirect(response) -> bool:
-    return "error=" in _location(response)
+    """A refusal: an `err`-kind flash for the next render of the panel."""
+    message, kind = _flash(response)
+    return message is not None and kind == "err"
 
 
 def _mentions_another_admin(response) -> bool:
-    """The refusal has to name the way out. `_q` URL-encodes the message, so
-    match on the encoded form the operator's browser actually receives."""
-    from urllib.parse import unquote
-
-    return "another admin" in unquote(_location(response)).lower()
+    """The refusal has to name the way out. The message is now stored
+    verbatim in the session — no URL-encoding to undo."""
+    return "another admin" in _flash_message(response).lower()
 
 
 # --- The bug: self-delete with other admins present -----------------------
@@ -294,9 +317,7 @@ def test_last_admin_guard_still_fires_on_its_one_reachable_path():
         assert session.deleted is None
         assert session.committed is False
         assert _is_error_redirect(response)
-        from urllib.parse import unquote
-
-        assert "last active admin" in unquote(_location(response)).lower()
+        assert "last active admin" in _flash_message(response).lower()
 
 
 def test_deleting_a_non_admin_succeeds_on_a_table_with_no_active_admin():
@@ -360,9 +381,7 @@ def test_a_demoted_actor_gets_the_actor_revoked_message_not_the_self_one():
         me, me, remaining_admins=3,
         actor_after_lock=_ActorRow(is_admin=False, is_active=True),
     )
-    from urllib.parse import unquote
-
-    msg = unquote(_location(response))
+    msg = _flash_message(response)
     assert users_mod._ACTOR_REVOKED_MSG in msg
     assert "your own account" not in msg.lower()
     assert me.is_active is True
@@ -402,9 +421,6 @@ def test_a_missing_target_is_still_a_404():
 
     me = _user()
     session = _FakeSession(target=None, remaining_admins=3)
-
-    class _Req:
-        query_params: dict = {}
 
     try:
         asyncio.run(
@@ -463,8 +479,10 @@ def _render_user_edit(is_self: bool) -> str:
             },
             "available_vaults": ["/vaults/max"],
             "is_self": is_self,
-            "error": None,
+            # What `_panel_context` supplies since #138 — one flash and its
+            # kind, popped from the session rather than read off the URL.
             "flash": None,
+            "flash_kind": "ok",
         },
     )
     return response.body.decode()

--- a/tests/test_security_review_followups.py
+++ b/tests/test_security_review_followups.py
@@ -5,6 +5,7 @@ import pytest
 
 from src.auth.session import get_current_user
 from src.control_panel import users as panel_users
+from src.control_panel.flash import FLASH_SESSION_KEY
 from src.mcp_server import tools
 from src.models.db import User
 from src.oauth import routes as oauth_routes
@@ -92,6 +93,18 @@ async def test_current_user_rejects_and_clears_stale_session(monkeypatch, cookie
     assert request.session == {}
 
 
+class _PanelRequest:
+    """The `Request` the panel user handlers take since #138.
+
+    The flash message is parked in `session` on the way to the redirect, so
+    a handler called directly still needs somewhere to put it.
+    """
+
+    def __init__(self):
+        self.session: dict = {}
+        self.query_params: dict = {}
+
+
 @pytest.mark.asyncio
 async def test_password_reset_bumps_session_version(monkeypatch):
     target = SimpleNamespace(
@@ -103,8 +116,10 @@ async def test_password_reset_bumps_session_version(monkeypatch):
     db.execute.return_value = result
     monkeypatch.setattr(panel_users, "hash_password", lambda _password: "new-hash")
 
+    request = _PanelRequest()
     response = await panel_users.reset_password(
         user_id=7,
+        request=request,
         new_password="new-password",
         session=db,
         user=SimpleNamespace(is_admin=True),
@@ -139,8 +154,10 @@ async def test_password_reset_takes_the_admin_guard_lock(monkeypatch):
     db.execute.side_effect = [lock, actor_row, target_row]
     monkeypatch.setattr(panel_users, "hash_password", lambda _password: "new-hash")
 
+    request = _PanelRequest()
     response = await panel_users.reset_password(
         user_id=7,
+        request=request,
         new_password="new-password",
         session=db,
         user=actor,
@@ -168,15 +185,22 @@ async def test_password_reset_refuses_an_actor_demoted_while_queued(monkeypatch)
     db.execute.side_effect = [lock, actor_row]
     monkeypatch.setattr(panel_users, "hash_password", lambda _password: "new-hash")
 
+    request = _PanelRequest()
     response = await panel_users.reset_password(
         user_id=7,
+        request=request,
         new_password="new-password",
         session=db,
         user=actor,
     )
 
     assert response.status_code == 303
-    assert response.headers["location"].startswith("/admin/users/?error=")
+    # The refusal message rides the session now, not the query string (#138).
+    assert response.headers["location"] == "/admin/users/"
+    assert request.session[FLASH_SESSION_KEY] == {
+        "message": panel_users._ACTOR_REVOKED_MSG,
+        "kind": "err",
+    }
     # Nothing was written and the target was never even loaded.
     assert db.execute.await_count == 2
     db.rollback.assert_awaited_once()


### PR DESCRIPTION
Closes the A6 item deferred from #130: panel flash/error text was carried in the query string and rendered from it (escaped — no XSS — but the message an authed admin reads was choosable by whoever composed the link, on the surface whose controls delete accounts).

- New `flash()`/`pop_flash()` pair; `_panel_context` is the single pop site — every panel render shows a flash exactly once, gone on reload
- 11 URL-building sites in users.py collapsed into 3 request-taking helpers; 3 handlers gained `Request`; templates render from context, never `query_params`
- Deliberately untouched: login/bootstrap error rendering (no redirect, no URL), OAuth `error=` redirects (protocol, not flash), and the three pre-existing dedicated session flashes
- 17 new tests incl. a crafted `?flash=` being inert, a real SessionMiddleware round trip, and an AST source sweep preventing the URL transport from coming back

2068 passed, 281 skipped (baseline 2051, zero regressions).

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019VBWJ5NiAGc2MQ9U5NSzrW