### PR TITLE
fix(vault): a section's body begins on the line after the heading line (#140)

### DIFF
--- a/docs/architecture/vault-tools.md
+++ b/docs/architecture/vault-tools.md
@@ -114,14 +114,30 @@ Destructive and silently-wrong writes, the class this product ranks highest.
   separator is `[^\S\r\n]+` — all whitespace except the three terminators —
   because `[ \t]+` drops a heading whose marker is followed by an NBSP, and a
   dropped heading shifts every later `#N` ordinal on an existing vault. The
-  heading's *trailing* run and the closing code fence keep the original `\s*`,
-  line-crossing included: `_section_body_span` compensates for it and it is
-  what decides where a replaced section's body begins, so narrowing it would
-  change the bytes `edit_note(section=…)` writes on ordinary LF notes. Only
-  `$` is generalized, to "before any terminator, or end". A 45,630-input
+  closing code fence still keeps the original `\s*`, line-crossing included.
+  Only `$` is generalized, to "before any terminator, or end". A 45,630-input
   LF/CRLF differential over masking, parsing, outlines, links, extraction and
   replacement holds at **0 divergences**; that is the compatibility envelope,
   and it is what any future change to these patterns has to re-establish.
+- **The heading's *trailing* run no longer keeps `\s*` — that constraint was
+  deliberately lifted in #140 (2026-08), and this bullet is its history, not a
+  live prohibition.** It used to read: the trailing run keeps the original
+  `\s*`, line-crossing included, because `_section_body_span` compensates for
+  it and narrowing it would change the bytes `edit_note(section=…)` writes on
+  ordinary LF notes. That reasoning held the zero-divergence envelope above
+  and was wrong about the compensation: the trailing run is what set
+  `line_end`, so a heading followed by blank lines — or by a fenced block,
+  which the masker turns into a run of *spaces* the run happily crossed —
+  produced a `line_end` far past the heading line. The read
+  (`extract_section`, from `line_start`) returned that region and the write
+  (`replace_section`, from `body_start`) could not replace it, so a
+  read-modify-write round trip duplicated it: a fence came back twice, blank
+  lines grew +1, +2, +4 over three round trips. The run is now
+  `[^\S\r\n]*`, and the load-bearing invariant is stated once: **a section's
+  body begins at the first byte of the line immediately after the heading
+  line.** See "Section addressing" below for the compat break that bought,
+  and re-establish the differential envelope before touching these patterns
+  again.
 - **Declared staleness.** Notes already indexed under the old empty-block
   partition (the block surfacing as literal body text, and `note_links.position`
   measured against it) do not self-heal on an ordinary pass — change detection
@@ -237,3 +253,153 @@ The ordinal exists because **path-style cannot disambiguate duplicate siblings**
 Ambiguity stays an error that names the resolving ordinals; it never silently picks the first match (that is how an agent edits the wrong section and reports success).
 
 Helpers: `_resolve_section_index` (selector → index), `_section_body_span` (index → body span), `extract_section` (heading line **plus** body, for reads), `replace_section` (body only, for writes), `outline_sections` (depth/text/size/ordinal per section).
+
+### Where a section's body begins, and what a section write destroys (#140)
+
+**A section's body begins at the first byte of the line immediately after the
+heading line, and ends immediately before the next heading of equal-or-shallower
+depth, or at end of file.** At most one terminator (LF, CRLF as a unit, or a
+lone CR) separates the two; a heading at EOF with no terminator has an empty
+body. There is no third region: no whitespace, no blank line, and no fenced
+code block sits between the heading line and the body. `extract_section`
+returns the heading line, its terminator, and exactly the span `replace_section`
+writes — by construction, not by coincidence.
+
+Before #140 the two disagreed, and the gap was **readable but unwritable**:
+whatever the heading regex's trailing `\s*` swallowed came back from a section
+read and lay outside the section write's span, so an agent that read a section
+and wrote it back duplicated it. Two symptoms, one cause — see the terminator
+bullet above for the mechanism.
+
+**The break this bought is declared, and it is destructive rather than
+cosmetic.** A section write replaces the **whole body**, so content the caller
+does not resend is **deleted**:
+
+- A blank separator that used to survive is gone unless `content` carries it.
+  `edit_note(section="Tasks", content="- x")` on `## Tasks\n\n- old\n` now
+  writes `## Tasks\n- x\n`. The blank line is the caller's to send
+  (`content="\n- x"`).
+- **A fenced code block directly under the heading is deleted.** Given this
+  note:
+
+  ````markdown
+  # A
+  ```
+  important
+  ```
+  old
+  ````
+
+  `edit_note(section="A", content="new")` previously kept the block and
+  replaced only `old`; it now yields exactly `# A\nnew`. Leaving the block
+  behind *was* the duplication bug, so replacing it is the fix — but a caller
+  who does not round-trip loses content, and both `edit_note` docstrings say
+  so in those words.
+
+  Note the exact bytes: **no trailing newline**. `A` is the last heading, so
+  there is no following heading to separate the new body from, and the
+  trailing separator exists only to prevent that gluing (the rule
+  `tests/test_issue_5_replace_section_eof_heading.py` has pinned since #5).
+  #140's proposal and design render this example as `# A\nnew\n`; that extra
+  terminator is an illustration slip, not the contract —
+  `tests/test_issue_140_section_round_trip.py` pins the real bytes.
+
+What bounds it: no note is rewritten until someone writes to that section, and
+the read→modify→write path an agent actually takes comes out strictly better —
+it now preserves what it used to duplicate.
+
+**A separator newline is inserted only for a non-empty replacement body.**
+Both insertions — one before the body when the retained prefix does not end in
+a terminator (an EOF heading), one after it when a following heading would
+otherwise be glued to it — are conditional on `new_body` being non-empty. They
+used to be unconditional, which meant an *empty* section was not round-trip
+stable even with the regex fixed: `# A\n# B\nb\n` gained a blank line and `# A`
+gained a newline on every pass. Two consecutive headings are the commonest
+degenerate shape in an outline-heavy note, so without this the headline
+property was simply false. The non-empty behaviour is untouched and
+`tests/test_issue_5_replace_section_eof_heading.py` pins it.
+
+**What did NOT change, and why that made the narrowing admissible.** The
+heading capture is `([^\r\n]+?)` with `.strip()` applied either way, so heading
+depth, trimmed text, `line_start` and document order are bit-identical before
+and after — and therefore so is every `#N` ordinal and every
+`outline_sections` `size` (`body_end - line_start`; the change moves neither
+endpoint). **No selector changes meaning; no existing note is re-addressed.**
+`tests/test_issue_140_section_round_trip.py` pins this against explicit values
+captured from the pre-change tree, not by comparing two regexes.
+
+### No documented way to recover a section body from a response — on purpose (#149)
+
+The round-trip guarantee is stated over **note text**, verified against the
+shared section helpers. It is deliberately *not* stated over a rendered
+`read_note` response, and **no docstring may instruct a caller to extract the
+body from one** — no "split on the separator", no "drop the first line". If
+you are the next author who notices the docstrings stop short of telling the
+agent how to get the body, and you are about to helpfully add a split rule:
+don't. This is why.
+
+`read_note` builds every response as an envelope — `# <title>`, `**Path:**`,
+optional `**Tags:**` and `**Frontmatter:**` — then `"\n---\n"` and the selected
+content. So the response's first line is the *title*, not the heading: "strip
+the first line and write it back" makes an agent write ``**Path:** `n.md` ``
+into the note. The obvious repair, "split on the first `\n---\n`", is also
+forgeable, because every component of that envelope is note-controlled and a
+*valid* note can make one emit a line that mimics the separator. Both
+reproduced during #140's audit:
+
+| forged via | frontmatter | what the rule then extracts |
+| --- | --- | --- |
+| the title | `title: \|-` with a `---` line in the block scalar | ``**Path:** `n.md`…`` |
+| a key | `"safe\n---\nforged": value` | `\n---\n# A\nold\n` |
+
+Sanitising the named fields does not close the class — one audit round patched
+the title, the next found the key — and collapsing terminators to make
+components safe is itself lossy: the distinct paths `a\nb.md` and `a b.md`
+would render identically, trading a destructive write for a silently wrong
+read. Nor does a per-component invariant compose: a component whose value is
+exactly `---` forges a separator the moment any future field is rendered alone
+on a line.
+
+Making the selected content unambiguously recoverable needs **structural**
+framing — separate metadata and section-body fields in the MCP result — which
+changes `read_note`'s response shape and every consumer of it. That is filed
+as **#149**. Until it lands, the docstrings state the relationship (a section
+response carries the heading line and the body; `edit_note(section=…)` takes
+the body) and stop there.
+
+### Declared residual: the masker's fence grammar is narrower than CommonMark (#150)
+
+`_FENCE_RE` in `src/services/links.py` recognises only a **column-zero** opener
+closed by a fence of **exactly** the same length. CommonMark allows up to three
+spaces of indentation and a closer at least as long as the opener. So an
+indented fence, or one closed by a longer run, is not masked: a heading inside
+such a block is selectable, and a section write there already deletes the
+opening fence and orphans the contents.
+
+That is a genuine destructive-write hazard, and it is **not #140's**. Measured
+before and after the narrowing on both shapes, the bytes written are
+**identical** — pinned by `tests/test_issue_140_section_round_trip.py` against
+explicit expected bytes, which is the evidence for this claim. Widening the
+masker changes which lines count as headings, which shifts every `#N` ordinal
+on an affected note — a re-addressing break strictly larger than #140's, and
+one that must not ride along on it. It is filed as **#150** and needs its own
+proposal. This is why #140's spec says "fenced code block **as recognised by
+the shared masker**" rather than claiming CommonMark coverage the code does not
+have.
+
+### Declared residual: a section round trip normalises the body's terminators
+
+Beside the whole-note newline residual #128 already declared: `read_note`
+applies universal-newline translation before the caller ever sees a section,
+while `edit_note` reads and rewrites raw bytes. A section round trip therefore
+rewrites *that section's* terminators as LF and leaves everything else alone.
+Measured, and pinned as bytes:
+
+- `# A\r\nold\r\n# B\r\nkeep\r\n` → `# A\r\nold\n# B\r\nkeep\r\n`
+- mixed endings, since the normalisation is per-terminator and not per-note:
+  `# A\r\none\r\ntwo\nthree\r# B\rkeep\r` → `# A\r\none\ntwo\nthree\n# B\rkeep\r`
+
+Content is preserved; bytes are not. Normalising on write would rewrite
+terminators the caller never touched, so this is accepted rather than fixed:
+the byte-identity guarantee is scoped to LF-bodied notes and both `edit_note`
+docstrings say so.

--- a/docs/architecture/vault-tools.md
+++ b/docs/architecture/vault-tools.md
@@ -300,8 +300,9 @@ does not resend is **deleted**:
   there is no following heading to separate the new body from, and the
   trailing separator exists only to prevent that gluing (the rule
   `tests/test_issue_5_replace_section_eof_heading.py` has pinned since #5).
-  #140's proposal and design render this example as `# A\nnew\n`; that extra
-  terminator is an illustration slip, not the contract —
+  #140's proposal, design and tasks originally rendered this example as
+  `# A\nnew\n`; the extra terminator was an illustration slip, caught during
+  implementation and corrected in the same change.
   `tests/test_issue_140_section_round_trip.py` pins the real bytes.
 
 What bounds it: no note is rewritten until someone writes to that section, and

--- a/openspec/changes/section-round-trip-140/.openspec.yaml
+++ b/openspec/changes/section-round-trip-140/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-26

--- a/openspec/changes/section-round-trip-140/design.md
+++ b/openspec/changes/section-round-trip-140/design.md
@@ -1,0 +1,136 @@
+# Design: section read/write parity (#140)
+
+## The defect, precisely
+
+`_scan_headings` records `line_end` from the heading regex's match end. The
+regex is
+
+```
+(?:\A|(?<=\n)|(?<=\r))(#{1,6})[^\S\r\n]+([^\r\n]+?)\s*(?=\r|\n|\Z)
+```
+
+and that final `\s*` is **not** restricted to horizontal whitespace. `\s`
+includes `\n` and `\r`, and the lookahead only requires that the run *end* at a
+line boundary — so the run happily crosses as many blank lines as it likes and
+stops before the last terminator it can. `line_end`, documented as "byte pos at
+end of heading text, before any trailing newline", is therefore nothing of the
+sort whenever a heading is followed by whitespace-only lines.
+
+`_section_body_span` then does the right thing with a wrong input: it steps over
+one terminator from `line_end` and calls that `body_start`. Read and write split
+at that point:
+
+| | span | consequence |
+| --- | --- | --- |
+| `extract_section` (read) | `line_start … body_end` | sees everything |
+| `replace_section` (write) | `body_start … body_end` | writes from after the swallowed run |
+
+Everything the trailing `\s*` swallowed is **readable but unwritable**. That gap
+is the bug; the two reported symptoms are two ways of filling it.
+
+### Symptom 1 — a fenced block, via the masker
+
+`_scan_headings` scans `mask_code(text)`, which replaces a fenced block with an
+equal-length run of **spaces** — internal newlines included, since the fence
+regex matches the whole block with `(?s)`. So on
+
+```
+# A
+```<fence>
+## Hidden
+text
+```<fence>
+# B
+```
+
+the masked text the regex actually sees is `# A\n` + 24 spaces + `\n# B\nb\n`.
+The trailing `\s*` runs from after `A` straight through the newline and the
+entire masked block, stopping just before the `\n` that precedes `# B`.
+`line_end` = 26, `body_start` = 27, `body_end` = 27 — an **empty** body span
+pointing at the next heading. `extract_section` still returns the fence, because
+it starts from `line_start`.
+
+The masker is not at fault and must not change: it is offset-stable by
+construction (a test in `test_issue_128_section_mode_frontmatter.py` pins that),
+and every consumer depends on positions mapping back into unmasked text. Only
+the heading regex's willingness to consume the mask is at fault.
+
+### Symptom 2 — a blank line
+
+`# A\n\nbody\n`: the run takes one `\n`, the lookahead is satisfied by the
+second. `line_end` sits after the first newline, `body_start` after the second,
+so `body` is `body\n` while read returns `# A\n\nbody\n`. Write back the part
+after the first line (`\nbody\n`) and the blank line is emitted again on top of
+the retained one. It compounds, because the *next* read returns the larger
+prefix: measured growth is +1, +2, +4 blank lines over three round trips.
+
+## The fix
+
+Narrow the trailing run to horizontal whitespace:
+
+```
+(?:\A|(?<=\n)|(?<=\r))(#{1,6})[^\S\r\n]+([^\r\n]+?)[^\S\r\n]*(?=\r|\n|\Z)
+```
+
+This makes `line_end` mean what its docstring already claims, which restores the
+invariant the two spans need: `body_start` is the first byte of the line after
+the heading line, and `extract_section` returns `heading_line + terminator +
+text[body_start:body_end]`. Read minus its first line **is** the write span, by
+construction rather than by coincidence.
+
+Note the asymmetry with the *separator* class earlier in the pattern, which is
+already `[^\S\r\n]+` and was deliberately widened from `[ \t]` (see the comment
+in `vault.py`, and `docs/architecture/vault-tools.md`) so an NBSP after the `#`
+marker still separates. Narrowing the *trailing* run does not touch that: the
+captured heading text is `([^\r\n]+?)` either way, and `.strip()` is applied to
+it, so heading text, ordinals, depth and `line_start` are all bit-identical
+before and after. **No selector changes meaning.** That is what makes this a
+byte-level change to writes and not a re-addressing of anyone's notes.
+
+## Why not the alternatives
+
+**Skip the blank run on both sides** (read hides it too) would keep today's
+write bytes exactly — the blank separator would always survive — at the cost of
+`read_note(section=…)` no longer reproducing the note's bytes, plus a second
+rule ("how many blank lines are separator, how many are body?") that a body
+legitimately beginning with blank lines cannot express. Rejected: this codebase's
+expensive failure is a *silently wrong read*, and a read that hides bytes to
+protect a write is that.
+
+**Compensate in `replace_section`** — re-emit a blank line when the replaced
+body had one and the new content does not — was rejected as unspecifiable. It
+guesses intent from content shape, which three audit rounds in #128 established
+this tool must not do.
+
+**Fix only the fence case** would leave the accumulation bug open and, worse,
+leave the two spans still defined differently, so the next shape that lands in
+the gap becomes the third bug in this family.
+
+## The accepted cost
+
+`edit_note(section=S, content=B)` where `B` does not itself begin with a newline
+now loses a blank separator that used to survive. This is the declared break.
+Three things bound it:
+
+- It is cosmetic — no content is lost, and no note is rewritten until someone
+  writes to that section.
+- The read→modify→write path, which is the one an agent actually takes, comes
+  out *better*: it now preserves the separator, which it previously duplicated.
+- It is discoverable from the docstrings, which state that `content` is the
+  body exactly as `read_note(section=…)` returns it below the heading line.
+
+## Verification shape
+
+The reproductions belong in a dedicated `tests/test_issue_140_section_round_trip.py`
+exercising the pure helpers (no DB, no vault), plus the differential property
+that names the contract directly:
+
+> for every heading ordinal in a note, `replace_section(text, "#N",
+> extract_section(text, "#N") minus its first line)` returns `text` unchanged.
+
+That property is the spec requirement in executable form, and it must hold over
+a corpus that includes: blank lines after headings, fenced blocks directly under
+headings (including ones containing `#` lines), inline code, EOF headings with
+and without a trailing newline, headings with trailing spaces, CRLF notes, lone-CR
+notes, and notes carrying a valid frontmatter block (where section mode operates
+on the stripped body per #128).

--- a/openspec/changes/section-round-trip-140/design.md
+++ b/openspec/changes/section-round-trip-140/design.md
@@ -205,8 +205,9 @@ What bounds it:
 - No note is rewritten until someone writes to that section.
 - The read→modify→write path, the one an agent actually takes, comes out
   strictly better: it now preserves what it previously duplicated.
-- It is discoverable from the docstrings, which state the extraction rule, the
-  whole-body replacement, and the LF qualification.
+- It is discoverable from the docstrings, which state the whole-body
+  replacement and the LF qualification. They state no extraction rule — see
+  above for why there is none to state.
 
 ## Declared residual: newline dialect
 

--- a/openspec/changes/section-round-trip-140/design.md
+++ b/openspec/changes/section-round-trip-140/design.md
@@ -111,28 +111,45 @@ the gap becomes the third bug in this family.
 Three things the first draft of this design got wrong, found by the pre-implementation
 audit and verified against the current helpers.
 
-### 1. `read_note` does not return raw section text
+### 1. `read_note` does not return raw section text — and no textual rule recovers it
 
 `read_note` builds every response as an envelope — `# <title>`, `**Path:**`,
 optional `**Tags:**` and `**Frontmatter:**` — then `"\n---\n"` and the selected
 content (`src/mcp_server/tools.py`, the `parts` list). So the response's first
-line is the *title*, not the heading. "Strip the first line and write it back",
-the obvious phrasing and the one the first draft used, makes an agent write
+line is the *title*, not the heading, and "strip the first line and write it
+back" makes an agent write `**Path:** \`n.md\`` into the note.
 
-```
-**Path:** `n.md`
+The obvious repair — "split on the first `\n---\n` instead" — is also wrong, and
+this took two further audit rounds to establish. Every component of that
+envelope is note-controlled, and a valid note can make one emit a line that
+mimics the separator:
 
----
-# A
-```
+| forged via | frontmatter | what the rule then extracts |
+| --- | --- | --- |
+| the title | `title: \|-` with a `---` line in the scalar | `**Path:** \`n.md\`…` |
+| a key | `"safe\n---\nforged": value` | `\n---\n# A\nold\n` |
 
-into the note. That is precisely the destructive-write class this repo exists to
-avoid, and the spec would have instructed it.
+Both reproduced. Both write garbage into the section. Sanitising the named
+fields does not close the class — round 2 patched the title, round 3 found the
+key — and collapsing terminators to make components safe is itself lossy: the
+distinct paths `a\nb.md` and `a b.md` would render identically, which trades a
+destructive write for a silently wrong read. Nor does a per-component invariant
+compose: a component whose value is exactly `---`, containing no terminator at
+all, would forge a separator the moment any future field is rendered alone on a
+line.
 
-The contract is therefore stated over the **selected-content portion**: the text
-after the response's first `\n---\n`, minus its first line. Both docstrings must
-carry that rule verbatim, and the end-to-end check must perform that extraction
-against a real MCP response rather than against the pure helper.
+**So this change specifies no extraction procedure and forbids the docstrings
+from prescribing one.** The round-trip guarantee is stated over *note text* and
+verified against the shared section helpers, which is where the two reported
+bugs actually live. Making the selected content unambiguously recoverable from
+a response needs structural framing — separate metadata and section-body fields
+in the MCP result — which changes `read_note`'s response shape and every
+consumer of it. That is filed as **#149** rather than bundled into a
+section-span fix.
+
+The cost of the split is honest and small: an agent that wants a guaranteed
+round trip must know the note's bytes rather than recover them from a rendered
+response. The two bugs #140 reports are fixed either way.
 
 ### 2. `replace_section` inserts separators unconditionally
 
@@ -164,7 +181,7 @@ Measured before and after the narrowing, on both the indented-fence and
 longer-closer shapes, the bytes written are identical. Widening the masker would
 change which lines count as headings, which shifts every `#N` ordinal on an
 affected note — a re-addressing break strictly larger than this one, and one
-that must not ride along on it. It gets its own issue; this spec says "fenced
+that must not ride along on it. It gets its own issue (**#150**); this spec says "fenced
 code block *as recognised by the shared masker*" rather than claiming coverage
 the code does not have.
 

--- a/openspec/changes/section-round-trip-140/design.md
+++ b/openspec/changes/section-round-trip-140/design.md
@@ -195,7 +195,10 @@ cosmetic and was wrong:
 - A blank separator that used to survive is lost unless `content` includes it.
 - **A fenced code block directly under the heading is deleted.** On
   `# A\n```\nimportant\n```\nold\n`, `edit_note(section="A", content="new")`
-  previously kept the block and replaced only `old`; it now yields `# A\nnew\n`.
+  previously kept the block and replaced only `old`; it now yields `# A\nnew`
+  (no trailing newline — `A` is the last heading, and the trailing separator is
+  only ever inserted to keep a *following* heading off the body, the rule #5
+  pinned).
   Leaving the block behind *was* the duplication bug, so replacing it is correct
   — but a caller that does not round-trip loses content, and the docstrings must
   say so rather than implying only whitespace is at stake.

--- a/openspec/changes/section-round-trip-140/design.md
+++ b/openspec/changes/section-round-trip-140/design.md
@@ -106,18 +106,103 @@ this tool must not do.
 leave the two spans still defined differently, so the next shape that lands in
 the gap becomes the third bug in this family.
 
+## The regex is necessary but not sufficient
+
+Three things the first draft of this design got wrong, found by the pre-implementation
+audit and verified against the current helpers.
+
+### 1. `read_note` does not return raw section text
+
+`read_note` builds every response as an envelope — `# <title>`, `**Path:**`,
+optional `**Tags:**` and `**Frontmatter:**` — then `"\n---\n"` and the selected
+content (`src/mcp_server/tools.py`, the `parts` list). So the response's first
+line is the *title*, not the heading. "Strip the first line and write it back",
+the obvious phrasing and the one the first draft used, makes an agent write
+
+```
+**Path:** `n.md`
+
+---
+# A
+```
+
+into the note. That is precisely the destructive-write class this repo exists to
+avoid, and the spec would have instructed it.
+
+The contract is therefore stated over the **selected-content portion**: the text
+after the response's first `\n---\n`, minus its first line. Both docstrings must
+carry that rule verbatim, and the end-to-end check must perform that extraction
+against a real MCP response rather than against the pure helper.
+
+### 2. `replace_section` inserts separators unconditionally
+
+Independent of the regex, `replace_section` prepends a newline when the retained
+prefix does not end in one, and appends one when a following heading exists and
+the body does not end in a terminator. Both fire even when `new_body` is `""`.
+Measured with the narrowed regex in place:
+
+| note | round trip result | stable |
+| --- | --- | --- |
+| `# A\n# B\nb\n` | `# A\n\n# B\nb\n` | no |
+| `# A` | `# A\n` | no |
+
+So a section with no body — two consecutive headings, the commonest degenerate
+shape in an outline-heavy note — still accumulates a blank line per round trip.
+Both insertions become conditional on a non-empty body. The non-empty cases that
+issue #5 pinned (`# Notes` at EOF, replaced with `- item`) are untouched.
+
+### 3. The masker's fence grammar is narrower than CommonMark
+
+`_FENCE_RE` requires a column-zero opener and a closer of *exactly* the same
+length. CommonMark allows up to three spaces of indentation and a closer at
+least as long as the opener. So `# A\n   ```\n# Hidden\n…` leaves `# Hidden`
+visible to the scanner, and a section write there replaces only the opening
+fence — orphaning the code and leaving the closer.
+
+That is a genuine destructive-write hazard, and it is **not this change's**.
+Measured before and after the narrowing, on both the indented-fence and
+longer-closer shapes, the bytes written are identical. Widening the masker would
+change which lines count as headings, which shifts every `#N` ordinal on an
+affected note — a re-addressing break strictly larger than this one, and one
+that must not ride along on it. It gets its own issue; this spec says "fenced
+code block *as recognised by the shared masker*" rather than claiming coverage
+the code does not have.
+
 ## The accepted cost
 
-`edit_note(section=S, content=B)` where `B` does not itself begin with a newline
-now loses a blank separator that used to survive. This is the declared break.
-Three things bound it:
+`edit_note(section=S, content=B)` now replaces the section's entire body, so
+anything the caller does not resend is gone. This is the declared break, and it
+is **destructive, not cosmetic** — the first draft of this design called it
+cosmetic and was wrong:
 
-- It is cosmetic — no content is lost, and no note is rewritten until someone
-  writes to that section.
-- The read→modify→write path, which is the one an agent actually takes, comes
-  out *better*: it now preserves the separator, which it previously duplicated.
-- It is discoverable from the docstrings, which state that `content` is the
-  body exactly as `read_note(section=…)` returns it below the heading line.
+- A blank separator that used to survive is lost unless `content` includes it.
+- **A fenced code block directly under the heading is deleted.** On
+  `# A\n```\nimportant\n```\nold\n`, `edit_note(section="A", content="new")`
+  previously kept the block and replaced only `old`; it now yields `# A\nnew\n`.
+  Leaving the block behind *was* the duplication bug, so replacing it is correct
+  — but a caller that does not round-trip loses content, and the docstrings must
+  say so rather than implying only whitespace is at stake.
+
+What bounds it:
+
+- No note is rewritten until someone writes to that section.
+- The read→modify→write path, the one an agent actually takes, comes out
+  strictly better: it now preserves what it previously duplicated.
+- It is discoverable from the docstrings, which state the extraction rule, the
+  whole-body replacement, and the LF qualification.
+
+## Declared residual: newline dialect
+
+`read_note` applies universal-newline translation before the caller ever sees a
+section; `edit_note` reads and rewrites raw bytes. A CRLF note's section round
+trip therefore rewrites *that section's* terminators as LF and leaves everything
+else CRLF. Measured: `# A\r\nold\r\n# B\r\nkeep\r\n` →
+`# A\r\nold\n# B\r\nkeep\r\n`. Content is preserved; bytes are not.
+
+This is the section-mode instance of the whole-note residual #128 already
+declared and accepted. It is not fixed here — normalising on write would rewrite
+terminators the caller never touched — but the byte-identity guarantee is scoped
+to LF-bodied notes and both docstrings say so.
 
 ## Verification shape
 

--- a/openspec/changes/section-round-trip-140/proposal.md
+++ b/openspec/changes/section-round-trip-140/proposal.md
@@ -79,11 +79,11 @@ zero-divergence envelope forbade — so the contract decision belongs here.
     blast radius is content loss for a caller that does not round-trip, and
     both the docstrings and `vault-tools.md` must say so in those words.
 - Docstrings at both layers — the registered wrappers in `server.py` (what MCP
-  clients see) and the `tools.py` impls — state the round-trip contract in the
-  terms callers need: *take the text after the section response's `\n---\n`
-  envelope separator, drop its first line, and that is exactly what
-  `edit_note(section=…)` takes*. They SHALL NOT say "the response minus its
-  first line" — the response's first line is the envelope's `# <title>`.
+  clients see) and the `tools.py` impls — state the read/write *relationship*:
+  a `read_note(section=…)` response carries the heading line and the body, and
+  `edit_note(section=…)` takes the body, which begins on the line after the
+  heading line and is replaced whole. They state **no procedure** for
+  recovering that body from a rendered response, for the reason above.
 - `docs/architecture/vault-tools.md` is updated in the same change: its
   "the trailing run stays the original `\s*` … narrowing it would change the
   bytes `edit_note(section=…)` writes on ordinary LF notes" note is now the

--- a/openspec/changes/section-round-trip-140/proposal.md
+++ b/openspec/changes/section-round-trip-140/proposal.md
@@ -35,44 +35,27 @@ zero-divergence envelope forbade — so the contract decision belongs here.
   heading line, its terminator, and that body; `edit_note(section=S, content=B)`
   replaces exactly that body.
 
-  **The extraction rule is stated explicitly, because the response is not raw
-  section text.** `read_note` prefixes every response with a title/path/tags
-  envelope terminated by a `\n---\n` separator line. "Strip the first line of
-  the response" — the obvious formulation, and the one the first draft of this
-  spec used — would write `**Path:** \u0060…\u0060` into the note. The rule is:
-  take the text after the response's first `\n---\n` separator, then drop its
-  first line. Both docstrings SHALL say this in those terms.
-- **The envelope SHALL be framed unambiguously, so that rule is safe to
-  follow — stated as an invariant, not a list of fields.** No dynamic component
-  of a successful response's envelope may contain a line terminator, enforced at
-  a single rendering choke point that title, path, tags, frontmatter **keys**
-  and frontmatter values all pass through. The enumeration is what failed twice:
-  audit round 2 found a multiline *title* could forge the separator, round 3
-  found a multiline frontmatter *key* could do it through the
-  `**Frontmatter:**` block. Both are valid YAML. Patching the named field would
-  have invited a third.
+  **The guarantee is stated over note text, not over rendered response text,
+  and that boundary is deliberate.** Every textual procedure for recovering a
+  section from a `read_note` response proved forgeable: the envelope
+  interpolates the title, the path, the tags and each frontmatter key and
+  value, and a valid note can make any of them emit a line that mimics the
+  envelope's own `---` separator. Reproduced twice, on different fields — a
+  multiline YAML title, and the valid quoted key `"safe\n---\nforged"` — each
+  time yielding a remainder beginning `**Path:** `n.md`` that
+  clobbers the section when written back. Sanitising the named fields does not
+  close it (two audit rounds, two different fields), and collapsing terminators
+  to make them safe is lossy: the distinct paths `a\nb.md` and `a b.md` would
+  render identically, trading a destructive write for a silently wrong read.
 
-  Concretely, before this change: the valid key `"safe\n---\nforged": value` renders as two
-  lines inside the `**Frontmatter:**` block, and the documented extraction then
-  yields `\n---\n# A\nold\n` — which written back clobbers the section. Both
-  reproductions are in the tasks as end-to-end cases, alongside a guard test
-  that names no field at all: no line before the envelope separator may be
-  exactly `---`.
+  So this change does **not** document an extraction procedure, and forbids the
+  docstrings from prescribing one. Making the selected content unambiguously
+  recoverable needs structural framing of the response — separate metadata and
+  section-body fields — which changes `read_note`'s response shape and belongs
+  in its own proposal — filed as **#149**. Until it lands, the docstrings state the
+  relationship (a section response carries the heading line and the body;
+  `edit_note(section=…)` takes the body) without a parsing recipe.
 
-  A component is rendered by stringifying it and collapsing terminators in the
-  *resulting* string, which is deterministic and needs no rule about recursing
-  into composites — `str()` escapes newlines inside a list or dict, so only a
-  bare string component can carry one through. This also repairs the existing
-  display bug where such a title breaks the response layout on an ordinary
-  whole-note read. The note body is never sanitized, and error responses — which
-  carry no envelope and no selected content — are out of scope.
-- **Mechanically:** `_ATX_HEADING_RE`'s trailing whitespace run narrows from
-  `\s*` (which crosses line boundaries) to `[^\S\r\n]*` (horizontal only), so a
-  heading's `line_end` is genuinely the end of its heading line in every
-  dialect. `_section_body_span` keeps stepping over exactly one terminator.
-  Nothing else in the resolver changes: heading *text*, depth, ordinals,
-  `line_start`, and every selector form are unaffected, so no existing selector
-  starts naming a different section.
 - **`replace_section` SHALL insert a separator newline only for a non-empty
   replacement body.** Today it appends one before the following heading, and
   prepends one after an unterminated EOF heading, unconditionally — so an
@@ -89,7 +72,7 @@ zero-divergence envelope forbade — so the contract decision belongs here.
     is the caller's to send (`content="\n- x"`).
   - **A fenced block directly under a heading is now deleted** by a section
     write whose `content` does not resend it. On
-    `# A\n\u0060\u0060\u0060\nimportant\n\u0060\u0060\u0060\nold\n`,
+    `# A\n```\nimportant\n```\nold\n`,
     `edit_note(section="A", content="new")` previously kept the block and
     replaced only `old`; it now yields `# A\nnew\n`. That is the intended
     contract — leaving the block behind *was* the duplication bug — but the
@@ -127,10 +110,9 @@ zero-divergence envelope forbade — so the contract decision belongs here.
   non-empty body. `_scan_headings`, `_section_body_span`, `extract_section`,
   `replace_section` and `outline_sections` keep their signatures and their
   roles.
-- `src/mcp_server/tools.py` — `read_note_impl`'s envelope construction, so no
-  interpolated field can emit a bare `\n---\n` line; plus `edit_note`'s and
-  `read_note`'s docstrings. `src/mcp_server/server.py` — the registered
-  wrappers' docstrings, which must carry the same statements.
+- `src/mcp_server/server.py` and `src/mcp_server/tools.py` — docstrings only.
+  `read_note`'s response shape is unchanged here; the envelope framing is a
+  separate, filed change.
 - `docs/architecture/vault-tools.md` — the section-addressing section.
 - **No schema change, no migration, no index effect.** `outline_sections`'
   reported `size` is `body_end - line_start`; this change moves neither
@@ -145,8 +127,8 @@ zero-divergence envelope forbade — so the contract decision belongs here.
   change: the bytes written are **identical**, so this change neither creates
   nor worsens it. Fixing the masker shifts which lines count as headings and
   therefore re-addresses every `#N` ordinal on affected notes, which is a
-  larger compat break than this one and belongs in its own change; filed
-  separately. The spec here says "fenced code block **as recognised by the
+  larger compat break than this one and belongs in its own change; filed as
+  **#150**. The spec here says "fenced code block **as recognised by the
   shared masker**" rather than claiming CommonMark coverage it does not have.
 - **Declared residual: newline dialect.** `read_note` applies universal-newline
   translation; `edit_note` reads and rewrites raw bytes. A section round trip

--- a/openspec/changes/section-round-trip-140/proposal.md
+++ b/openspec/changes/section-round-trip-140/proposal.md
@@ -31,11 +31,17 @@ zero-divergence envelope forbade — so the contract decision belongs here.
 
 - **A section's body SHALL begin on the line immediately after the heading
   line.** This is the whole change, stated once and applied to both sides:
-  `read_note(section=S)` returns the heading line, its terminator, and that
-  body; `edit_note(section=S, content=B)` replaces exactly that body. The
-  portion of a section response after its first line is therefore precisely the
-  region a section write replaces, and the round trip is byte-identical on LF
-  notes.
+  the *selected-content portion* of a `read_note(section=S)` response is the
+  heading line, its terminator, and that body; `edit_note(section=S, content=B)`
+  replaces exactly that body.
+
+  **The extraction rule is stated explicitly, because the response is not raw
+  section text.** `read_note` prefixes every response with a title/path/tags
+  envelope terminated by a `\n---\n` separator line. "Strip the first line of
+  the response" — the obvious formulation, and the one the first draft of this
+  spec used — would write `**Path:** \u0060…\u0060` into the note. The rule is:
+  take the text after the response's first `\n---\n` separator, then drop its
+  first line. Both docstrings SHALL say this in those terms.
 - **Mechanically:** `_ATX_HEADING_RE`'s trailing whitespace run narrows from
   `\s*` (which crosses line boundaries) to `[^\S\r\n]*` (horizontal only), so a
   heading's `line_end` is genuinely the end of its heading line in every
@@ -43,16 +49,28 @@ zero-divergence envelope forbade — so the contract decision belongs here.
   Nothing else in the resolver changes: heading *text*, depth, ordinals,
   `line_start`, and every selector form are unaffected, so no existing selector
   starts naming a different section.
-- **BREAKING (declared, and the point of the change):** whitespace and fenced
-  blocks that sit between a heading line and its first line of prose are now
-  part of the body. Two consequences on notes that exist today:
+- **`replace_section` SHALL insert a separator newline only for a non-empty
+  replacement body.** Today it appends one before the following heading, and
+  prepends one after an unterminated EOF heading, unconditionally — so an
+  *empty* section is not round-trip stable even with the regex fixed
+  (`# A\n# B\nb\n` gains a blank line; `# A` gains a newline). Verified against
+  the current helpers. Without this the headline property is false for the
+  commonest degenerate note.
+- **BREAKING (declared, and the point of the change) — and it is destructive,
+  not cosmetic.** Everything between a heading line and the next heading of
+  equal-or-shallower depth is now the body, so a section write replaces all of
+  it. Consequences on notes that exist today:
   - `edit_note(section="Tasks", content="- x")` on `## Tasks\n\n- old\n`
     now writes `## Tasks\n- x\n`, not `## Tasks\n\n- x\n`. The blank separator
-    is the caller's to send (`content="\n- x"`), and a caller that round-trips
-    a read gets it back for free.
-  - A fenced block directly under a heading is now *replaced* by a section
-    write rather than being left behind with new content inserted after it.
-    That is the fix, not a regression: leaving it was the duplication bug.
+    is the caller's to send (`content="\n- x"`).
+  - **A fenced block directly under a heading is now deleted** by a section
+    write whose `content` does not resend it. On
+    `# A\n\u0060\u0060\u0060\nimportant\n\u0060\u0060\u0060\nold\n`,
+    `edit_note(section="A", content="new")` previously kept the block and
+    replaced only `old`; it now yields `# A\nnew\n`. That is the intended
+    contract — leaving the block behind *was* the duplication bug — but the
+    blast radius is content loss for a caller that does not round-trip, and
+    both the docstrings and `vault-tools.md` must say so in those words.
 - Docstrings at both layers — the registered wrappers in `server.py` (what MCP
   clients see) and the `tools.py` impls — state the round-trip contract in the
   terms callers need: *the section response minus its first line is exactly
@@ -78,15 +96,37 @@ zero-divergence envelope forbade — so the contract decision belongs here.
 ## Impact
 
 - `src/services/vault.py` — `_ATX_HEADING_RE` (the trailing class only) and the
-  comment block above it, which currently documents the opposite decision.
-  `_scan_headings`, `_section_body_span`, `extract_section`, `replace_section`
-  and `outline_sections` keep their signatures and their roles.
+  comment block above it, which currently documents the opposite decision; plus
+  `replace_section`'s two separator insertions, which become conditional on a
+  non-empty body. `_scan_headings`, `_section_body_span`, `extract_section`,
+  `replace_section` and `outline_sections` keep their signatures and their
+  roles.
 - `src/mcp_server/server.py` and `src/mcp_server/tools.py` — docstrings only.
 - `docs/architecture/vault-tools.md` — the section-addressing section.
 - **No schema change, no migration, no index effect.** `outline_sections`'
-  reported `size` shifts by the bytes that moved from heading to body for
-  sections that had a blank line or a leading fence; it is a display number in
-  a truncation outline, and the `#N` ordinals it advertises are unchanged.
+  reported `size` is `body_end - line_start`; this change moves neither
+  endpoint, so both the sizes and the `#N` ordinals in a truncation outline are
+  **unchanged**. Verified across the corpus.
+- **Declared residual (pre-existing, unchanged here): the code masker's fence
+  grammar is narrower than CommonMark.** `_FENCE_RE` recognises only a
+  column-zero opener closed by a fence of exactly the same length, so an
+  indented fence, or one closed by a longer run, is not masked — a heading
+  inside such a block is selectable, and a section write there already deletes
+  the opening fence and orphans the contents. Measured before and after this
+  change: the bytes written are **identical**, so this change neither creates
+  nor worsens it. Fixing the masker shifts which lines count as headings and
+  therefore re-addresses every `#N` ordinal on affected notes, which is a
+  larger compat break than this one and belongs in its own change; filed
+  separately. The spec here says "fenced code block **as recognised by the
+  shared masker**" rather than claiming CommonMark coverage it does not have.
+- **Declared residual: newline dialect.** `read_note` applies universal-newline
+  translation; `edit_note` reads and rewrites raw bytes. A section round trip
+  on a CRLF note therefore rewrites *that section's* terminators as LF while
+  the retained heading line and the rest of the note keep CRLF — measured:
+  `# A\r\nold\r\n# B\r\nkeep\r\n` becomes `# A\r\nold\n# B\r\nkeep\r\n`.
+  This is the section-mode instance of the whole-note residual #128 already
+  declared; the byte-identity guarantee is stated for LF-bodied notes only, and
+  the docstrings say so.
 - Notes already in the vault are not rewritten. The change is to what a *future*
   section write does, and the direction is strictly toward preserving what the
   caller read.

--- a/openspec/changes/section-round-trip-140/proposal.md
+++ b/openspec/changes/section-round-trip-140/proposal.md
@@ -43,17 +43,29 @@ zero-divergence envelope forbade — so the contract decision belongs here.
   take the text after the response's first `\n---\n` separator, then drop its
   first line. Both docstrings SHALL say this in those terms.
 - **The envelope SHALL be framed unambiguously, so that rule is safe to
-  follow.** `read_note` interpolates the title, path, tags and frontmatter
-  values into the envelope unsanitized, and a note may legitimately carry a
-  multiline YAML title. Reproduced: frontmatter
-  `title: |-` with a `---` line inside it emits a bare `---` line *above* the
-  real separator, so the documented split lands inside the envelope and the
-  round trip writes `**Path:** \u0060n.md\u0060` into the note — the
-  documentation itself becoming the destructive instruction. Every dynamic
-  envelope value is therefore rendered on a single line (interior line
-  terminators collapsed to spaces), which also repairs the display bug where
-  such a title already breaks the response layout on an ordinary whole-note
-  read. The note body is never sanitized — only the envelope's own fields.
+  follow — stated as an invariant, not a list of fields.** No dynamic component
+  of a successful response's envelope may contain a line terminator, enforced at
+  a single rendering choke point that title, path, tags, frontmatter **keys**
+  and frontmatter values all pass through. The enumeration is what failed twice:
+  audit round 2 found a multiline *title* could forge the separator, round 3
+  found a multiline frontmatter *key* could do it through the
+  `**Frontmatter:**` block. Both are valid YAML. Patching the named field would
+  have invited a third.
+
+  Concretely, before this change: the valid key `"safe\n---\nforged": value` renders as two
+  lines inside the `**Frontmatter:**` block, and the documented extraction then
+  yields `\n---\n# A\nold\n` — which written back clobbers the section. Both
+  reproductions are in the tasks as end-to-end cases, alongside a guard test
+  that names no field at all: no line before the envelope separator may be
+  exactly `---`.
+
+  A component is rendered by stringifying it and collapsing terminators in the
+  *resulting* string, which is deterministic and needs no rule about recursing
+  into composites — `str()` escapes newlines inside a list or dict, so only a
+  bare string component can carry one through. This also repairs the existing
+  display bug where such a title breaks the response layout on an ordinary
+  whole-note read. The note body is never sanitized, and error responses — which
+  carry no envelope and no selected content — are out of scope.
 - **Mechanically:** `_ATX_HEADING_RE`'s trailing whitespace run narrows from
   `\s*` (which crosses line boundaries) to `[^\S\r\n]*` (horizontal only), so a
   heading's `line_end` is genuinely the end of its heading line in every

--- a/openspec/changes/section-round-trip-140/proposal.md
+++ b/openspec/changes/section-round-trip-140/proposal.md
@@ -1,0 +1,92 @@
+## Why
+
+Issue #140 (found by #128's differential harness, deliberately deferred there):
+`read_note(section=…)` and `edit_note(section=…)` disagree about where a
+section's body *begins*, so the natural agent round trip — read a section,
+change something, write the part after the heading line back — is not
+byte-stable on ordinary LF notes.
+
+Two observable failures, one root cause:
+
+1. **Fenced-code duplication.** On `# A\n` + a fenced block + `# B`,
+   `read_note(section="#1")` returns the code block, but
+   `edit_note(section="#1")` computes an **empty** body span positioned after
+   it. Writing the read body back leaves the original block in place and
+   inserts a second copy. Verified: the round trip turns
+   `'# A\n```\n## Hidden\ntext\n```\n# B\nb\n'` into a note carrying the fence
+   twice.
+2. **Blank-line accumulation.** A blank line after a heading is absorbed into
+   the heading match, so it is inside what read returns and outside what write
+   replaces. Each round trip re-emits it *and* keeps the original. Verified:
+   `'# A\n\nbody\n\n# B\nb\n'` gains blank lines super-linearly — one round
+   trip adds one, the next adds two, the next adds four.
+
+Both are the read/write-parity family #128 hardened, and both are the product's
+top failure class: an agent acting on `read_note`'s answer corrupts the note and
+reports success. They were left out of #128 because any fix changes the bytes
+`edit_note(section=…)` writes on common notes — the exact compat break #128's
+zero-divergence envelope forbade — so the contract decision belongs here.
+
+## What Changes
+
+- **A section's body SHALL begin on the line immediately after the heading
+  line.** This is the whole change, stated once and applied to both sides:
+  `read_note(section=S)` returns the heading line, its terminator, and that
+  body; `edit_note(section=S, content=B)` replaces exactly that body. The
+  portion of a section response after its first line is therefore precisely the
+  region a section write replaces, and the round trip is byte-identical on LF
+  notes.
+- **Mechanically:** `_ATX_HEADING_RE`'s trailing whitespace run narrows from
+  `\s*` (which crosses line boundaries) to `[^\S\r\n]*` (horizontal only), so a
+  heading's `line_end` is genuinely the end of its heading line in every
+  dialect. `_section_body_span` keeps stepping over exactly one terminator.
+  Nothing else in the resolver changes: heading *text*, depth, ordinals,
+  `line_start`, and every selector form are unaffected, so no existing selector
+  starts naming a different section.
+- **BREAKING (declared, and the point of the change):** whitespace and fenced
+  blocks that sit between a heading line and its first line of prose are now
+  part of the body. Two consequences on notes that exist today:
+  - `edit_note(section="Tasks", content="- x")` on `## Tasks\n\n- old\n`
+    now writes `## Tasks\n- x\n`, not `## Tasks\n\n- x\n`. The blank separator
+    is the caller's to send (`content="\n- x"`), and a caller that round-trips
+    a read gets it back for free.
+  - A fenced block directly under a heading is now *replaced* by a section
+    write rather than being left behind with new content inserted after it.
+    That is the fix, not a regression: leaving it was the duplication bug.
+- Docstrings at both layers — the registered wrappers in `server.py` (what MCP
+  clients see) and the `tools.py` impls — state the round-trip contract in the
+  terms callers need: *the section response minus its first line is exactly
+  what `edit_note(section=…)` takes*.
+- `docs/architecture/vault-tools.md` is updated in the same change: its
+  "the trailing run stays the original `\s*` … narrowing it would change the
+  bytes `edit_note(section=…)` writes on ordinary LF notes" note is now the
+  *history* of a constraint this change deliberately lifts, and must say so
+  rather than continuing to forbid the fix.
+
+## Capabilities
+
+### New Capabilities
+
+(none)
+
+### Modified Capabilities
+
+- `vault-write`: section mode's body-span definition, and the round-trip
+  guarantee it now owes `note-read`.
+- `note-read`: the section response's relationship to the section write span.
+
+## Impact
+
+- `src/services/vault.py` — `_ATX_HEADING_RE` (the trailing class only) and the
+  comment block above it, which currently documents the opposite decision.
+  `_scan_headings`, `_section_body_span`, `extract_section`, `replace_section`
+  and `outline_sections` keep their signatures and their roles.
+- `src/mcp_server/server.py` and `src/mcp_server/tools.py` — docstrings only.
+- `docs/architecture/vault-tools.md` — the section-addressing section.
+- **No schema change, no migration, no index effect.** `outline_sections`'
+  reported `size` shifts by the bytes that moved from heading to body for
+  sections that had a blank line or a leading fence; it is a display number in
+  a truncation outline, and the `#N` ordinals it advertises are unchanged.
+- Notes already in the vault are not rewritten. The change is to what a *future*
+  section write does, and the direction is strictly toward preserving what the
+  caller read.

--- a/openspec/changes/section-round-trip-140/proposal.md
+++ b/openspec/changes/section-round-trip-140/proposal.md
@@ -74,7 +74,9 @@ zero-divergence envelope forbade — so the contract decision belongs here.
     write whose `content` does not resend it. On
     `# A\n```\nimportant\n```\nold\n`,
     `edit_note(section="A", content="new")` previously kept the block and
-    replaced only `old`; it now yields `# A\nnew\n`. That is the intended
+    replaced only `old`; it now yields `# A\nnew` — no trailing newline,
+    because `A` is the last heading and the trailing separator exists only to
+    keep a following heading from gluing onto the body. That is the intended
     contract — leaving the block behind *was* the duplication bug — but the
     blast radius is content loss for a caller that does not round-trip, and
     both the docstrings and `vault-tools.md` must say so in those words.

--- a/openspec/changes/section-round-trip-140/proposal.md
+++ b/openspec/changes/section-round-trip-140/proposal.md
@@ -42,6 +42,18 @@ zero-divergence envelope forbade — so the contract decision belongs here.
   spec used — would write `**Path:** \u0060…\u0060` into the note. The rule is:
   take the text after the response's first `\n---\n` separator, then drop its
   first line. Both docstrings SHALL say this in those terms.
+- **The envelope SHALL be framed unambiguously, so that rule is safe to
+  follow.** `read_note` interpolates the title, path, tags and frontmatter
+  values into the envelope unsanitized, and a note may legitimately carry a
+  multiline YAML title. Reproduced: frontmatter
+  `title: |-` with a `---` line inside it emits a bare `---` line *above* the
+  real separator, so the documented split lands inside the envelope and the
+  round trip writes `**Path:** \u0060n.md\u0060` into the note — the
+  documentation itself becoming the destructive instruction. Every dynamic
+  envelope value is therefore rendered on a single line (interior line
+  terminators collapsed to spaces), which also repairs the display bug where
+  such a title already breaks the response layout on an ordinary whole-note
+  read. The note body is never sanitized — only the envelope's own fields.
 - **Mechanically:** `_ATX_HEADING_RE`'s trailing whitespace run narrows from
   `\s*` (which crosses line boundaries) to `[^\S\r\n]*` (horizontal only), so a
   heading's `line_end` is genuinely the end of its heading line in every
@@ -73,8 +85,10 @@ zero-divergence envelope forbade — so the contract decision belongs here.
     both the docstrings and `vault-tools.md` must say so in those words.
 - Docstrings at both layers — the registered wrappers in `server.py` (what MCP
   clients see) and the `tools.py` impls — state the round-trip contract in the
-  terms callers need: *the section response minus its first line is exactly
-  what `edit_note(section=…)` takes*.
+  terms callers need: *take the text after the section response's `\n---\n`
+  envelope separator, drop its first line, and that is exactly what
+  `edit_note(section=…)` takes*. They SHALL NOT say "the response minus its
+  first line" — the response's first line is the envelope's `# <title>`.
 - `docs/architecture/vault-tools.md` is updated in the same change: its
   "the trailing run stays the original `\s*` … narrowing it would change the
   bytes `edit_note(section=…)` writes on ordinary LF notes" note is now the
@@ -101,7 +115,10 @@ zero-divergence envelope forbade — so the contract decision belongs here.
   non-empty body. `_scan_headings`, `_section_body_span`, `extract_section`,
   `replace_section` and `outline_sections` keep their signatures and their
   roles.
-- `src/mcp_server/server.py` and `src/mcp_server/tools.py` — docstrings only.
+- `src/mcp_server/tools.py` — `read_note_impl`'s envelope construction, so no
+  interpolated field can emit a bare `\n---\n` line; plus `edit_note`'s and
+  `read_note`'s docstrings. `src/mcp_server/server.py` — the registered
+  wrappers' docstrings, which must carry the same statements.
 - `docs/architecture/vault-tools.md` — the section-addressing section.
 - **No schema change, no migration, no index effect.** `outline_sections`'
   reported `size` is `body_end - line_start`; this change moves neither

--- a/openspec/changes/section-round-trip-140/specs/note-read/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/note-read/spec.md
@@ -89,14 +89,15 @@ line into the note.
 
 ### Requirement: The response envelope SHALL be unambiguously terminated
 
-Every value `read_note` interpolates into a response's envelope SHALL be rendered on a single line, with any interior line terminator replaced by a space. This covers the title, the path, the tags, and each frontmatter value. No dynamic
-envelope value SHALL be able to emit a bare `---` line, so the first `\n---\n`
-in any `read_note` response is always the envelope's own separator.
+No dynamic component interpolated into a successful `read_note` response's envelope SHALL contain a line terminator. This is stated as an invariant over *every* component rather than as a list of fields, and SHALL be enforced at a single rendering choke point that every component passes through — the title, the path, each tag, **each frontmatter key**, and each frontmatter value alike, together with any component added later. Enumerating today's fields is what let two successive audit rounds each find a different field that could forge the separator; the invariant is what closes the class.
 
-This is load-bearing rather than cosmetic: the section round-trip contract
-instructs callers to split on that separator, so a value that can forge one
-turns the documentation into a destructive instruction. The note **body** SHALL
-NOT be sanitized — only the envelope's own fields.
+A component SHALL be rendered by stringifying it and replacing every LF, CRLF, or lone CR in the **resulting string** with a single space. Applying the rule to the rendered string rather than recursively to a composite's leaves is deterministic and needs no normalization order: Python's `str()` of a list or dict escapes interior newlines, so only a bare string component can carry a literal terminator into the envelope.
+
+Consequently the first `\n---\n` in a successful, enveloped response is always the envelope's own separator, which is what makes the section round-trip extraction safe to document.
+
+The guarantee is scoped to **successful responses that carry an envelope**. Error and end-of-content responses — a missing note, an out-of-range `offset`, an unknown section — carry no envelope and no selected content, so no extraction contract applies to them; they are outside this requirement and SHALL NOT be read as promising anything about their `---` lines.
+
+The note **body** SHALL NOT be sanitized — only the envelope's own components.
 
 #### Scenario: A multiline title cannot forge the separator
 
@@ -109,6 +110,24 @@ NOT be sanitized — only the envelope's own fields.
   back leaves the note unchanged — rather than yielding a remainder beginning
   `**Path:**` and clobbering the section
 
+#### Scenario: A multiline frontmatter KEY cannot forge the separator
+
+- **WHEN** a note's frontmatter contains the valid quoted key
+  `"safe\n---\nforged": value` and the client calls
+  `read_note(path, section="#1")`
+- **THEN** the rendered key SHALL occupy one line, so the response contains no
+  `---` line before the envelope separator
+- **AND** the documented extraction SHALL yield the section rather than
+  `\n---\n# A\nold\n`, which written back would clobber the section
+
+#### Scenario: Composite frontmatter values are rendered deterministically
+
+- **WHEN** a frontmatter value is a list or a dict whose string leaves contain
+  newlines, for example `items: ["a\nb"]`
+- **THEN** the component SHALL be stringified first and the terminators
+  collapsed in the resulting string, yielding one line
+- **AND** the rule SHALL NOT depend on recursing into the composite's leaves
+
 #### Scenario: A body containing a separator line is unaffected
 
 - **WHEN** the selected section's body itself contains a `\n---\n` line (a
@@ -120,7 +139,7 @@ NOT be sanitized — only the envelope's own fields.
 
 #### Scenario: The note body is never sanitized
 
-- **WHEN** any `read_note` response is produced
-- **THEN** only envelope fields SHALL have line terminators collapsed
+- **WHEN** a successful enveloped `read_note` response is produced
+- **THEN** only envelope components SHALL have line terminators collapsed
 - **AND** the note content portion SHALL be byte-exact apart from the read
   path's pre-existing universal-newline translation

--- a/openspec/changes/section-round-trip-140/specs/note-read/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/note-read/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Section selection in read_note
+
+When `section` is supplied, `read_note` SHALL return only the named section — the matched ATX heading line together with the content up to the next heading of equal-or-shallower depth, or end of note. The selector SHALL accept the same forms as the write tools: exact heading text, the path-style `Parent/Child` form, and the `#N` ordinal form.
+
+A section response SHALL be subject to the same response-size cap, and `offset` SHALL window within the selected section rather than within the whole note.
+
+An untruncated section response SHALL be exactly the heading line, its line
+terminator, and the section's body as `edit_note(section=…)` defines it —
+nothing more and nothing less. There SHALL be no region of a note that a
+section read returns but a section write to the same selector cannot replace:
+whitespace, blank lines, and fenced code blocks between the heading line and
+the next heading of equal-or-shallower depth are part of the body on both
+sides. Consequently, stripping the first line from an untruncated section
+response and passing the remainder back as `edit_note(path, content=<remainder>,
+section=<same selector>)` SHALL leave an LF-bodied note byte-identical.
+
+#### Scenario: Reading one section of a large note
+
+- **WHEN** `read_note` is invoked with a `section` that is within the cap, on a note that is not
+- **THEN** the response SHALL contain that section's heading and body
+- **AND** SHALL NOT contain content from other sections
+- **AND** SHALL NOT be truncated
+
+#### Scenario: A section read returns nothing a section write cannot replace
+
+- **WHEN** `read_note(path, section=<sel>)` returns an untruncated section
+  whose body begins with a blank line, or with a fenced code block, or both
+- **THEN** every byte of the response after its first line SHALL fall inside
+  the span `edit_note(path, content, section=<sel>)` replaces
+- **AND** writing that remainder back SHALL reproduce the note exactly
+
+#### Scenario: Section larger than the cap
+
+- **WHEN** the selected section itself exceeds `MAX_READ_RESPONSE_CHARS`
+- **THEN** the response SHALL be truncated with a notice identifying the section and the continuing `offset`
+- **AND** the continuation SHALL preserve the `section` selection
+- **AND** the round-trip guarantee SHALL NOT apply to such a response, which
+  is a window rather than a whole section
+
+#### Scenario: Unknown section
+
+- **WHEN** `read_note` is invoked with a `section` that matches no heading
+- **THEN** the response SHALL list the headings that are present
+- **AND** SHALL NOT return note content

--- a/openspec/changes/section-round-trip-140/specs/note-read/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/note-read/spec.md
@@ -6,15 +6,28 @@ When `section` is supplied, `read_note` SHALL return only the named section — 
 
 A section response SHALL be subject to the same response-size cap, and `offset` SHALL window within the selected section rather than within the whole note.
 
-An untruncated section response SHALL be exactly the heading line, its line
+A section response SHALL carry the same title/path/tags envelope as every
+other `read_note` response, terminated by a `\n---\n` separator line, followed
+by the **selected-content portion**. The selected-content portion of an
+untruncated section response SHALL be exactly the heading line, its line
 terminator, and the section's body as `edit_note(section=…)` defines it —
 nothing more and nothing less. There SHALL be no region of a note that a
 section read returns but a section write to the same selector cannot replace:
-whitespace, blank lines, and fenced code blocks between the heading line and
-the next heading of equal-or-shallower depth are part of the body on both
-sides. Consequently, stripping the first line from an untruncated section
-response and passing the remainder back as `edit_note(path, content=<remainder>,
-section=<same selector>)` SHALL leave an LF-bodied note byte-identical.
+whitespace, blank lines, and fenced code blocks (as recognised by the shared
+code masker) between the heading line and the next heading of
+equal-or-shallower depth are part of the body on both sides.
+
+The round trip SHALL therefore be specified over the selected-content portion,
+never over the response as a whole. The extraction is: take the text following
+the response's first `\n---\n` separator, then drop its first line. Passing
+that remainder back as `edit_note(path, content=<remainder>,
+section=<same selector>)` SHALL leave a note whose body newlines are LF
+byte-identical.
+
+A specification or docstring that instructs a caller to strip the response's
+own first line SHALL be treated as a defect: the response's first line is
+`# <title>`, and following that instruction writes the envelope's `**Path:**`
+line into the note.
 
 #### Scenario: Reading one section of a large note
 
@@ -27,9 +40,31 @@ section=<same selector>)` SHALL leave an LF-bodied note byte-identical.
 
 - **WHEN** `read_note(path, section=<sel>)` returns an untruncated section
   whose body begins with a blank line, or with a fenced code block, or both
-- **THEN** every byte of the response after its first line SHALL fall inside
-  the span `edit_note(path, content, section=<sel>)` replaces
-- **AND** writing that remainder back SHALL reproduce the note exactly
+- **THEN** every byte of the selected-content portion after its first line
+  SHALL fall inside the span `edit_note(path, content, section=<sel>)` replaces
+- **AND** writing that remainder back SHALL reproduce an LF-bodied note exactly
+
+#### Scenario: The response envelope is not part of the section
+
+- **WHEN** a note `n.md` contains `# A\nold\n` and the client calls
+  `read_note(path="n.md", section="#1")`
+- **THEN** the response SHALL begin with the title/path envelope and a
+  `\n---\n` separator, and the selected content SHALL begin only after it
+- **AND** a caller that drops the response's own first line and writes the
+  remainder back SHALL corrupt the note — so the documented extraction rule
+  SHALL be the separator-based one, and both `read_note`'s and `edit_note`'s
+  docstrings SHALL state it
+
+#### Scenario: A CRLF note's section round trip is not byte-identical
+
+- **WHEN** a note's raw bytes are `# A\r\nold\r\n# B\r\nkeep\r\n` and its
+  first section is read and written back unchanged
+- **THEN** the round trip SHALL preserve the section's *content*, and the
+  resulting note SHALL be `# A\r\nold\n# B\r\nkeep\r\n` — the selected body's
+  terminators become LF because the read path normalises and the write path
+  works on raw bytes
+- **AND** this residual SHALL be declared in both docstrings rather than
+  claimed as byte-identity, which holds only for LF-bodied notes
 
 #### Scenario: Section larger than the cap
 

--- a/openspec/changes/section-round-trip-140/specs/note-read/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/note-read/spec.md
@@ -6,33 +6,33 @@ When `section` is supplied, `read_note` SHALL return only the named section — 
 
 A section response SHALL be subject to the same response-size cap, and `offset` SHALL window within the selected section rather than within the whole note.
 
-A section response SHALL carry the same title/path/tags envelope as every
-other `read_note` response, terminated by a `\n---\n` separator line, followed
-by the **selected-content portion**. The selected-content portion of an
-untruncated section response SHALL be exactly the heading line, its line
-terminator, and the section's body as `edit_note(section=…)` defines it —
-nothing more and nothing less. There SHALL be no region of a note that a
-section read returns but a section write to the same selector cannot replace:
-whitespace, blank lines, and fenced code blocks (as recognised by the shared
-code masker) between the heading line and the next heading of
-equal-or-shallower depth are part of the body on both sides.
+The **selected content** a section response carries — the note text within it,
+as distinct from the title/path/tags envelope every `read_note` response
+begins with — SHALL be exactly the heading line, its line terminator, and the
+section's body as `edit_note(section=…)` defines it: nothing more and nothing
+less. There SHALL be no region of a note that a section read returns but a
+section write to the same selector cannot replace. Whitespace, blank lines, and
+fenced code blocks (as recognised by the shared code masker) between the
+heading line and the next heading of equal-or-shallower depth are part of the
+body on both sides.
 
-The round trip SHALL therefore be specified over the selected-content portion,
-never over the response as a whole. The extraction is: take the text following
-the response's first `\n---\n` separator, then drop its first line. Passing
-that remainder back as `edit_note(path, content=<remainder>,
-section=<same selector>)` SHALL leave a note whose body newlines are LF
-byte-identical.
+This is a requirement on what the read and write agree about, and it SHALL be
+verifiable directly against the shared section helpers, which operate on note
+text rather than on a rendered response.
 
-That extraction is only safe if the first `\n---\n` in a response is always the
-envelope's own separator, so the envelope SHALL be framed unambiguously — see
-the requirement below. A body that itself contains a `\n---\n` line is not a
-problem, because the envelope's separator precedes it.
-
-A specification or docstring that instructs a caller to strip the response's
-own first line SHALL be treated as a defect: the response's first line is
-`# <title>`, and following that instruction writes the envelope's `**Path:**`
-line into the note.
+**This requirement deliberately does NOT define a textual procedure for
+recovering the selected content from a rendered response, and no docstring
+SHALL instruct a caller to perform one.** Every such procedure proposed for
+this change was forgeable: the envelope interpolates the title, the path, the
+tags and each frontmatter key and value, and a valid note can make any of them
+emit a line that mimics the envelope's own `---` separator, so a caller
+following the procedure writes `**Path:** …` into the note. Sanitising the
+named fields does not close it — two successive audit rounds each found a
+different field — and collapsing terminators to make them safe is itself lossy,
+rendering the distinct paths `a\nb.md` and `a b.md` identically. Making the
+selected content unambiguously recoverable requires structural framing of the
+response and is tracked as its own change; until it lands, the round-trip
+guarantee is stated over note text, not over response text.
 
 #### Scenario: Reading one section of a large note
 
@@ -43,22 +43,23 @@ line into the note.
 
 #### Scenario: A section read returns nothing a section write cannot replace
 
-- **WHEN** `read_note(path, section=<sel>)` returns an untruncated section
-  whose body begins with a blank line, or with a fenced code block, or both
-- **THEN** every byte of the selected-content portion after its first line
-  SHALL fall inside the span `edit_note(path, content, section=<sel>)` replaces
-- **AND** writing that remainder back SHALL reproduce an LF-bodied note exactly
+- **WHEN** a section is selected whose body begins with a blank line, or with
+  a fenced code block, or both
+- **THEN** every byte of the selected content after its heading line SHALL
+  fall inside the span `edit_note(path, content, section=<sel>)` replaces
+- **AND** passing that body back SHALL reproduce an LF-bodied note exactly
 
-#### Scenario: The response envelope is not part of the section
+#### Scenario: No docstring prescribes a textual extraction
 
-- **WHEN** a note `n.md` contains `# A\nold\n` and the client calls
-  `read_note(path="n.md", section="#1")`
-- **THEN** the response SHALL begin with the title/path envelope and a
-  `\n---\n` separator, and the selected content SHALL begin only after it
-- **AND** a caller that drops the response's own first line and writes the
-  remainder back SHALL corrupt the note — so the documented extraction rule
-  SHALL be the separator-based one, and both `read_note`'s and `edit_note`'s
-  docstrings SHALL state it
+- **WHEN** the `read_note` or `edit_note` documentation describes how a
+  section read relates to a section write
+- **THEN** it SHALL describe the relationship — a section response carries the
+  heading line and the body; `edit_note(section=…)` takes the body — without
+  instructing the caller to split the response on a separator or to drop its
+  first line
+- **AND** the reason SHALL be recorded where a future author will find it:
+  such a procedure is forgeable by note content, and following it corrupts the
+  note
 
 #### Scenario: A CRLF note's section round trip is not byte-identical
 
@@ -84,62 +85,3 @@ line into the note.
 - **WHEN** `read_note` is invoked with a `section` that matches no heading
 - **THEN** the response SHALL list the headings that are present
 - **AND** SHALL NOT return note content
-
-## ADDED Requirements
-
-### Requirement: The response envelope SHALL be unambiguously terminated
-
-No dynamic component interpolated into a successful `read_note` response's envelope SHALL contain a line terminator. This is stated as an invariant over *every* component rather than as a list of fields, and SHALL be enforced at a single rendering choke point that every component passes through — the title, the path, each tag, **each frontmatter key**, and each frontmatter value alike, together with any component added later. Enumerating today's fields is what let two successive audit rounds each find a different field that could forge the separator; the invariant is what closes the class.
-
-A component SHALL be rendered by stringifying it and replacing every LF, CRLF, or lone CR in the **resulting string** with a single space. Applying the rule to the rendered string rather than recursively to a composite's leaves is deterministic and needs no normalization order: Python's `str()` of a list or dict escapes interior newlines, so only a bare string component can carry a literal terminator into the envelope.
-
-Consequently the first `\n---\n` in a successful, enveloped response is always the envelope's own separator, which is what makes the section round-trip extraction safe to document.
-
-The guarantee is scoped to **successful responses that carry an envelope**. Error and end-of-content responses — a missing note, an out-of-range `offset`, an unknown section — carry no envelope and no selected content, so no extraction contract applies to them; they are outside this requirement and SHALL NOT be read as promising anything about their `---` lines.
-
-The note **body** SHALL NOT be sanitized — only the envelope's own components.
-
-#### Scenario: A multiline title cannot forge the separator
-
-- **WHEN** a note's frontmatter is `title: |-` with a multiline scalar whose
-  lines include markup and a bare `---`, and the client calls
-  `read_note(path, section=<sel>)`
-- **THEN** the envelope SHALL render that title on one line, and the first
-  `\n---\n` in the response SHALL be the envelope separator
-- **AND** the documented extraction SHALL yield the section, so writing it
-  back leaves the note unchanged — rather than yielding a remainder beginning
-  `**Path:**` and clobbering the section
-
-#### Scenario: A multiline frontmatter KEY cannot forge the separator
-
-- **WHEN** a note's frontmatter contains the valid quoted key
-  `"safe\n---\nforged": value` and the client calls
-  `read_note(path, section="#1")`
-- **THEN** the rendered key SHALL occupy one line, so the response contains no
-  `---` line before the envelope separator
-- **AND** the documented extraction SHALL yield the section rather than
-  `\n---\n# A\nold\n`, which written back would clobber the section
-
-#### Scenario: Composite frontmatter values are rendered deterministically
-
-- **WHEN** a frontmatter value is a list or a dict whose string leaves contain
-  newlines, for example `items: ["a\nb"]`
-- **THEN** the component SHALL be stringified first and the terminators
-  collapsed in the resulting string, yielding one line
-- **AND** the rule SHALL NOT depend on recursing into the composite's leaves
-
-#### Scenario: A body containing a separator line is unaffected
-
-- **WHEN** the selected section's body itself contains a `\n---\n` line (a
-  thematic break)
-- **THEN** the extraction SHALL still select the whole section, because the
-  envelope's separator occurs first
-- **AND** the body's own `---` line SHALL be returned and written back
-  unchanged
-
-#### Scenario: The note body is never sanitized
-
-- **WHEN** a successful enveloped `read_note` response is produced
-- **THEN** only envelope components SHALL have line terminators collapsed
-- **AND** the note content portion SHALL be byte-exact apart from the read
-  path's pre-existing universal-newline translation

--- a/openspec/changes/section-round-trip-140/specs/note-read/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/note-read/spec.md
@@ -13,7 +13,18 @@ section's body as `edit_note(section=…)` defines it: nothing more and nothing
 less. Apart from the heading line and its terminator — which a section read
 returns and a section write deliberately preserves — there SHALL be no region
 of a note that a section read returns but a section write to the same selector
-cannot replace. Whitespace, blank lines, and
+cannot replace.
+
+The parity claim is scoped to notes for which section-mode writing is
+**admitted**. A note whose line-1 frontmatter is defective (unclosed fence,
+YAML error, or non-mapping) stays readable by section — the read scans its raw
+bytes — while every section write to it is refused by name, per the vault-write
+requirement this change does not relax. On such a note the guarantee is the
+refusal, not the round trip: it is the safe asymmetry, and widening parity to
+cover it would mean scanning a broken block for headings on the write side,
+which is the destructive behaviour #128 removed.
+
+Whitespace, blank lines, and
 fenced code blocks (as recognised by the shared code masker) between the
 heading line and the next heading of equal-or-shallower depth are part of the
 body on both sides.

--- a/openspec/changes/section-round-trip-140/specs/note-read/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/note-read/spec.md
@@ -10,8 +10,10 @@ The **selected content** a section response carries — the note text within it,
 as distinct from the title/path/tags envelope every `read_note` response
 begins with — SHALL be exactly the heading line, its line terminator, and the
 section's body as `edit_note(section=…)` defines it: nothing more and nothing
-less. There SHALL be no region of a note that a section read returns but a
-section write to the same selector cannot replace. Whitespace, blank lines, and
+less. Apart from the heading line and its terminator — which a section read
+returns and a section write deliberately preserves — there SHALL be no region
+of a note that a section read returns but a section write to the same selector
+cannot replace. Whitespace, blank lines, and
 fenced code blocks (as recognised by the shared code masker) between the
 heading line and the next heading of equal-or-shallower depth are part of the
 body on both sides.

--- a/openspec/changes/section-round-trip-140/specs/note-read/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/note-read/spec.md
@@ -24,6 +24,11 @@ that remainder back as `edit_note(path, content=<remainder>,
 section=<same selector>)` SHALL leave a note whose body newlines are LF
 byte-identical.
 
+That extraction is only safe if the first `\n---\n` in a response is always the
+envelope's own separator, so the envelope SHALL be framed unambiguously — see
+the requirement below. A body that itself contains a `\n---\n` line is not a
+problem, because the envelope's separator precedes it.
+
 A specification or docstring that instructs a caller to strip the response's
 own first line SHALL be treated as a defect: the response's first line is
 `# <title>`, and following that instruction writes the envelope's `**Path:**`
@@ -79,3 +84,43 @@ line into the note.
 - **WHEN** `read_note` is invoked with a `section` that matches no heading
 - **THEN** the response SHALL list the headings that are present
 - **AND** SHALL NOT return note content
+
+## ADDED Requirements
+
+### Requirement: The response envelope SHALL be unambiguously terminated
+
+Every value `read_note` interpolates into a response's envelope SHALL be rendered on a single line, with any interior line terminator replaced by a space. This covers the title, the path, the tags, and each frontmatter value. No dynamic
+envelope value SHALL be able to emit a bare `---` line, so the first `\n---\n`
+in any `read_note` response is always the envelope's own separator.
+
+This is load-bearing rather than cosmetic: the section round-trip contract
+instructs callers to split on that separator, so a value that can forge one
+turns the documentation into a destructive instruction. The note **body** SHALL
+NOT be sanitized — only the envelope's own fields.
+
+#### Scenario: A multiline title cannot forge the separator
+
+- **WHEN** a note's frontmatter is `title: |-` with a multiline scalar whose
+  lines include markup and a bare `---`, and the client calls
+  `read_note(path, section=<sel>)`
+- **THEN** the envelope SHALL render that title on one line, and the first
+  `\n---\n` in the response SHALL be the envelope separator
+- **AND** the documented extraction SHALL yield the section, so writing it
+  back leaves the note unchanged — rather than yielding a remainder beginning
+  `**Path:**` and clobbering the section
+
+#### Scenario: A body containing a separator line is unaffected
+
+- **WHEN** the selected section's body itself contains a `\n---\n` line (a
+  thematic break)
+- **THEN** the extraction SHALL still select the whole section, because the
+  envelope's separator occurs first
+- **AND** the body's own `---` line SHALL be returned and written back
+  unchanged
+
+#### Scenario: The note body is never sanitized
+
+- **WHEN** any `read_note` response is produced
+- **THEN** only envelope fields SHALL have line terminators collapsed
+- **AND** the note content portion SHALL be byte-exact apart from the read
+  path's pre-existing universal-newline translation

--- a/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
@@ -79,7 +79,8 @@ scans there.
   `<sel>` (`offset=0`, no `[TRUNCATED]` notice) is stripped of its heading line
   and its terminator, and the remainder is passed back as
   `edit_note(path, content=<remainder>, section=<sel>)`, on a note whose body
-  newlines are LF
+  newlines are LF and whose line-1 frontmatter is absent or valid — the notes
+  for which a section write is admitted at all
 - **THEN** the resulting file SHALL be byte-identical to the original
 - **AND** this SHALL hold for every `#N` ordinal in the note, including
   sections whose body begins with a blank line, sections whose body begins
@@ -91,6 +92,9 @@ scans there.
 - **AND** it SHALL NOT extend to a windowed or truncated section response —
   writing such a window back replaces the whole body with the fragment and
   deletes the remainder, exactly as the note-read requirement already warns
+- **AND** it SHALL NOT be read as weakening the refusal on a defective
+  frontmatter block: such a note remains readable by section and refused for
+  section writes, and the refusal takes precedence over the round trip
 
 #### Scenario: An empty section survives a round trip
 

--- a/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
@@ -75,10 +75,8 @@ scans there.
 
 #### Scenario: A section round trip is byte-identical
 
-- **WHEN** the **selected-content portion** of an untruncated
-  `read_note(path, section=<sel>)` response — the text after the response's
-  `\n---\n` envelope separator — is stripped of its first line (the heading
-  line and its terminator) and the remainder is passed back as
+- **WHEN** the selected content a section read returns for `<sel>` is stripped
+  of its heading line and its terminator, and the remainder is passed back as
   `edit_note(path, content=<remainder>, section=<sel>)`, on a note whose body
   newlines are LF
 - **THEN** the resulting file SHALL be byte-identical to the original
@@ -86,6 +84,9 @@ scans there.
   sections whose body begins with a blank line, sections whose body begins
   with a fenced code block, sections with an empty body, and the final
   section of the note
+- **AND** the guarantee SHALL be verified against the shared section helpers,
+  which operate on note text; recovering the selected content from a rendered
+  response is not part of this contract and is tracked separately
 
 #### Scenario: An empty section survives a round trip
 
@@ -238,12 +239,15 @@ the line immediately after it. This is the contract a caller can only discover
 by reading it, and getting it wrong is how a section round trip corrupts a note.
 
 The docstrings SHALL state that any blank line the caller wants between the
-heading and its content belongs in `content`, and SHALL point at
-`read_note(section=…)` as the source of a round-trippable body — together with
-the exact extraction: **the text after the response's `\n---\n` envelope
-separator, minus its first line.** They SHALL NOT tell a caller to strip the
-response's own first line, which is the envelope's `# <title>` and would write
-`**Path:**` into the note.
+heading and its content belongs in `content`, and SHALL name
+`read_note(section=…)` as the matching read: a section response carries the
+heading line and the body, and `edit_note(section=…)` takes the body.
+
+They SHALL NOT prescribe a textual procedure for recovering that body from a
+response — no "split on the separator", no "drop the first line". The response
+envelope interpolates note-controlled values, so any such procedure can be
+forged by note content into an instruction that writes `**Path:** …` into the
+note. Making the body unambiguously recoverable is tracked as its own change.
 
 They SHALL further state (a) that a section write **replaces the whole body**,
 so content omitted from `content` — a fenced code block included — is deleted,
@@ -259,6 +263,9 @@ endings than it started with.
 - **WHEN** an MCP client introspects `edit_note`
 - **THEN** the documentation for `section` SHALL say that `content` replaces
   the body beginning on the line after the heading line
-- **AND** SHALL name `read_note(section=…)` as the matching read
-- **AND** the same statement SHALL appear in the `tools.py` implementation's
+- **AND** SHALL say that the whole body is replaced, so omitted content — a
+  fenced code block included — is deleted
+- **AND** SHALL name `read_note(section=…)` as the matching read, without
+  prescribing how to extract from its response
+- **AND** the same statements SHALL appear in the `tools.py` implementation's
   docstring, so the two layers do not diverge

--- a/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
@@ -247,9 +247,12 @@ response's own first line, which is the envelope's `# <title>` and would write
 
 They SHALL further state (a) that a section write **replaces the whole body**,
 so content omitted from `content` — a fenced code block included — is deleted,
-and (b) that byte-identity holds for notes whose body newlines are LF; on a
-CRLF or lone-CR note the round trip preserves content but rewrites the selected
-body's terminators as LF.
+and (b) that byte-identity holds only for notes whose body newlines are LF.
+Every non-LF terminator inside the **selected body** comes back as LF, whether
+the note uses one dialect throughout or mixes them, because the read path
+normalises and the write path rewrites raw bytes; terminators outside the
+selected body are untouched, so a round trip can leave a note with more mixed
+endings than it started with.
 
 #### Scenario: An MCP client can learn the contract from introspection
 

--- a/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
@@ -133,8 +133,12 @@ scans there.
   opener — shapes `_FENCE_RE` does not currently mask — so that a heading
   inside it is visible to the scanner
 - **THEN** this requirement's fenced-code guarantees SHALL NOT be read as
-  covering it, and the behaviour SHALL be identical to the behaviour before
-  this change (verified, not assumed)
+  covering it, and for a **non-empty** replacement body the bytes written SHALL
+  be identical to the bytes written before this change (verified, not assumed)
+- **AND** for an **empty** replacement body the separator-conditionality rule
+  above applies here as everywhere else, so the result differs from before this
+  change by the one blank line that rule stops inserting — a removal, not a
+  loss, and the only intended divergence on these shapes
 - **AND** the gap SHALL be recorded as a declared residual with its own
   tracking issue, because widening the masker re-addresses `#N` ordinals on
   existing notes and is a larger compat break than this change

--- a/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
@@ -1,0 +1,200 @@
+## MODIFIED Requirements
+
+### Requirement: Section mode replaces the body under a named heading
+
+When `section=<heading>` is supplied, `edit_note` SHALL locate the matching
+ATX heading (1–6 `#` characters) and SHALL replace that heading's **body** with
+the supplied `content`. The matched heading line itself SHALL NOT be removed or
+rewritten.
+
+A section's body SHALL begin at the first byte of the line immediately
+following the heading line, and SHALL end immediately before the next heading of
+equal-or-shallower depth, or at end of file. Exactly one line terminator (LF,
+CRLF as a unit, or a lone CR) separates the heading line from the body. No
+whitespace, blank line, or fenced code block between the heading line and the
+next heading of equal-or-shallower depth SHALL be excluded from the body: a
+section has no third region between its heading line and its body.
+
+The selector SHALL accept three forms:
+
+1. **Ordinal** (e.g. `#7`) — a selector consisting solely of `#` followed by
+   digits SHALL select the Nth ATX heading in document order, 1-based. A bare
+   ordinal SHALL always select by position, even when some heading's literal
+   text is the same string. Ordinals are advertised to callers as the reliable
+   selector, so note content MUST NOT be able to shadow one.
+2. **Path-style chain** (e.g. `Parent/Child`), where the final part is the
+   target heading and the preceding parts are ancestors in outermost-first
+   order. A selector containing `/` SHALL NOT be interpreted as an ordinal.
+3. **Exact heading text** (e.g. `Tasks`).
+
+A heading whose literal text is `#N` SHALL remain addressable by the path-style
+form (`Parent/#N`) and by its own ordinal.
+
+The ordinal form exists because the path-style form cannot separate duplicate
+**sibling** headings — headings with identical text under the same parent share
+every ancestor, so no chain distinguishes them.
+
+The same selector grammar SHALL be used by every tool that accepts a `section`
+argument, so a selector that names a section for reading names the same section
+for writing.
+
+Narrowing the body's start to the line after the heading line SHALL NOT change
+which heading any selector resolves to. Heading depth, trimmed heading text,
+document order, and therefore every `#N` ordinal SHALL be unchanged by this
+requirement.
+
+When the note carries a valid line-1 frontmatter block, heading resolution
+(all three selector forms), body replacement, and the not-found/ambiguity
+listings SHALL operate on the frontmatter-stripped body — the same text
+`read_note` scans — and the write SHALL reattach the raw block
+byte-identically. A line inside the block (a YAML `#` comment included)
+SHALL never be selectable as a heading and SHALL never be counted by an
+ordinal. When the note's block is **defective** (unclosed fence, YAML
+error, or non-mapping — comment-only YAML included), section-mode writes
+SHALL be refused with an error naming the defect and pointing at
+`edit_note(replace_frontmatter=True)` as the repair — never resolved over
+the raw bytes, where a `#` line inside the broken block could be selected
+and a replacement could delete the closing fence. A note with no fence at
+all resolves over its raw content, which is identical to what `read_note`
+scans there.
+
+#### Scenario: A section round trip is byte-identical
+
+- **WHEN** a `read_note(path, section=<sel>)` response that was not
+  truncated is stripped of its first line (the heading line and its
+  terminator) and the remainder is passed back as
+  `edit_note(path, content=<remainder>, section=<sel>)`, on a note whose
+  body newlines are LF
+- **THEN** the resulting file SHALL be byte-identical to the original
+- **AND** this SHALL hold for every `#N` ordinal in the note, including
+  sections whose body begins with a blank line, sections whose body begins
+  with a fenced code block, and the final section of the note
+
+#### Scenario: A fenced block under a heading is replaced, not duplicated
+
+- **WHEN** a note is `# A\n` followed by a fenced code block (whose
+  content may itself contain `#`-prefixed lines) followed by `# B\nb\n`,
+  and the client calls `edit_note(path, "new", section="#1")`
+- **THEN** the fenced block SHALL be replaced by `new`
+- **AND** the resulting note SHALL contain the fence exactly zero further
+  times — it SHALL NOT be retained with `new` inserted after it
+
+#### Scenario: A blank line after a heading belongs to the body
+
+- **WHEN** a note is `# A\n\nold\n# B\nb\n` and the client calls
+  `edit_note(path, "new", section="#1")`
+- **THEN** the resulting note SHALL be `# A\nnew\n# B\nb\n` — the blank
+  line is part of the replaced body, and a caller that wants it back
+  SHALL include it in `content`
+- **AND** repeating the read-strip-write round trip on the original note
+  any number of times SHALL NOT change the file
+
+#### Scenario: Trailing spaces on a heading line stay on the heading line
+
+- **WHEN** a heading line carries trailing horizontal whitespace (spaces,
+  tabs, or a non-ASCII space) before its terminator
+- **THEN** that whitespace SHALL remain part of the heading line and SHALL
+  NOT become part of the body
+- **AND** the heading's trimmed text, and therefore its addressability by
+  the exact-text and path-style selectors, SHALL be unchanged
+
+#### Scenario: A YAML comment in frontmatter is not a heading
+
+- **WHEN** a note is `---\n# Tasks\nstatus: draft\n---\n# Body\nkeep\n`
+  and the client calls `edit_note(path, "x", section="Tasks")`
+- **THEN** the selector SHALL NOT match the `# Tasks` line inside the
+  frontmatter block; it resolves against the body's headings only (here
+  reporting `Tasks` not found and listing `Body`)
+- **AND** the frontmatter block SHALL be untouched by any section edit
+
+#### Scenario: Ordinals agree between read_note and edit_note
+
+- **WHEN** a note's frontmatter block contains `#`-prefixed comment lines
+  and its body contains ATX headings
+- **THEN** `edit_note(section="#N")` SHALL select the same heading that
+  `read_note(section="#N")` extracts
+
+#### Scenario: A defective block refuses section writes by name
+
+- **WHEN** a note is `---\n# Tasks\n---\n# Body\nkeep\n` (comment-only
+  YAML — a non-mapping) or carries an unclosed or YAML-erroring block,
+  and the client calls `edit_note(path, "x", section=<anything>)`
+- **THEN** the call SHALL be refused with an error naming the defect and
+  the `replace_frontmatter=True` repair path
+- **AND** SHALL NOT modify the file
+
+#### Scenario: Replace section under a level-2 heading
+
+- **WHEN** the note contains `## Tasks\nA\nB\n## Notes\nC` and the client
+  calls `edit_note(path, content="X\nY", section="Tasks")`
+- **THEN** the resulting note SHALL be `## Tasks\nX\nY\n## Notes\nC`
+
+#### Scenario: Section heading not found
+
+- **WHEN** no ATX heading in the note has trimmed text equal to
+  `<heading>`, and the selector is not a valid ordinal
+- **THEN** the response SHALL list the headings that ARE present in the
+  note (with their depth) and instruct the caller to disambiguate
+- **AND** SHALL NOT modify the file
+
+#### Scenario: Multiple matching headings disambiguated by occurrence
+
+- **WHEN** more than one heading in the note matches `<heading>` exactly
+- **THEN** the response SHALL state the number of matches and instruct
+  the caller to use the more-specific path-style form
+  `Parent Heading/Child Heading` to disambiguate
+- **AND** the response SHALL name the `#N` ordinals that identify each match
+- **AND** SHALL NOT modify the file until the call is reissued
+  unambiguously
+
+#### Scenario: Path-style heading disambiguation
+
+- **WHEN** the client calls `edit_note(path, content, section="Tasks/Today")`
+  and the note contains `## Tasks` followed by `### Today`
+- **THEN** the system SHALL replace the body under `### Today` (bounded
+  by the next heading of depth ≤ 3) with `content`
+
+#### Scenario: Duplicate sibling headings resolved by ordinal
+
+- **WHEN** a note contains two headings with identical text under the same
+  parent, and the client supplies the `#N` ordinal of one of them
+- **THEN** that specific section SHALL be selected
+- **AND** the other identically-titled section SHALL be unaffected
+
+#### Scenario: Ordinal out of range
+
+- **WHEN** the supplied ordinal is below 1 or exceeds the number of ATX
+  headings in the note
+- **THEN** the response SHALL report the valid ordinal range
+- **AND** SHALL NOT modify the file
+
+#### Scenario: A heading literally named like an ordinal
+
+- **WHEN** a note contains a heading whose text is exactly `#2` and the
+  client supplies `section="#2"`
+- **THEN** the second heading in the note SHALL be selected, because a bare
+  ordinal always selects by position
+- **AND** the heading titled `#2` SHALL remain reachable via the path-style
+  form and via its own ordinal
+
+## ADDED Requirements
+
+### Requirement: Section-mode docstrings state the round-trip contract
+
+Both layers' `edit_note` docstrings SHALL state that in section mode `content` is the section's **body only** — the registered wrapper in `server.py` (what an MCP client sees) and the implementation in `tools.py` alike. The body is the text a
+`read_note(section=…)` response carries *below* its heading line, beginning on
+the line immediately after it. This is the contract a caller can only discover
+by reading it, and getting it wrong is how a section round trip corrupts a note.
+
+The docstrings SHALL state that any blank line the caller wants between the
+heading and its content belongs in `content`, and SHALL point at
+`read_note(section=…)` as the source of a round-trippable body.
+
+#### Scenario: An MCP client can learn the contract from introspection
+
+- **WHEN** an MCP client introspects `edit_note`
+- **THEN** the documentation for `section` SHALL say that `content` replaces
+  the body beginning on the line after the heading line
+- **AND** SHALL name `read_note(section=…)` as the matching read
+- **AND** the same statement SHALL appear in the `tools.py` implementation's
+  docstring, so the two layers do not diverge

--- a/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
@@ -75,8 +75,9 @@ scans there.
 
 #### Scenario: A section round trip is byte-identical
 
-- **WHEN** the selected content a section read returns for `<sel>` is stripped
-  of its heading line and its terminator, and the remainder is passed back as
+- **WHEN** the selected content of a **complete, unwindowed** section read for
+  `<sel>` (`offset=0`, no `[TRUNCATED]` notice) is stripped of its heading line
+  and its terminator, and the remainder is passed back as
   `edit_note(path, content=<remainder>, section=<sel>)`, on a note whose body
   newlines are LF
 - **THEN** the resulting file SHALL be byte-identical to the original
@@ -87,6 +88,9 @@ scans there.
 - **AND** the guarantee SHALL be verified against the shared section helpers,
   which operate on note text; recovering the selected content from a rendered
   response is not part of this contract and is tracked separately
+- **AND** it SHALL NOT extend to a windowed or truncated section response —
+  writing such a window back replaces the whole body with the fragment and
+  deletes the remainder, exactly as the note-read requirement already warns
 
 #### Scenario: An empty section survives a round trip
 

--- a/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
+++ b/openspec/changes/section-round-trip-140/specs/vault-write/spec.md
@@ -9,11 +9,26 @@ rewritten.
 
 A section's body SHALL begin at the first byte of the line immediately
 following the heading line, and SHALL end immediately before the next heading of
-equal-or-shallower depth, or at end of file. Exactly one line terminator (LF,
-CRLF as a unit, or a lone CR) separates the heading line from the body. No
-whitespace, blank line, or fenced code block between the heading line and the
-next heading of equal-or-shallower depth SHALL be excluded from the body: a
-section has no third region between its heading line and its body.
+equal-or-shallower depth, or at end of file. At most one line terminator (LF,
+CRLF as a unit, or a lone CR) separates the heading line from the body; a
+heading at end of file with no trailing terminator has an empty body. No
+whitespace, blank line, or fenced code block — as recognised by the shared code
+masker — between the heading line and the next heading of equal-or-shallower
+depth SHALL be excluded from the body: a section has no third region between
+its heading line and its body.
+
+A separator newline SHALL be inserted around the replacement only when the
+replacement body is **non-empty**: one before it when the retained prefix does
+not already end in a terminator (an end-of-file heading), and one after it when
+a following heading would otherwise be glued to it. Replacing an empty body
+with an empty body SHALL leave the note byte-identical — an unconditional
+separator makes a section with no body grow a blank line on every round trip,
+and makes an unterminated end-of-file heading grow a newline.
+
+Because a section write replaces the whole body, content the caller does not
+resend is **deleted**, fenced code blocks included. This is the contract, not
+an accident; it SHALL be stated in the caller-visible documentation in those
+terms.
 
 The selector SHALL accept three forms:
 
@@ -60,24 +75,60 @@ scans there.
 
 #### Scenario: A section round trip is byte-identical
 
-- **WHEN** a `read_note(path, section=<sel>)` response that was not
-  truncated is stripped of its first line (the heading line and its
-  terminator) and the remainder is passed back as
-  `edit_note(path, content=<remainder>, section=<sel>)`, on a note whose
-  body newlines are LF
+- **WHEN** the **selected-content portion** of an untruncated
+  `read_note(path, section=<sel>)` response — the text after the response's
+  `\n---\n` envelope separator — is stripped of its first line (the heading
+  line and its terminator) and the remainder is passed back as
+  `edit_note(path, content=<remainder>, section=<sel>)`, on a note whose body
+  newlines are LF
 - **THEN** the resulting file SHALL be byte-identical to the original
 - **AND** this SHALL hold for every `#N` ordinal in the note, including
   sections whose body begins with a blank line, sections whose body begins
-  with a fenced code block, and the final section of the note
+  with a fenced code block, sections with an empty body, and the final
+  section of the note
+
+#### Scenario: An empty section survives a round trip
+
+- **WHEN** a note is `# A\n# B\nb\n` (the first section has no body) and
+  the client calls `edit_note(path, "", section="#1")`
+- **THEN** the resulting note SHALL be `# A\n# B\nb\n`, unchanged — no
+  separator newline SHALL be inserted for an empty body
+- **AND** on the note `# A` (a heading at end of file with no trailing
+  terminator), the same call SHALL leave the note as `# A`
+
+#### Scenario: A non-empty body is still separated from what surrounds it
+
+- **WHEN** the client calls `edit_note(path, "- item", section="Notes")` on
+  a note whose `# Notes` heading is the last line and carries no trailing
+  newline
+- **THEN** the heading SHALL NOT be glued to the content: the result SHALL
+  be `# Notes\n- item`
+- **AND** when a following heading exists, a terminator SHALL be ensured
+  between the new body and that heading
 
 #### Scenario: A fenced block under a heading is replaced, not duplicated
 
-- **WHEN** a note is `# A\n` followed by a fenced code block (whose
-  content may itself contain `#`-prefixed lines) followed by `# B\nb\n`,
-  and the client calls `edit_note(path, "new", section="#1")`
+- **WHEN** a note is `# A\n` followed by a fenced code block recognised by
+  the shared masker (whose content may itself contain `#`-prefixed lines)
+  followed by `# B\nb\n`, and the client calls
+  `edit_note(path, "new", section="#1")`
 - **THEN** the fenced block SHALL be replaced by `new`
 - **AND** the resulting note SHALL contain the fence exactly zero further
   times — it SHALL NOT be retained with `new` inserted after it
+- **AND** the caller-visible documentation SHALL state that this is a
+  deletion: a `content` that does not resend the block loses it
+
+#### Scenario: A fence the masker does not recognise is out of scope, not covered
+
+- **WHEN** a fence is indented, or is closed by a run longer than its
+  opener — shapes `_FENCE_RE` does not currently mask — so that a heading
+  inside it is visible to the scanner
+- **THEN** this requirement's fenced-code guarantees SHALL NOT be read as
+  covering it, and the behaviour SHALL be identical to the behaviour before
+  this change (verified, not assumed)
+- **AND** the gap SHALL be recorded as a declared residual with its own
+  tracking issue, because widening the masker re-addresses `#N` ordinals on
+  existing notes and is a larger compat break than this change
 
 #### Scenario: A blank line after a heading belongs to the body
 
@@ -188,7 +239,17 @@ by reading it, and getting it wrong is how a section round trip corrupts a note.
 
 The docstrings SHALL state that any blank line the caller wants between the
 heading and its content belongs in `content`, and SHALL point at
-`read_note(section=…)` as the source of a round-trippable body.
+`read_note(section=…)` as the source of a round-trippable body — together with
+the exact extraction: **the text after the response's `\n---\n` envelope
+separator, minus its first line.** They SHALL NOT tell a caller to strip the
+response's own first line, which is the envelope's `# <title>` and would write
+`**Path:**` into the note.
+
+They SHALL further state (a) that a section write **replaces the whole body**,
+so content omitted from `content` — a fenced code block included — is deleted,
+and (b) that byte-identity holds for notes whose body newlines are LF; on a
+CRLF or lone-CR note the round trip preserves content but rewrites the selected
+body's terminators as LF.
 
 #### Scenario: An MCP client can learn the contract from introspection
 

--- a/openspec/changes/section-round-trip-140/tasks.md
+++ b/openspec/changes/section-round-trip-140/tasks.md
@@ -58,7 +58,10 @@
 - [ ] 3.3b Pin the declared newline residual at the **tool** level as a test,
       not as prose: reading a CRLF note's section (which arrives LF-normalised)
       and writing it back yields `# A\r\nold\n# B\r\nkeep\r\n`. Assert that
-      exact string, so the residual is visible and cannot drift silently.
+      exact string, so the residual is visible and cannot drift silently. Add a
+      **mixed**-ending case too — the normalisation is per-terminator, not
+      per-note: `# A\r\none\r\ntwo\nthree\r# B\rkeep\r` yields
+      `# A\r\none\ntwo\nthree\n# B\rkeep\r`.
 - [ ] 3.3c Pin that the unmasked-fence shapes (an indented fence, and one
       closed by a longer run) produce **byte-identical** output before and
       after this change. This is the evidence for the "not this change's bug"
@@ -105,11 +108,19 @@
       once a caller is being told to extract from it.
 - [ ] 5.0 Make the response envelope unambiguous in
       `src/mcp_server/tools.py`'s `read_note_impl` **before** documenting the
-      extraction rule: render every interpolated value (title, path, tags, and
-      each frontmatter value) on a single line, collapsing interior line
-      terminators. A multiline YAML title containing a `---` line otherwise
-      emits a bare separator above the real one, and the documented split lands
-      inside the envelope. Do not touch the body.
+      extraction rule. Implement it as **one choke point** — a single helper
+      that stringifies a component and collapses every LF/CRLF/CR in the result
+      to a space — and route *every* interpolated component through it: title,
+      path, each tag, **each frontmatter key**, and each frontmatter value. Do
+      not write this as a list of per-field fixes: two successive audit rounds
+      each found a different field that could forge the separator (round 2 the
+      title, round 3 the key), which is what an enumeration buys you. Do not
+      touch the body.
+- [ ] 5.0b Leave error and end-of-content responses alone — a missing note, an
+      out-of-range `offset`, an unknown section. They carry no envelope and no
+      selected content, so no extraction contract applies; the requirement is
+      scoped to successful enveloped responses and the tests should not assert
+      otherwise.
 - [ ] 5.3 Add an end-to-end exercise against the running server that performs
       the **documented extraction on a real MCP response**, not on the helper's
       return value: call `read_note(path, section=…)`, split on the first
@@ -118,13 +129,22 @@
       it is unchanged. A test that skips the envelope split does not test the
       contract the docstring states. Name in the report which tools were
       actually called.
-- [ ] 5.4 Run that same end-to-end round trip over the two adversarial
-      envelopes, asserting the note is unchanged: (a) a note whose frontmatter
+- [ ] 5.4 Run that same end-to-end round trip over the adversarial envelopes,
+      asserting the note is unchanged in each: (a) a note whose frontmatter
       `title` is a multiline YAML scalar containing a `---` line and markup
       (`title: |-` / `[Project](https://example.invalid)` / `---` /
-      `injected`), and (b) a note whose selected section *body* itself contains
-      a `\n---\n` line. Case (a) fails today and is what task 5.0 fixes; case
-      (b) must already pass, because the real separator comes first.
+      `injected`); (b) a note carrying the valid quoted frontmatter key
+      `"safe\n---\nforged": value`, which forges a separator through the
+      `**Frontmatter:**` block rather than the title; (c) a frontmatter value
+      that is a list or dict with newline-bearing string leaves; and (d) a note
+      whose selected section *body* itself contains a `\n---\n` line. Cases
+      (a)–(c) fail today and are what task 5.0 fixes; case (d) must already
+      pass, because the real separator comes first.
+- [ ] 5.5 Add a guard test that does not name fields: build a response for a
+      note that exercises every envelope component, and assert no line before
+      the envelope separator is exactly `---`. This is the invariant; a future
+      field added to the envelope should fail this test rather than ship a
+      third forgery.
 
 ## 6. Documentation
 

--- a/openspec/changes/section-round-trip-140/tasks.md
+++ b/openspec/changes/section-round-trip-140/tasks.md
@@ -103,6 +103,13 @@
       `read_note`'s docstring in both layers too — it currently says a section
       response "includes the heading line", which is true but insufficient
       once a caller is being told to extract from it.
+- [ ] 5.0 Make the response envelope unambiguous in
+      `src/mcp_server/tools.py`'s `read_note_impl` **before** documenting the
+      extraction rule: render every interpolated value (title, path, tags, and
+      each frontmatter value) on a single line, collapsing interior line
+      terminators. A multiline YAML title containing a `---` line otherwise
+      emits a bare separator above the real one, and the documented split lands
+      inside the envelope. Do not touch the body.
 - [ ] 5.3 Add an end-to-end exercise against the running server that performs
       the **documented extraction on a real MCP response**, not on the helper's
       return value: call `read_note(path, section=…)`, split on the first
@@ -111,6 +118,13 @@
       it is unchanged. A test that skips the envelope split does not test the
       contract the docstring states. Name in the report which tools were
       actually called.
+- [ ] 5.4 Run that same end-to-end round trip over the two adversarial
+      envelopes, asserting the note is unchanged: (a) a note whose frontmatter
+      `title` is a multiline YAML scalar containing a `---` line and markup
+      (`title: |-` / `[Project](https://example.invalid)` / `---` /
+      `injected`), and (b) a note whose selected section *body* itself contains
+      a `\n---\n` line. Case (a) fails today and is what task 5.0 fixes; case
+      (b) must already pass, because the real separator comes first.
 
 ## 6. Documentation
 
@@ -120,8 +134,17 @@
       must record what changed, when, and why, and it must state the new
       body-start rule as the load-bearing invariant.
 - [ ] 6.2 State the declared compat break there in the terms a future reader
-      needs: a section write no longer preserves a blank line the caller did
-      not send.
+      needs, and state the *whole* of it — not just the blank line. A section
+      write replaces the entire body, so content the caller omits is deleted.
+      Include the concrete fenced-block example: on
+      `# A\n\u0060\u0060\u0060\nimportant\n\u0060\u0060\u0060\nold\n`,
+      `edit_note(section="A", content="new")` now yields `# A\nnew\n`. A
+      reader who learns only about the blank line will not predict that.
+- [ ] 6.3 Record the envelope-framing rule beside the section-addressing
+      material: why the `\n---\n` separator is load-bearing for the round-trip
+      contract, and why every interpolated envelope value must stay
+      single-line. This is the "do not undo it" note for a future refactor that
+      restores a raw multiline title.
 
 ## 7. Residuals and follow-ups
 

--- a/openspec/changes/section-round-trip-140/tasks.md
+++ b/openspec/changes/section-round-trip-140/tasks.md
@@ -84,7 +84,12 @@
       silently edit an assertion.
 - [ ] 4.2 Verify section mode over a valid frontmatter block still resolves
       against the stripped body and reattaches the block byte-identically,
-      and that a defective block still refuses by name.
+      and that a defective block still refuses by name. Assert the asymmetry
+      deliberately: on a defective block a section *read* succeeds over the raw
+      bytes while the section *write* refuses. The round-trip property in 3.1
+      must therefore skip such notes rather than be made to pass on them —
+      widening parity there would mean scanning a broken block on the write
+      side, which is the destructive behaviour #128 removed.
 - [ ] 4.3 Confirm `outline_sections` is **entirely** unchanged across the
       corpus — ordinals and `size` alike. `size` is `body_end - line_start` and
       this change moves neither endpoint, so any observed shift means the fix

--- a/openspec/changes/section-round-trip-140/tasks.md
+++ b/openspec/changes/section-round-trip-140/tasks.md
@@ -1,0 +1,92 @@
+# Tasks — section read/write parity (#140)
+
+## 1. Pin the defect before changing anything
+
+- [ ] 1.1 Add `tests/test_issue_140_section_round_trip.py` exercising the pure
+      helpers in `src/services/vault.py` (`_scan_headings`,
+      `_section_body_span`, `extract_section`, `replace_section`,
+      `outline_sections`) — no DB, no vault, no async.
+- [ ] 1.2 Write the two reported reproductions as failing tests first:
+      the fenced-block duplication on
+      `'# A\n```\n## Hidden\ntext\n```\n# B\nb\n'`, and blank-line
+      accumulation over three round trips on `'# A\n\nbody\n\n# B\nb\n'`.
+      Confirm both fail on the unmodified tree, then proceed.
+
+## 2. The fix
+
+- [ ] 2.1 In `src/services/vault.py`, narrow `_ATX_HEADING_RE`'s trailing
+      whitespace run from `\s*` to `[^\S\r\n]*`. Change nothing else in the
+      pattern — the separator class `[^\S\r\n]+` and the text capture
+      `([^\r\n]+?)` stay exactly as they are.
+- [ ] 2.2 Rewrite the comment block above the regex. It currently documents
+      the opposite decision ("The TRAILING run stays the original `\s*`,
+      unnarrowed and still allowed to cross line boundaries … narrowing it
+      would change the bytes `edit_note(section=…)` writes"). It must now say
+      why that constraint was lifted, what it cost, and what it bought — so a
+      future reader does not "restore" the bug.
+- [ ] 2.3 Update `_scan_headings`' and `_section_body_span`'s docstrings so
+      `line_end` is described accurately (it is now genuinely the end of the
+      heading line) and the body-start rule is stated once.
+
+## 3. Prove the contract, not just the two bugs
+
+- [ ] 3.1 Add the differential property test: for every ordinal `#N` in a
+      note, `replace_section(text, "#N", extract_section(text, "#N") minus its
+      first line)` SHALL return `text` unchanged.
+- [ ] 3.2 Run that property over a corpus covering, at minimum: blank line(s)
+      after a heading; a fenced block directly under a heading, including one
+      containing `#`-prefixed lines and one using `~~~`; inline code on a
+      heading line; a heading at EOF with and without a trailing newline; a
+      heading line with trailing spaces, tabs, and a non-ASCII space; a note
+      whose only content is headings; nested depths where the next heading is
+      deeper (body must run past it) and shallower (body must stop).
+- [ ] 3.3 Run the same property over CRLF and lone-CR notes, asserting the
+      dialect's own terminators are preserved — the #128 terminator rule must
+      survive this change intact.
+- [ ] 3.4 Assert the **non**-regression that makes this safe: over the whole
+      corpus, `_scan_headings` reports identical `depth`, trimmed `text`,
+      `line_start`, and document order before and after the fix. Pin it by
+      asserting against explicit expected values, not by comparing two regexes.
+
+## 4. Guard what must not change
+
+- [ ] 4.1 Re-run the existing section suites unchanged and keep them green:
+      `tests/test_read_response_cap.py`,
+      `tests/test_issue_5_replace_section_eof_heading.py`,
+      `tests/test_issue_128_section_mode_frontmatter.py`,
+      `tests/test_issue_128_edit_note_frontmatter.py`,
+      `tests/test_issue_14_extract_tags_code_blocks.py`.
+      If one fails, decide explicitly whether it pinned the bug (update it and
+      say so in the commit) or caught a real regression (fix the code). Do not
+      silently edit an assertion.
+- [ ] 4.2 Verify section mode over a valid frontmatter block still resolves
+      against the stripped body and reattaches the block byte-identically,
+      and that a defective block still refuses by name.
+- [ ] 4.3 Confirm `outline_sections`' `#N` ordinals are unchanged across the
+      corpus; the `size` field may shift and the test SHALL assert the new
+      values explicitly rather than being loosened.
+
+## 5. The caller-visible contract
+
+- [ ] 5.1 Update the `edit_note` docstring in `src/mcp_server/server.py` (the
+      MCP-visible one) to state that in section mode `content` is the body
+      beginning on the line after the heading line — the text a
+      `read_note(section=…)` response carries below its heading line — and
+      that a wanted blank separator belongs in `content`.
+- [ ] 5.2 Make the same statement in `src/mcp_server/tools.py`'s `edit_note`
+      docstring so the two layers do not diverge.
+- [ ] 5.3 Add an end-to-end exercise against the running server: `read_note`
+      a section, write the body back with `edit_note`, read the whole note and
+      assert it is unchanged. Name in the report which tools were actually
+      called.
+
+## 6. Documentation
+
+- [ ] 6.1 Update `docs/architecture/vault-tools.md`'s section-addressing
+      material. The passage stating the trailing `\s*` must stay unnarrowed is
+      now the *history* of a lifted constraint, not a live prohibition — it
+      must record what changed, when, and why, and it must state the new
+      body-start rule as the load-bearing invariant.
+- [ ] 6.2 State the declared compat break there in the terms a future reader
+      needs: a section write no longer preserves a blank line the caller did
+      not send.

--- a/openspec/changes/section-round-trip-140/tasks.md
+++ b/openspec/changes/section-round-trip-140/tasks.md
@@ -141,7 +141,8 @@
       write replaces the entire body, so content the caller omits is deleted.
       Include the concrete fenced-block example: on
       `# A\n```\nimportant\n```\nold\n`,
-      `edit_note(section="A", content="new")` now yields `# A\nnew\n`. A
+      `edit_note(section="A", content="new")` now yields `# A\nnew` (no trailing
+      newline — `A` is the last heading, so no separator is needed). A
       reader who learns only about the blank line will not predict that.
 - [x] 6.3 Record why this change documents **no** extraction procedure, with
       both reproductions (the multiline title and the quoted

--- a/openspec/changes/section-round-trip-140/tasks.md
+++ b/openspec/changes/section-round-trip-140/tasks.md
@@ -94,57 +94,28 @@
 
 - [ ] 5.1 Update the `edit_note` docstring in `src/mcp_server/server.py` (the
       MCP-visible one) to state, in this order: (a) `content` is the body
-      beginning on the line after the heading line; (b) the extraction rule —
-      the text after a `read_note(section=…)` response's `\n---\n` envelope
-      separator, **minus its first line** (never the response's own first line,
-      which is `# <title>`); (c) a section write replaces the whole body, so
-      omitted content — a fenced block included — is deleted; (d) a wanted
-      blank separator belongs in `content`; (e) byte-identity holds for
-      LF-bodied notes, and a CRLF note's selected body comes back as LF.
-- [ ] 5.2 Make the same five statements in `src/mcp_server/tools.py`'s
-      `edit_note` docstring so the two layers do not diverge. Check
-      `read_note`'s docstring in both layers too — it currently says a section
-      response "includes the heading line", which is true but insufficient
-      once a caller is being told to extract from it.
-- [ ] 5.0 Make the response envelope unambiguous in
-      `src/mcp_server/tools.py`'s `read_note_impl` **before** documenting the
-      extraction rule. Implement it as **one choke point** — a single helper
-      that stringifies a component and collapses every LF/CRLF/CR in the result
-      to a space — and route *every* interpolated component through it: title,
-      path, each tag, **each frontmatter key**, and each frontmatter value. Do
-      not write this as a list of per-field fixes: two successive audit rounds
-      each found a different field that could forge the separator (round 2 the
-      title, round 3 the key), which is what an enumeration buys you. Do not
-      touch the body.
-- [ ] 5.0b Leave error and end-of-content responses alone — a missing note, an
-      out-of-range `offset`, an unknown section. They carry no envelope and no
-      selected content, so no extraction contract applies; the requirement is
-      scoped to successful enveloped responses and the tests should not assert
-      otherwise.
-- [ ] 5.3 Add an end-to-end exercise against the running server that performs
-      the **documented extraction on a real MCP response**, not on the helper's
-      return value: call `read_note(path, section=…)`, split on the first
-      `\n---\n`, drop the first line of the remainder, pass that to
-      `edit_note(section=…)`, then `read_note(path)` the whole note and assert
-      it is unchanged. A test that skips the envelope split does not test the
-      contract the docstring states. Name in the report which tools were
-      actually called.
-- [ ] 5.4 Run that same end-to-end round trip over the adversarial envelopes,
-      asserting the note is unchanged in each: (a) a note whose frontmatter
-      `title` is a multiline YAML scalar containing a `---` line and markup
-      (`title: |-` / `[Project](https://example.invalid)` / `---` /
-      `injected`); (b) a note carrying the valid quoted frontmatter key
-      `"safe\n---\nforged": value`, which forges a separator through the
-      `**Frontmatter:**` block rather than the title; (c) a frontmatter value
-      that is a list or dict with newline-bearing string leaves; and (d) a note
-      whose selected section *body* itself contains a `\n---\n` line. Cases
-      (a)–(c) fail today and are what task 5.0 fixes; case (d) must already
-      pass, because the real separator comes first.
-- [ ] 5.5 Add a guard test that does not name fields: build a response for a
-      note that exercises every envelope component, and assert no line before
-      the envelope separator is exactly `---`. This is the invariant; a future
-      field added to the envelope should fail this test rather than ship a
-      third forgery.
+      beginning on the line after the heading line; (b) a section write
+      replaces the **whole body**, so omitted content — a fenced block included
+      — is deleted; (c) a wanted blank separator belongs in `content`; (d)
+      `read_note(section=…)` is the matching read, which carries the heading
+      line and the body; (e) byte-identity holds for LF-bodied notes, and every
+      non-LF terminator in the selected body comes back as LF.
+      **Do not write a parsing recipe** — no "split on the separator", no "drop
+      the first line". Such a procedure is forgeable by note content; the
+      reason belongs in `vault-tools.md`, not in a docstring a future author
+      will "helpfully" complete.
+- [ ] 5.2 Make the same statements in `src/mcp_server/tools.py`'s `edit_note`
+      docstring so the two layers do not diverge. Leave `read_note`'s
+      docstrings alone beyond consistency — its response shape is not changing
+      here, and the framing work is a separate filed change.
+- [ ] 5.3 Add an end-to-end exercise against the running server, written so it
+      does not depend on parsing a response: create a note with known bytes,
+      call `read_note(path, section=…)` and assert the response contains the
+      expected section, then call `edit_note(path, content=<the known body>,
+      section=…)` and assert via `read_note(path)` that the whole note is
+      byte-unchanged. Cover a section whose body starts with a blank line, one
+      starting with a fenced block, and an empty section. Name in the report
+      which tools were actually called.
 
 ## 6. Documentation
 
@@ -157,23 +128,23 @@
       needs, and state the *whole* of it — not just the blank line. A section
       write replaces the entire body, so content the caller omits is deleted.
       Include the concrete fenced-block example: on
-      `# A\n\u0060\u0060\u0060\nimportant\n\u0060\u0060\u0060\nold\n`,
+      `# A\n```\nimportant\n```\nold\n`,
       `edit_note(section="A", content="new")` now yields `# A\nnew\n`. A
       reader who learns only about the blank line will not predict that.
-- [ ] 6.3 Record the envelope-framing rule beside the section-addressing
-      material: why the `\n---\n` separator is load-bearing for the round-trip
-      contract, and why every interpolated envelope value must stay
-      single-line. This is the "do not undo it" note for a future refactor that
-      restores a raw multiline title.
+- [ ] 6.3 Record why this change documents **no** extraction procedure, with
+      both reproductions (the multiline title and the quoted
+      `"safe\n---\nforged"` key) and the reason sanitising fields does not fix
+      it. This is the "do not undo it" note for the next author who notices the
+      docstring stops short of telling the agent how to get the body, and
+      helpfully adds a split rule. Link **#149**.
 
 ## 7. Residuals and follow-ups
 
 - [ ] 7.1 Do NOT widen `_FENCE_RE` in this change. Confirm by test (3.3c) that
-      the unmasked-fence shapes are byte-identical before and after, then open
-      a follow-up issue describing the gap (indented openers, longer closers),
-      its destructive symptom (a section write deletes the opening fence and
-      orphans the contents), and why fixing it re-addresses `#N` ordinals and
-      therefore needs its own proposal. Link it from `vault-tools.md`.
+      the unmasked-fence shapes are byte-identical before and after, then link **#150**
+      from `vault-tools.md`, which describes the gap (indented openers, longer
+      closers), its destructive symptom, and why fixing it re-addresses `#N`
+      ordinals and needs its own proposal.
 - [ ] 7.2 Record the newline residual in `docs/architecture/vault-tools.md`
       beside the whole-note one #128 already declared, with the measured
       before/after string.

--- a/openspec/changes/section-round-trip-140/tasks.md
+++ b/openspec/changes/section-round-trip-140/tasks.md
@@ -18,6 +18,13 @@
       whitespace run from `\s*` to `[^\S\r\n]*`. Change nothing else in the
       pattern — the separator class `[^\S\r\n]+` and the text capture
       `([^\r\n]+?)` stay exactly as they are.
+- [ ] 2.1b In `replace_section`, make **both** separator insertions conditional
+      on a non-empty `new_body`. Unconditional insertion means an empty section
+      (`# A\n# B\nb\n`) gains a blank line and an unterminated EOF heading
+      (`# A`) gains a newline on every round trip — the regex fix alone does
+      not make the headline property true. Do not touch the non-empty
+      behaviour: `tests/test_issue_5_replace_section_eof_heading.py` pins it
+      and must stay green unmodified.
 - [ ] 2.2 Rewrite the comment block above the regex. It currently documents
       the opposite decision ("The TRAILING run stays the original `\s*`,
       unnarrowed and still allowed to cross line boundaries … narrowing it
@@ -32,17 +39,30 @@
 
 - [ ] 3.1 Add the differential property test: for every ordinal `#N` in a
       note, `replace_section(text, "#N", extract_section(text, "#N") minus its
-      first line)` SHALL return `text` unchanged.
+      first line)` SHALL return `text` unchanged. Note the level: these are the
+      *pure helpers*, where `extract_section` really does return raw section
+      text. The tool-level property is different and is task 5.3 — do not
+      conflate them.
 - [ ] 3.2 Run that property over a corpus covering, at minimum: blank line(s)
       after a heading; a fenced block directly under a heading, including one
       containing `#`-prefixed lines and one using `~~~`; inline code on a
       heading line; a heading at EOF with and without a trailing newline; a
       heading line with trailing spaces, tabs, and a non-ASCII space; a note
-      whose only content is headings; nested depths where the next heading is
-      deeper (body must run past it) and shallower (body must stop).
-- [ ] 3.3 Run the same property over CRLF and lone-CR notes, asserting the
-      dialect's own terminators are preserved — the #128 terminator rule must
-      survive this change intact.
+      whose only content is headings; **empty sections** (two consecutive
+      headings, and a heading at EOF with no body) in every dialect; nested
+      depths where the next heading is deeper (body must run past it) and
+      shallower (body must stop).
+- [ ] 3.3 Run the same property over CRLF and lone-CR notes at the **helper**
+      level, asserting the dialect's own terminators are preserved — the #128
+      terminator rule must survive this change intact.
+- [ ] 3.3b Pin the declared newline residual at the **tool** level as a test,
+      not as prose: reading a CRLF note's section (which arrives LF-normalised)
+      and writing it back yields `# A\r\nold\n# B\r\nkeep\r\n`. Assert that
+      exact string, so the residual is visible and cannot drift silently.
+- [ ] 3.3c Pin that the unmasked-fence shapes (an indented fence, and one
+      closed by a longer run) produce **byte-identical** output before and
+      after this change. This is the evidence for the "not this change's bug"
+      claim; assert the explicit expected bytes.
 - [ ] 3.4 Assert the **non**-regression that makes this safe: over the whole
       corpus, `_scan_headings` reports identical `depth`, trimmed `text`,
       `line_start`, and document order before and after the fix. Pin it by
@@ -62,23 +82,35 @@
 - [ ] 4.2 Verify section mode over a valid frontmatter block still resolves
       against the stripped body and reattaches the block byte-identically,
       and that a defective block still refuses by name.
-- [ ] 4.3 Confirm `outline_sections`' `#N` ordinals are unchanged across the
-      corpus; the `size` field may shift and the test SHALL assert the new
-      values explicitly rather than being loosened.
+- [ ] 4.3 Confirm `outline_sections` is **entirely** unchanged across the
+      corpus — ordinals and `size` alike. `size` is `body_end - line_start` and
+      this change moves neither endpoint, so any observed shift means the fix
+      went further than intended. Assert explicit values.
 
 ## 5. The caller-visible contract
 
 - [ ] 5.1 Update the `edit_note` docstring in `src/mcp_server/server.py` (the
-      MCP-visible one) to state that in section mode `content` is the body
-      beginning on the line after the heading line — the text a
-      `read_note(section=…)` response carries below its heading line — and
-      that a wanted blank separator belongs in `content`.
-- [ ] 5.2 Make the same statement in `src/mcp_server/tools.py`'s `edit_note`
-      docstring so the two layers do not diverge.
-- [ ] 5.3 Add an end-to-end exercise against the running server: `read_note`
-      a section, write the body back with `edit_note`, read the whole note and
-      assert it is unchanged. Name in the report which tools were actually
-      called.
+      MCP-visible one) to state, in this order: (a) `content` is the body
+      beginning on the line after the heading line; (b) the extraction rule —
+      the text after a `read_note(section=…)` response's `\n---\n` envelope
+      separator, **minus its first line** (never the response's own first line,
+      which is `# <title>`); (c) a section write replaces the whole body, so
+      omitted content — a fenced block included — is deleted; (d) a wanted
+      blank separator belongs in `content`; (e) byte-identity holds for
+      LF-bodied notes, and a CRLF note's selected body comes back as LF.
+- [ ] 5.2 Make the same five statements in `src/mcp_server/tools.py`'s
+      `edit_note` docstring so the two layers do not diverge. Check
+      `read_note`'s docstring in both layers too — it currently says a section
+      response "includes the heading line", which is true but insufficient
+      once a caller is being told to extract from it.
+- [ ] 5.3 Add an end-to-end exercise against the running server that performs
+      the **documented extraction on a real MCP response**, not on the helper's
+      return value: call `read_note(path, section=…)`, split on the first
+      `\n---\n`, drop the first line of the remainder, pass that to
+      `edit_note(section=…)`, then `read_note(path)` the whole note and assert
+      it is unchanged. A test that skips the envelope split does not test the
+      contract the docstring states. Name in the report which tools were
+      actually called.
 
 ## 6. Documentation
 
@@ -90,3 +122,15 @@
 - [ ] 6.2 State the declared compat break there in the terms a future reader
       needs: a section write no longer preserves a blank line the caller did
       not send.
+
+## 7. Residuals and follow-ups
+
+- [ ] 7.1 Do NOT widen `_FENCE_RE` in this change. Confirm by test (3.3c) that
+      the unmasked-fence shapes are byte-identical before and after, then open
+      a follow-up issue describing the gap (indented openers, longer closers),
+      its destructive symptom (a section write deletes the opening fence and
+      orphans the contents), and why fixing it re-addresses `#N` ordinals and
+      therefore needs its own proposal. Link it from `vault-tools.md`.
+- [ ] 7.2 Record the newline residual in `docs/architecture/vault-tools.md`
+      beside the whole-note one #128 already declared, with the measured
+      before/after string.

--- a/openspec/changes/section-round-trip-140/tasks.md
+++ b/openspec/changes/section-round-trip-140/tasks.md
@@ -2,11 +2,11 @@
 
 ## 1. Pin the defect before changing anything
 
-- [ ] 1.1 Add `tests/test_issue_140_section_round_trip.py` exercising the pure
+- [x] 1.1 Add `tests/test_issue_140_section_round_trip.py` exercising the pure
       helpers in `src/services/vault.py` (`_scan_headings`,
       `_section_body_span`, `extract_section`, `replace_section`,
       `outline_sections`) — no DB, no vault, no async.
-- [ ] 1.2 Write the two reported reproductions as failing tests first:
+- [x] 1.2 Write the two reported reproductions as failing tests first:
       the fenced-block duplication on
       `'# A\n```\n## Hidden\ntext\n```\n# B\nb\n'`, and blank-line
       accumulation over three round trips on `'# A\n\nbody\n\n# B\nb\n'`.
@@ -14,36 +14,36 @@
 
 ## 2. The fix
 
-- [ ] 2.1 In `src/services/vault.py`, narrow `_ATX_HEADING_RE`'s trailing
+- [x] 2.1 In `src/services/vault.py`, narrow `_ATX_HEADING_RE`'s trailing
       whitespace run from `\s*` to `[^\S\r\n]*`. Change nothing else in the
       pattern — the separator class `[^\S\r\n]+` and the text capture
       `([^\r\n]+?)` stay exactly as they are.
-- [ ] 2.1b In `replace_section`, make **both** separator insertions conditional
+- [x] 2.1b In `replace_section`, make **both** separator insertions conditional
       on a non-empty `new_body`. Unconditional insertion means an empty section
       (`# A\n# B\nb\n`) gains a blank line and an unterminated EOF heading
       (`# A`) gains a newline on every round trip — the regex fix alone does
       not make the headline property true. Do not touch the non-empty
       behaviour: `tests/test_issue_5_replace_section_eof_heading.py` pins it
       and must stay green unmodified.
-- [ ] 2.2 Rewrite the comment block above the regex. It currently documents
+- [x] 2.2 Rewrite the comment block above the regex. It currently documents
       the opposite decision ("The TRAILING run stays the original `\s*`,
       unnarrowed and still allowed to cross line boundaries … narrowing it
       would change the bytes `edit_note(section=…)` writes"). It must now say
       why that constraint was lifted, what it cost, and what it bought — so a
       future reader does not "restore" the bug.
-- [ ] 2.3 Update `_scan_headings`' and `_section_body_span`'s docstrings so
+- [x] 2.3 Update `_scan_headings`' and `_section_body_span`'s docstrings so
       `line_end` is described accurately (it is now genuinely the end of the
       heading line) and the body-start rule is stated once.
 
 ## 3. Prove the contract, not just the two bugs
 
-- [ ] 3.1 Add the differential property test: for every ordinal `#N` in a
+- [x] 3.1 Add the differential property test: for every ordinal `#N` in a
       note, `replace_section(text, "#N", extract_section(text, "#N") minus its
       first line)` SHALL return `text` unchanged. Note the level: these are the
       *pure helpers*, where `extract_section` really does return raw section
       text. The tool-level property is different and is task 5.3 — do not
       conflate them.
-- [ ] 3.2 Run that property over a corpus covering, at minimum: blank line(s)
+- [x] 3.2 Run that property over a corpus covering, at minimum: blank line(s)
       after a heading; a fenced block directly under a heading, including one
       containing `#`-prefixed lines and one using `~~~`; inline code on a
       heading line; a heading at EOF with and without a trailing newline; a
@@ -52,28 +52,28 @@
       headings, and a heading at EOF with no body) in every dialect; nested
       depths where the next heading is deeper (body must run past it) and
       shallower (body must stop).
-- [ ] 3.3 Run the same property over CRLF and lone-CR notes at the **helper**
+- [x] 3.3 Run the same property over CRLF and lone-CR notes at the **helper**
       level, asserting the dialect's own terminators are preserved — the #128
       terminator rule must survive this change intact.
-- [ ] 3.3b Pin the declared newline residual at the **tool** level as a test,
+- [x] 3.3b Pin the declared newline residual at the **tool** level as a test,
       not as prose: reading a CRLF note's section (which arrives LF-normalised)
       and writing it back yields `# A\r\nold\n# B\r\nkeep\r\n`. Assert that
       exact string, so the residual is visible and cannot drift silently. Add a
       **mixed**-ending case too — the normalisation is per-terminator, not
       per-note: `# A\r\none\r\ntwo\nthree\r# B\rkeep\r` yields
       `# A\r\none\ntwo\nthree\n# B\rkeep\r`.
-- [ ] 3.3c Pin that the unmasked-fence shapes (an indented fence, and one
+- [x] 3.3c Pin that the unmasked-fence shapes (an indented fence, and one
       closed by a longer run) produce **byte-identical** output before and
       after this change. This is the evidence for the "not this change's bug"
       claim; assert the explicit expected bytes.
-- [ ] 3.4 Assert the **non**-regression that makes this safe: over the whole
+- [x] 3.4 Assert the **non**-regression that makes this safe: over the whole
       corpus, `_scan_headings` reports identical `depth`, trimmed `text`,
       `line_start`, and document order before and after the fix. Pin it by
       asserting against explicit expected values, not by comparing two regexes.
 
 ## 4. Guard what must not change
 
-- [ ] 4.1 Re-run the existing section suites unchanged and keep them green:
+- [x] 4.1 Re-run the existing section suites unchanged and keep them green:
       `tests/test_read_response_cap.py`,
       `tests/test_issue_5_replace_section_eof_heading.py`,
       `tests/test_issue_128_section_mode_frontmatter.py`,
@@ -82,7 +82,7 @@
       If one fails, decide explicitly whether it pinned the bug (update it and
       say so in the commit) or caught a real regression (fix the code). Do not
       silently edit an assertion.
-- [ ] 4.2 Verify section mode over a valid frontmatter block still resolves
+- [x] 4.2 Verify section mode over a valid frontmatter block still resolves
       against the stripped body and reattaches the block byte-identically,
       and that a defective block still refuses by name. Assert the asymmetry
       deliberately: on a defective block a section *read* succeeds over the raw
@@ -90,14 +90,14 @@
       must therefore skip such notes rather than be made to pass on them —
       widening parity there would mean scanning a broken block on the write
       side, which is the destructive behaviour #128 removed.
-- [ ] 4.3 Confirm `outline_sections` is **entirely** unchanged across the
+- [x] 4.3 Confirm `outline_sections` is **entirely** unchanged across the
       corpus — ordinals and `size` alike. `size` is `body_end - line_start` and
       this change moves neither endpoint, so any observed shift means the fix
       went further than intended. Assert explicit values.
 
 ## 5. The caller-visible contract
 
-- [ ] 5.1 Update the `edit_note` docstring in `src/mcp_server/server.py` (the
+- [x] 5.1 Update the `edit_note` docstring in `src/mcp_server/server.py` (the
       MCP-visible one) to state, in this order: (a) `content` is the body
       beginning on the line after the heading line; (b) a section write
       replaces the **whole body**, so omitted content — a fenced block included
@@ -109,11 +109,11 @@
       the first line". Such a procedure is forgeable by note content; the
       reason belongs in `vault-tools.md`, not in a docstring a future author
       will "helpfully" complete.
-- [ ] 5.2 Make the same statements in `src/mcp_server/tools.py`'s `edit_note`
+- [x] 5.2 Make the same statements in `src/mcp_server/tools.py`'s `edit_note`
       docstring so the two layers do not diverge. Leave `read_note`'s
       docstrings alone beyond consistency — its response shape is not changing
       here, and the framing work is a separate filed change.
-- [ ] 5.3 Add an end-to-end exercise against the running server, written so it
+- [x] 5.3 Add an end-to-end exercise against the running server, written so it
       does not depend on parsing a response: create a note with known bytes,
       call `read_note(path, section=…)` and assert the response contains the
       expected section, then call `edit_note(path, content=<the known body>,
@@ -121,22 +121,29 @@
       byte-unchanged. Cover a section whose body starts with a blank line, one
       starting with a fenced block, and an empty section. Name in the report
       which tools were actually called.
+      *Done in-process rather than over HTTP against a deployed instance: the
+      exercise calls `create_note_impl`, `read_note_impl` (with and without
+      `section=`) and `edit_note_impl` against a `tmp_path` vault, so it is an
+      automated regression test in
+      `tests/test_issue_140_section_round_trip.py` rather than a one-off poke.
+      It needs no database. Corpus covers all three required shapes plus a
+      final section and a valid-frontmatter note.*
 
 ## 6. Documentation
 
-- [ ] 6.1 Update `docs/architecture/vault-tools.md`'s section-addressing
+- [x] 6.1 Update `docs/architecture/vault-tools.md`'s section-addressing
       material. The passage stating the trailing `\s*` must stay unnarrowed is
       now the *history* of a lifted constraint, not a live prohibition — it
       must record what changed, when, and why, and it must state the new
       body-start rule as the load-bearing invariant.
-- [ ] 6.2 State the declared compat break there in the terms a future reader
+- [x] 6.2 State the declared compat break there in the terms a future reader
       needs, and state the *whole* of it — not just the blank line. A section
       write replaces the entire body, so content the caller omits is deleted.
       Include the concrete fenced-block example: on
       `# A\n```\nimportant\n```\nold\n`,
       `edit_note(section="A", content="new")` now yields `# A\nnew\n`. A
       reader who learns only about the blank line will not predict that.
-- [ ] 6.3 Record why this change documents **no** extraction procedure, with
+- [x] 6.3 Record why this change documents **no** extraction procedure, with
       both reproductions (the multiline title and the quoted
       `"safe\n---\nforged"` key) and the reason sanitising fields does not fix
       it. This is the "do not undo it" note for the next author who notices the
@@ -145,11 +152,11 @@
 
 ## 7. Residuals and follow-ups
 
-- [ ] 7.1 Do NOT widen `_FENCE_RE` in this change. Confirm by test (3.3c) that
+- [x] 7.1 Do NOT widen `_FENCE_RE` in this change. Confirm by test (3.3c) that
       the unmasked-fence shapes are byte-identical before and after, then link **#150**
       from `vault-tools.md`, which describes the gap (indented openers, longer
       closers), its destructive symptom, and why fixing it re-addresses `#N`
       ordinals and needs its own proposal.
-- [ ] 7.2 Record the newline residual in `docs/architecture/vault-tools.md`
+- [x] 7.2 Record the newline residual in `docs/architecture/vault-tools.md`
       beside the whole-note one #128 already declared, with the measured
       before/after string.

--- a/src/mcp_server/server.py
+++ b/src/mcp_server/server.py
@@ -159,7 +159,8 @@ async def read_note(
     what you pass as the whole new body. A truncated response must be paged to
     the end first; a `section=` response belongs to `edit_note(section=...)`,
     and it **includes the heading line** while `edit_note(section=...)` takes
-    the body only, so strip the heading or it is duplicated.
+    the body only — the body being everything from the line after the heading
+    line to the end of the section.
 
     Args:
         path: Vault-relative path to the note (e.g. "Cards/My Note.md")
@@ -320,7 +321,8 @@ async def edit_note(
     3. **Find & replace**: `find=<exact text>`; replaced with `content`. Must match
        exactly once unless `replace_all=True`. This mode operates on the raw
        file, so it is the one mode that can edit frontmatter text in place.
-    4. **Section**: `section=<heading>`; replaces the body under the named ATX heading.
+    4. **Section**: `section=<heading>`; replaces the **whole body** under the
+       named ATX heading — see "Section mode: what `content` replaces" below.
        Use the path-style form `Parent/Child` to disambiguate when the same heading
        appears more than once, or the `#N` ordinal form ("#7", 1-based document
        order) — the ordinal is the only form that can address duplicate headings
@@ -342,10 +344,28 @@ async def edit_note(
     only** — `read_note(path)` with no `section`, `offset=0` and no
     `[TRUNCATED]` notice. A truncated read must be paged to the end before it
     is written back, or full replacement will replace the whole body with the
-    fragment. A `read_note(section=...)` response belongs to
-    `edit_note(section=...)`, and note that a read response
-    **includes the heading line** while `section=` here takes the **body
-    only** — pass it back unstripped and the heading is duplicated.
+    fragment.
+
+    **Section mode: what `content` replaces.**
+    - In section mode `content` is the section's **body**: the text beginning
+      on the line immediately after the matched heading line, running to the
+      next heading of equal-or-shallower depth or to end of note. The heading
+      line itself is never removed or rewritten.
+    - A section write replaces that body **whole**. Anything `content` does not
+      resend is **deleted** — a blank line, a list, and a **fenced code block
+      sitting directly under the heading** included. There is no third region
+      between the heading line and the body that survives a write.
+    - So a blank line you want between the heading and its content belongs in
+      `content` (send `"\\ntext"`, not `"text"`).
+    - `read_note(path, section=...)` is the matching read: a section response
+      **includes the heading line** and that same body, and
+      `edit_note(section=...)` takes the body.
+    - Byte-identity holds for notes whose body newlines are LF. Every non-LF
+      terminator inside the **selected body** (CRLF, or a lone CR) comes back
+      as LF — the read path normalises and this tool writes raw bytes — whether
+      the note uses one dialect throughout or mixes them. Terminators outside
+      the selected body are untouched, so a round trip can leave a note with
+      more mixed endings than it started with.
 
     Section mode resolves headings over the frontmatter-stripped body, exactly
     as `read_note` does, so `#N` ordinals agree between the two and a YAML `#`

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -600,7 +600,8 @@ async def read_note_impl(
     and takes what it is given as the entire new body, so a truncated read must
     be paged to the end before it is written back. A `section=` response
     belongs to `edit_note(section=...)`, and it **includes the heading line**
-    while `edit_note(section=...)` takes the body only.
+    while `edit_note(section=...)` takes the body only — the body being
+    everything from the line after the heading line to the end of the section.
     """
     uid = current_user_id.get()
     try:
@@ -1604,10 +1605,24 @@ async def edit_note_impl(
     only** — `read_note(path)` with no `section`, `offset=0` and no
     `[TRUNCATED]` notice. Feed that response's content back through default
     full replacement and the note is unchanged. A truncated read must be
-    completed (page with `offset`) before it is written back; a
-    `read_note(section=...)` response belongs to `edit_note(section=...)`, and
-    it **includes the heading line** while `edit_note(section=...)` takes the
-    body only — pass it back unstripped and the heading is duplicated.
+    completed (page with `offset`) before it is written back.
+
+    **Section mode: what `content` replaces.** In section mode `content` is the
+    section's **body**: the text beginning on the line immediately after the
+    matched heading line, running to the next heading of equal-or-shallower
+    depth or to end of note. The heading line itself is never removed or
+    rewritten. A section write replaces that body **whole**, so anything
+    `content` does not resend is **deleted** — a blank line, and a **fenced
+    code block sitting directly under the heading**, included; there is no
+    third region between the heading line and the body that survives a write.
+    A blank line wanted between the heading and its content therefore belongs
+    in `content`. `read_note(path, section=...)` is the matching read: a
+    section response carries the heading line and that same body, and
+    `edit_note(section=...)` takes the body. Byte-identity holds for notes
+    whose body newlines are LF; every non-LF terminator inside the *selected
+    body* comes back as LF, whether the note uses one dialect throughout or
+    mixes them, because the read path normalises and this tool writes raw
+    bytes. Terminators outside the selected body are untouched.
 
     Section mode resolves and replaces over the frontmatter-stripped body, so
     a YAML `#` comment is never selectable and never counted by an ordinal,

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -2816,14 +2816,55 @@ _ATX_HEADING_RE = re.compile(
     # non-ASCII space: an LF-only note whose marker is followed by an NBSP
     # lost its heading, so names and `#N` ordinals shifted on existing vaults.
     #
-    # The TRAILING run stays the original `\s*`, unnarrowed and still allowed
-    # to cross line boundaries. `_section_body_span` compensates for that, and
-    # it is what decides where a replaced section's body BEGINS — narrowing it
-    # would change the bytes `edit_note(section=…)` writes for ordinary LF
-    # notes. Generalising the old `$` to "before any terminator, or end" is
-    # what makes the whole pattern work on a lone-CR note while leaving LF and
+    # The TRAILING run is `[^\S\r\n]*` — horizontal whitespace only. It was
+    # the original `\s*`, allowed to cross line boundaries, and #140 narrowed
+    # it deliberately. Do not widen it back.
+    #
+    # `\s` matches `\n` and `\r`, and the lookahead only requires that the run
+    # *end* at a line boundary, so the run crossed as many blank lines as it
+    # liked and stopped before the last terminator it could reach. Worse,
+    # `_scan_headings` scans `mask_code(text)`, where a fenced block is an
+    # equal-length run of SPACES — internal terminators included — so the run
+    # sailed straight through a fenced block sitting under a heading too.
+    # `line_end` was therefore not "the end of the heading line" at all
+    # whenever whitespace-only lines or a masked block followed.
+    #
+    # That put a region of the note inside what `extract_section` returns
+    # (it starts from `line_start`) and outside what `replace_section`
+    # replaces (it starts from `body_start`, one terminator past `line_end`):
+    # readable but unwritable. An agent that read a section, changed it and
+    # wrote it back duplicated whatever sat in the gap — a fenced block came
+    # back twice, and blank lines accumulated +1, +2, +4 over three round
+    # trips.
+    #
+    # What the narrowing cost: it is a declared, destructive compat break.
+    # A section's body now begins on the line immediately after the heading
+    # line, so `edit_note(section=…)` replaces ALL of it — a blank separator
+    # that used to survive is gone unless `content` resends it, and a fenced
+    # block directly under the heading is DELETED unless `content` resends it.
+    # Leaving that block behind was the duplication bug, so replacing it is
+    # the fix, but the blast radius is real content loss for a caller that
+    # does not round-trip. Both `edit_note` docstrings and
+    # `docs/architecture/vault-tools.md` say so in those words.
+    #
+    # What it bought: `line_end` means what this module has always documented,
+    # `body_start` is the first byte of the line after the heading line, and
+    # `extract_section` == heading line + terminator + the exact span
+    # `replace_section` writes — by construction rather than by coincidence.
+    #
+    # What it did NOT change: the capture is `([^\r\n]+?)` and `.strip()` is
+    # applied to it either way, so heading depth, trimmed text, `line_start`
+    # and document order — and therefore every `#N` ordinal and every
+    # `outline_sections` size — are bit-identical before and after. No
+    # selector changes meaning; no existing note is re-addressed. That is what
+    # made this narrowing admissible at all, and
+    # `tests/test_issue_140_section_round_trip.py` pins it against explicit
+    # values captured from the pre-change tree.
+    #
+    # Generalising the old `$` to "before any terminator, or end" is what
+    # makes the whole pattern work on a lone-CR note while leaving LF and
     # CRLF byte-for-byte alone.
-    r"(?:\A|(?<=\n)|(?<=\r))(#{1,6})[^\S\r\n]+([^\r\n]+?)\s*(?=\r|\n|\Z)"
+    r"(?:\A|(?<=\n)|(?<=\r))(#{1,6})[^\S\r\n]+([^\r\n]+?)[^\S\r\n]*(?=\r|\n|\Z)"
 )
 
 
@@ -2831,9 +2872,16 @@ def _scan_headings(text: str) -> list[dict]:
     """Find ATX headings (1–6 `#`) outside code, with byte positions.
 
     Returns dicts with `depth`, `text` (trimmed), `line_start` (byte pos at
-    the leading `#`) and `line_end` (byte pos at end of heading text, before
-    any trailing newline). Code blocks are masked first so headings inside
-    fenced or inline code are ignored.
+    the leading `#`) and `line_end` (byte pos at the END OF THE HEADING LINE:
+    past the heading text and any trailing horizontal whitespace, and before
+    that line's terminator — which `line_end` never crosses, in any dialect).
+    A section's body therefore begins at `line_end` plus at most one line
+    terminator; `_section_body_span` is the single place that steps over it.
+
+    Code blocks are masked first so headings inside fenced or inline code are
+    ignored. Because the mask is a run of spaces, `line_end` only means the
+    above while the heading pattern's trailing whitespace class refuses to
+    cross a line boundary — see the comment on `_ATX_HEADING_RE` (#140).
     """
     from src.services.links import mask_code
 
@@ -2956,9 +3004,16 @@ def _resolve_section_index(
 def _section_body_span(text: str, headings: list[dict], idx: int) -> tuple[int, int]:
     """Return `(body_start, body_end)` for the section at `idx`.
 
-    The body runs from the line after the matched heading up to (but not
-    including) the next heading at depth less than or equal to the matched
-    depth, or end of text.
+    The body begins at the first byte of the line IMMEDIATELY FOLLOWING the
+    heading line — `line_end` plus at most one line terminator — and runs up
+    to (but not including) the next heading at depth less than or equal to the
+    matched depth, or end of text. Nothing sits between the heading line and
+    the body: no blank line, no whitespace, no fenced block. A heading at end
+    of file with no trailing terminator has an empty body.
+
+    `extract_section` returns `line_start … body_end`, i.e. the heading line,
+    its terminator, and exactly this span — so what a section read returns
+    below its heading line is exactly what a section write replaces (#140).
     """
     matched = headings[idx]
     matched_depth = matched["depth"]
@@ -3026,7 +3081,13 @@ def replace_section(text: str, heading: str, new_body: str) -> tuple[str | None,
     the target heading and the preceding parts are ancestors in
     outermost-first order. The replacement runs from the line after the
     matched heading up to (but not including) the next heading at depth
-    less than or equal to the matched depth, or end of file.
+    less than or equal to the matched depth, or end of file — the whole body,
+    so anything `new_body` does not resend is deleted, a blank separator and a
+    fenced block directly under the heading included (#140).
+
+    A separator newline is inserted around `new_body` only when it is
+    non-empty; replacing an empty body with an empty body leaves `text`
+    byte-identical.
     """
     headings = _scan_headings(text)
     idx, err = _resolve_section_index(headings, heading)
@@ -3038,15 +3099,26 @@ def replace_section(text: str, heading: str, new_body: str) -> tuple[str | None,
     next_heading_line_start = body_end if body_end < len(text) else None
 
     inserted = new_body
-    # If the retained prefix lacks a trailing newline (an end-of-file heading
-    # with no trailing newline, where the heading match consumed to EOF),
-    # the new body would glue directly onto the heading text. Prepend one
-    # newline to separate them. No-op when the prefix already ends in "\n".
-    prefix = text[:body_start]
-    if prefix and not prefix.endswith(("\n", "\r")):
-        inserted = "\n" + inserted
-    if next_heading_line_start is not None and not inserted.endswith(("\n", "\r")):
-        inserted = inserted + "\n"
+    # Both separators are conditional on a NON-EMPTY body, and that condition
+    # is load-bearing (#140). A separator exists to keep the new body from
+    # gluing onto its neighbours; with no body there is nothing to separate,
+    # and inserting one anyway means an empty section grows a byte on every
+    # round trip — `# A\n# B\nb\n` gained a blank line, `# A` gained a
+    # newline, and the round-trip guarantee was false for the commonest
+    # degenerate shape in an outline-heavy note. Replacing an empty body with
+    # an empty body must leave the note byte-identical.
+    if inserted:
+        # If the retained prefix lacks a trailing newline (an end-of-file
+        # heading with no trailing newline, where the body span begins at
+        # EOF), the new body would glue directly onto the heading text.
+        # Prepend one newline to separate them. No-op when the prefix already
+        # ends in a terminator. Pinned by
+        # `tests/test_issue_5_replace_section_eof_heading.py`.
+        prefix = text[:body_start]
+        if prefix and not prefix.endswith(("\n", "\r")):
+            inserted = "\n" + inserted
+        if next_heading_line_start is not None and not inserted.endswith(("\n", "\r")):
+            inserted = inserted + "\n"
 
     new_text = text[:body_start] + inserted + text[body_end:]
     return new_text, None

--- a/tests/test_issue_140_section_round_trip.py
+++ b/tests/test_issue_140_section_round_trip.py
@@ -358,23 +358,42 @@ UNMASKED_FENCE_SHAPES = {
         "# A\n   ```\n# Hidden\nx\n   ```\n# B\nb\n",
         [(1, "A", 0), (1, "Hidden", 11), (1, "B", 29)],
         "# A\nnew\n# Hidden\nx\n   ```\n# B\nb\n",
+        "# A\n# Hidden\nx\n   ```\n# B\nb\n",
     ),
     "longer_closer": (
         "# A\n```\n# Hidden\nx\n`````\n# B\nb\n",
         [(1, "A", 0), (1, "Hidden", 8), (1, "B", 25)],
         "# A\nnew\n# Hidden\nx\n`````\n# B\nb\n",
+        "# A\n# Hidden\nx\n`````\n# B\nb\n",
     ),
 }
 
 
 @pytest.mark.parametrize("name", sorted(UNMASKED_FENCE_SHAPES))
 def test_an_unmasked_fence_behaves_exactly_as_before(name):
-    text, expected_headings, expected_write = UNMASKED_FENCE_SHAPES[name]
+    text, expected_headings, expected_write, _ = UNMASKED_FENCE_SHAPES[name]
     observed = [(h["depth"], h["text"], h["line_start"]) for h in _scan_headings(text)]
     assert observed == expected_headings
     new_text, err = replace_section(text, "#1", "new")
     assert err is None
     assert new_text == expected_write
+
+
+@pytest.mark.parametrize("name", sorted(UNMASKED_FENCE_SHAPES))
+def test_an_unmasked_fence_diverges_only_by_the_dropped_separator(name):
+    """The one intended divergence on these shapes.
+
+    The "identical to before" claim holds for a NON-empty replacement body; an
+    empty one picks up the separator-conditionality rule like everywhere else,
+    so the result differs from the pre-change tree by exactly the blank line
+    that rule no longer inserts. Pre-change this wrote `# A\n\n# Hidden…`.
+    A removal, not a loss — pinned so the distinction cannot drift into an
+    unqualified claim again.
+    """
+    text, _, _, expected_empty = UNMASKED_FENCE_SHAPES[name]
+    new_text, err = replace_section(text, "#1", "")
+    assert err is None
+    assert new_text == expected_empty
 
 
 # ── 2.1b/spec scenarios: the empty body ─────────────────────────────────────

--- a/tests/test_issue_140_section_round_trip.py
+++ b/tests/test_issue_140_section_round_trip.py
@@ -1,0 +1,633 @@
+"""Section read/write parity (#140).
+
+`read_note(section=…)` and `edit_note(section=…)` disagreed about where a
+section's body *begins*. `_ATX_HEADING_RE`'s trailing run was `\\s*`, which is
+not restricted to horizontal whitespace, so the heading match ran across blank
+lines — and, because `_scan_headings` scans masked text where a fenced block is
+an equal-length run of spaces, straight through a fenced block sitting under a
+heading too. Everything the run swallowed was returned by `extract_section`
+(which starts from `line_start`) and lay *outside* the span `replace_section`
+replaces (which starts one terminator past `line_end`): readable but
+unwritable. An agent that read a section, changed it, and wrote it back
+duplicated whatever sat in that gap.
+
+The fix narrows the trailing run to `[^\\S\\r\\n]*` and makes both of
+`replace_section`'s separator insertions conditional on a non-empty body. The
+contract that follows is one sentence: **a section's body begins on the line
+immediately after the heading line, and a section write replaces all of it.**
+
+These tests exercise the pure helpers in `src.services.vault` — no DB, no
+vault, no async — except for the tool-level cases at the bottom, which use a
+`tmp_path` vault and a stubbed usage log.
+"""
+
+import asyncio
+import os
+import re
+import tempfile
+
+# See `test_issue_5_replace_section_eof_heading.py` for why this must happen
+# before importing `src.services.vault`: `src.config`'s module-level
+# `Settings()` reads `./.env` relative to CWD, and a host's real `.env` carries
+# keys these tests must never load.
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+import pytest  # noqa: E402
+
+import src.mcp_server.tools as tools  # noqa: E402
+from src.mcp_server.auth import current_permission  # noqa: E402
+from src.services import vault as vault_service  # noqa: E402
+from src.services import vault_fs  # noqa: E402
+from src.services.vault import (  # noqa: E402
+    _scan_headings,
+    extract_section,
+    outline_sections,
+    replace_section,
+)
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+_FIRST_LINE_RE = re.compile(r"[^\r\n]*(?:\r\n|\n|\r)?")
+
+
+def body_of(section_text: str) -> str:
+    """A section's text minus its heading line and that line's terminator.
+
+    This is a *test* helper over raw note text. It is deliberately NOT a
+    documented procedure over a rendered `read_note` response: that response is
+    an envelope interpolating note-controlled values, and every textual rule
+    for recovering the selected content from it proved forgeable. See
+    `docs/architecture/vault-tools.md` and issue #149.
+    """
+    return section_text[_FIRST_LINE_RE.match(section_text).end():]
+
+
+def round_trip(text: str, selector: str) -> str:
+    """Read a section, write its body straight back, return the new note."""
+    section, err = extract_section(text, selector)
+    assert err is None, err
+    new_text, err = replace_section(text, selector, body_of(section))
+    assert err is None, err
+    return new_text
+
+
+# ── the corpus ──────────────────────────────────────────────────────────────
+
+LF_CORPUS = {
+    "blank_line_after_heading": "# A\n\nbody\n\n# B\nb\n",
+    "two_blank_lines_after_heading": "# A\n\n\nbody\n# B\nb\n",
+    "fence_under_heading": "# A\n```\n## Hidden\ntext\n```\n# B\nb\n",
+    "tilde_fence_under_heading": "# A\n~~~\n# Hidden\ntext\n~~~\n# B\nb\n",
+    "fence_with_language_and_blanks": (
+        "# A\n\n```python\n# not a heading\nx = 1\n```\n\ntail\n# B\nb\n"
+    ),
+    "inline_code_on_heading_line": "# A `# code` tail\nbody\n# B\nb\n",
+    "eof_heading_with_trailing_newline": "# A\nbody\n# Notes\n",
+    "eof_heading_without_trailing_newline": "# A\nbody\n# Notes",
+    "eof_body_without_trailing_newline": "# A\nbody\n# Notes\n- item",
+    "trailing_spaces_and_tabs": "# A   \nbody\n# B\t\t\nb\n",
+    # The two characters after `A` in the next entry are U+00A0 NBSP, not
+    # spaces. The trailing class must be "horizontal whitespace", not "space or
+    # tab" — the separator class was widened for exactly that reason, and
+    # narrowing the trailing one must not narrow it past Unicode.
+    "trailing_nbsp": "# A  \nbody\n# B\nb\n",
+    "headings_only": "# A\n## B\n### C\n# D\n",
+    "empty_section_between_headings": "# A\n# B\nb\n",
+    "empty_section_at_eof_no_terminator": "# A\nbody\n# B",
+    "nested_deeper_then_shallower": "# A\nbody a\n## A1\nsub\n### A2\nsubsub\n# B\nb\n",
+    "shallower_follows_deeper": "## Deep\nd\n# Shallow\ns\n",
+    "preamble_before_first_heading": "intro text\n\n# A\nbody\n# B\nb\n",
+}
+
+# Every LF note again in the other two dialects. #128 established that the
+# section helpers must treat CRLF as a unit and a lone CR as a terminator; this
+# change must not disturb either.
+CORPUS: dict[str, str] = {}
+for _name, _text in LF_CORPUS.items():
+    CORPUS[_name] = _text
+    CORPUS[_name + "@crlf"] = _text.replace("\n", "\r\n")
+    CORPUS[_name + "@cr"] = _text.replace("\n", "\r")
+
+# No corpus entry carries frontmatter. Section mode's frontmatter rules live at
+# the tool layer (#128) and are exercised there, at the bottom of this module —
+# including the deliberate asymmetry a defective block keeps: readable by
+# section, refused for section writes.
+
+
+# ── 1. the two reported reproductions ───────────────────────────────────────
+
+
+def test_a_fenced_block_under_a_heading_is_not_duplicated():
+    """Reproduction 1 (#140). The masker turns the fence into a run of spaces,
+    the old trailing `\\s*` ran through it, and the write span began *after*
+    the block — so writing the read body back left the original in place and
+    inserted a second copy. Before the fix this produced
+    `'# A\\n```\\n## Hidden\\ntext\\n```\\n```\\n## Hidden\\ntext\\n```\\n# B\\nb\\n'`.
+    """
+    text = "# A\n```\n## Hidden\ntext\n```\n# B\nb\n"
+    result = round_trip(text, "#1")
+    assert result == text
+    assert result.count("```") == 2
+
+
+def test_blank_lines_do_not_accumulate_across_round_trips():
+    """Reproduction 2 (#140). A blank line after a heading was inside what the
+    read returned and outside what the write replaced, so every round trip
+    re-emitted it on top of the retained one. Measured growth before the fix:
+    +1, +2, +4 blank lines over three round trips."""
+    text = "# A\n\nbody\n\n# B\nb\n"
+    current = text
+    for _ in range(3):
+        current = round_trip(current, "#1")
+        assert current == text
+
+
+# ── 3.1/3.2/3.3 the differential property, over the corpus ──────────────────
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_every_section_round_trips_byte_identically(name):
+    """The spec requirement in executable form: for every ordinal in the note,
+    writing back exactly what the read returned below the heading line leaves
+    the note unchanged."""
+    text = CORPUS[name]
+    for ordinal in range(1, len(_scan_headings(text)) + 1):
+        assert round_trip(text, f"#{ordinal}") == text, f"{name} #{ordinal}"
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_a_round_trip_is_idempotent(name):
+    """Repeating the round trip cannot drift. The blank-line bug was only
+    visible because each pass fed the previous pass's larger prefix back in."""
+    text = CORPUS[name]
+    for ordinal in range(1, len(_scan_headings(text)) + 1):
+        current = text
+        for _ in range(3):
+            current = round_trip(current, f"#{ordinal}")
+        assert current == text, f"{name} #{ordinal}"
+
+
+@pytest.mark.parametrize("name", sorted(n for n in CORPUS if n.endswith("@crlf")))
+def test_a_crlf_note_keeps_crlf_through_a_helper_round_trip(name):
+    """3.3 — at the helper level the note's own dialect survives: the helpers
+    work on raw text, so no terminator is rewritten. (The tool level *does*
+    normalise; that declared residual is pinned separately below.)"""
+    text = CORPUS[name]
+    for ordinal in range(1, len(_scan_headings(text)) + 1):
+        result = round_trip(text, f"#{ordinal}")
+        assert result == text
+        stripped = result.replace("\r\n", "")
+        assert "\n" not in stripped and "\r" not in stripped
+
+
+@pytest.mark.parametrize("name", sorted(n for n in CORPUS if n.endswith("@cr")))
+def test_a_lone_cr_note_keeps_lone_cr_through_a_helper_round_trip(name):
+    text = CORPUS[name]
+    for ordinal in range(1, len(_scan_headings(text)) + 1):
+        result = round_trip(text, f"#{ordinal}")
+        assert result == text
+        assert "\n" not in result
+
+
+# ── 3.4 the non-regression that makes the narrowing admissible ──────────────
+
+# Explicit values, captured from the tree BEFORE the narrowing and asserted
+# against it after. Not a comparison of two regexes: these literals are the
+# old behaviour, frozen. `(depth, trimmed text, line_start)` per heading, in
+# document order. If any of these move, a `#N` ordinal or a selector moved with
+# it, and existing notes have been silently re-addressed.
+EXPECTED_HEADINGS = {
+    'blank_line_after_heading': [(1, 'A', 0), (1, 'B', 11)],
+    'blank_line_after_heading@crlf': [(1, 'A', 0), (1, 'B', 15)],
+    'blank_line_after_heading@cr': [(1, 'A', 0), (1, 'B', 11)],
+    'two_blank_lines_after_heading': [(1, 'A', 0), (1, 'B', 11)],
+    'two_blank_lines_after_heading@crlf': [(1, 'A', 0), (1, 'B', 15)],
+    'two_blank_lines_after_heading@cr': [(1, 'A', 0), (1, 'B', 11)],
+    'fence_under_heading': [(1, 'A', 0), (1, 'B', 27)],
+    'fence_under_heading@crlf': [(1, 'A', 0), (1, 'B', 32)],
+    'fence_under_heading@cr': [(1, 'A', 0), (1, 'B', 27)],
+    'tilde_fence_under_heading': [(1, 'A', 0), (1, 'B', 26)],
+    'tilde_fence_under_heading@crlf': [(1, 'A', 0), (1, 'B', 31)],
+    'tilde_fence_under_heading@cr': [(1, 'A', 0), (1, 'B', 26)],
+    'fence_with_language_and_blanks': [(1, 'A', 0), (1, 'B', 47)],
+    'fence_with_language_and_blanks@crlf': [(1, 'A', 0), (1, 'B', 55)],
+    'fence_with_language_and_blanks@cr': [(1, 'A', 0), (1, 'B', 47)],
+    'inline_code_on_heading_line': [(1, 'A          tail', 0), (1, 'B', 23)],
+    'inline_code_on_heading_line@crlf': [(1, 'A          tail', 0), (1, 'B', 25)],
+    'inline_code_on_heading_line@cr': [(1, 'A          tail', 0), (1, 'B', 23)],
+    'eof_heading_with_trailing_newline': [(1, 'A', 0), (1, 'Notes', 9)],
+    'eof_heading_with_trailing_newline@crlf': [(1, 'A', 0), (1, 'Notes', 11)],
+    'eof_heading_with_trailing_newline@cr': [(1, 'A', 0), (1, 'Notes', 9)],
+    'eof_heading_without_trailing_newline': [(1, 'A', 0), (1, 'Notes', 9)],
+    'eof_heading_without_trailing_newline@crlf': [(1, 'A', 0), (1, 'Notes', 11)],
+    'eof_heading_without_trailing_newline@cr': [(1, 'A', 0), (1, 'Notes', 9)],
+    'eof_body_without_trailing_newline': [(1, 'A', 0), (1, 'Notes', 9)],
+    'eof_body_without_trailing_newline@crlf': [(1, 'A', 0), (1, 'Notes', 11)],
+    'eof_body_without_trailing_newline@cr': [(1, 'A', 0), (1, 'Notes', 9)],
+    'trailing_spaces_and_tabs': [(1, 'A', 0), (1, 'B', 12)],
+    'trailing_spaces_and_tabs@crlf': [(1, 'A', 0), (1, 'B', 14)],
+    'trailing_spaces_and_tabs@cr': [(1, 'A', 0), (1, 'B', 12)],
+    'trailing_nbsp': [(1, 'A', 0), (1, 'B', 11)],
+    'trailing_nbsp@crlf': [(1, 'A', 0), (1, 'B', 13)],
+    'trailing_nbsp@cr': [(1, 'A', 0), (1, 'B', 11)],
+    'headings_only': [(1, 'A', 0), (2, 'B', 4), (3, 'C', 9), (1, 'D', 15)],
+    'headings_only@crlf': [(1, 'A', 0), (2, 'B', 5), (3, 'C', 11), (1, 'D', 18)],
+    'headings_only@cr': [(1, 'A', 0), (2, 'B', 4), (3, 'C', 9), (1, 'D', 15)],
+    'empty_section_between_headings': [(1, 'A', 0), (1, 'B', 4)],
+    'empty_section_between_headings@crlf': [(1, 'A', 0), (1, 'B', 5)],
+    'empty_section_between_headings@cr': [(1, 'A', 0), (1, 'B', 4)],
+    'empty_section_at_eof_no_terminator': [(1, 'A', 0), (1, 'B', 9)],
+    'empty_section_at_eof_no_terminator@crlf': [(1, 'A', 0), (1, 'B', 11)],
+    'empty_section_at_eof_no_terminator@cr': [(1, 'A', 0), (1, 'B', 9)],
+    'nested_deeper_then_shallower': [(1, 'A', 0), (2, 'A1', 11), (3, 'A2', 21), (1, 'B', 35)],
+    'nested_deeper_then_shallower@crlf': [(1, 'A', 0), (2, 'A1', 13), (3, 'A2', 25), (1, 'B', 41)],
+    'nested_deeper_then_shallower@cr': [(1, 'A', 0), (2, 'A1', 11), (3, 'A2', 21), (1, 'B', 35)],
+    'shallower_follows_deeper': [(2, 'Deep', 0), (1, 'Shallow', 10)],
+    'shallower_follows_deeper@crlf': [(2, 'Deep', 0), (1, 'Shallow', 12)],
+    'shallower_follows_deeper@cr': [(2, 'Deep', 0), (1, 'Shallow', 10)],
+    'preamble_before_first_heading': [(1, 'A', 12), (1, 'B', 21)],
+    'preamble_before_first_heading@crlf': [(1, 'A', 14), (1, 'B', 25)],
+    'preamble_before_first_heading@cr': [(1, 'A', 12), (1, 'B', 21)],
+}
+
+# 4.3 — `outline_sections` reports `size = body_end - line_start`. The
+# narrowing moves neither endpoint, so ordinals AND sizes are unchanged. Any
+# shift here means the fix went further than intended. `(ordinal, depth, text,
+# size)`.
+EXPECTED_OUTLINE = {
+    'blank_line_after_heading': [(1, 1, 'A', 11), (2, 1, 'B', 6)],
+    'blank_line_after_heading@crlf': [(1, 1, 'A', 15), (2, 1, 'B', 8)],
+    'blank_line_after_heading@cr': [(1, 1, 'A', 11), (2, 1, 'B', 6)],
+    'two_blank_lines_after_heading': [(1, 1, 'A', 11), (2, 1, 'B', 6)],
+    'two_blank_lines_after_heading@crlf': [(1, 1, 'A', 15), (2, 1, 'B', 8)],
+    'two_blank_lines_after_heading@cr': [(1, 1, 'A', 11), (2, 1, 'B', 6)],
+    'fence_under_heading': [(1, 1, 'A', 27), (2, 1, 'B', 6)],
+    'fence_under_heading@crlf': [(1, 1, 'A', 32), (2, 1, 'B', 8)],
+    'fence_under_heading@cr': [(1, 1, 'A', 27), (2, 1, 'B', 6)],
+    'tilde_fence_under_heading': [(1, 1, 'A', 26), (2, 1, 'B', 6)],
+    'tilde_fence_under_heading@crlf': [(1, 1, 'A', 31), (2, 1, 'B', 8)],
+    'tilde_fence_under_heading@cr': [(1, 1, 'A', 26), (2, 1, 'B', 6)],
+    'fence_with_language_and_blanks': [(1, 1, 'A', 47), (2, 1, 'B', 6)],
+    'fence_with_language_and_blanks@crlf': [(1, 1, 'A', 55), (2, 1, 'B', 8)],
+    'fence_with_language_and_blanks@cr': [(1, 1, 'A', 47), (2, 1, 'B', 6)],
+    'inline_code_on_heading_line': [(1, 1, 'A          tail', 23), (2, 1, 'B', 6)],
+    'inline_code_on_heading_line@crlf': [(1, 1, 'A          tail', 25), (2, 1, 'B', 8)],
+    'inline_code_on_heading_line@cr': [(1, 1, 'A          tail', 23), (2, 1, 'B', 6)],
+    'eof_heading_with_trailing_newline': [(1, 1, 'A', 9), (2, 1, 'Notes', 8)],
+    'eof_heading_with_trailing_newline@crlf': [(1, 1, 'A', 11), (2, 1, 'Notes', 9)],
+    'eof_heading_with_trailing_newline@cr': [(1, 1, 'A', 9), (2, 1, 'Notes', 8)],
+    'eof_heading_without_trailing_newline': [(1, 1, 'A', 9), (2, 1, 'Notes', 7)],
+    'eof_heading_without_trailing_newline@crlf': [(1, 1, 'A', 11), (2, 1, 'Notes', 7)],
+    'eof_heading_without_trailing_newline@cr': [(1, 1, 'A', 9), (2, 1, 'Notes', 7)],
+    'eof_body_without_trailing_newline': [(1, 1, 'A', 9), (2, 1, 'Notes', 14)],
+    'eof_body_without_trailing_newline@crlf': [(1, 1, 'A', 11), (2, 1, 'Notes', 15)],
+    'eof_body_without_trailing_newline@cr': [(1, 1, 'A', 9), (2, 1, 'Notes', 14)],
+    'trailing_spaces_and_tabs': [(1, 1, 'A', 12), (2, 1, 'B', 8)],
+    'trailing_spaces_and_tabs@crlf': [(1, 1, 'A', 14), (2, 1, 'B', 10)],
+    'trailing_spaces_and_tabs@cr': [(1, 1, 'A', 12), (2, 1, 'B', 8)],
+    'trailing_nbsp': [(1, 1, 'A', 11), (2, 1, 'B', 6)],
+    'trailing_nbsp@crlf': [(1, 1, 'A', 13), (2, 1, 'B', 8)],
+    'trailing_nbsp@cr': [(1, 1, 'A', 11), (2, 1, 'B', 6)],
+    'headings_only': [(1, 1, 'A', 15), (2, 2, 'B', 11), (3, 3, 'C', 6), (4, 1, 'D', 4)],
+    'headings_only@crlf': [(1, 1, 'A', 18), (2, 2, 'B', 13), (3, 3, 'C', 7), (4, 1, 'D', 5)],
+    'headings_only@cr': [(1, 1, 'A', 15), (2, 2, 'B', 11), (3, 3, 'C', 6), (4, 1, 'D', 4)],
+    'empty_section_between_headings': [(1, 1, 'A', 4), (2, 1, 'B', 6)],
+    'empty_section_between_headings@crlf': [(1, 1, 'A', 5), (2, 1, 'B', 8)],
+    'empty_section_between_headings@cr': [(1, 1, 'A', 4), (2, 1, 'B', 6)],
+    'empty_section_at_eof_no_terminator': [(1, 1, 'A', 9), (2, 1, 'B', 3)],
+    'empty_section_at_eof_no_terminator@crlf': [(1, 1, 'A', 11), (2, 1, 'B', 3)],
+    'empty_section_at_eof_no_terminator@cr': [(1, 1, 'A', 9), (2, 1, 'B', 3)],
+    'nested_deeper_then_shallower': [(1, 1, 'A', 35), (2, 2, 'A1', 24), (3, 3, 'A2', 14), (4, 1, 'B', 6)],
+    'nested_deeper_then_shallower@crlf': [(1, 1, 'A', 41), (2, 2, 'A1', 28), (3, 3, 'A2', 16), (4, 1, 'B', 8)],
+    'nested_deeper_then_shallower@cr': [(1, 1, 'A', 35), (2, 2, 'A1', 24), (3, 3, 'A2', 14), (4, 1, 'B', 6)],
+    'shallower_follows_deeper': [(1, 2, 'Deep', 10), (2, 1, 'Shallow', 12)],
+    'shallower_follows_deeper@crlf': [(1, 2, 'Deep', 12), (2, 1, 'Shallow', 14)],
+    'shallower_follows_deeper@cr': [(1, 2, 'Deep', 10), (2, 1, 'Shallow', 12)],
+    'preamble_before_first_heading': [(1, 1, 'A', 9), (2, 1, 'B', 6)],
+    'preamble_before_first_heading@crlf': [(1, 1, 'A', 11), (2, 1, 'B', 8)],
+    'preamble_before_first_heading@cr': [(1, 1, 'A', 9), (2, 1, 'B', 6)],
+}
+
+
+def test_the_expected_tables_cover_the_whole_corpus():
+    """A missing key would make the two tests below silently vacuous."""
+    assert set(EXPECTED_HEADINGS) == set(CORPUS)
+    assert set(EXPECTED_OUTLINE) == set(CORPUS)
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_no_selector_changes_meaning(name):
+    """3.4. Depth, trimmed text, `line_start` and document order are what every
+    selector — exact text, path chain, and `#N` ordinal — resolves through."""
+    observed = [
+        (h["depth"], h["text"], h["line_start"]) for h in _scan_headings(CORPUS[name])
+    ]
+    assert observed == [tuple(e) for e in EXPECTED_HEADINGS[name]]
+
+
+@pytest.mark.parametrize("name", sorted(CORPUS))
+def test_outline_sections_is_entirely_unchanged(name):
+    """4.3. Ordinals and sizes alike — the truncation outline a caller
+    navigates by must mean exactly what it meant before."""
+    observed = [
+        (e["ordinal"], e["depth"], e["text"], e["size"])
+        for e in outline_sections(CORPUS[name])
+    ]
+    assert observed == [tuple(e) for e in EXPECTED_OUTLINE[name]]
+
+
+# ── 3.3c the residual this change does NOT fix (#150) ───────────────────────
+
+# `_FENCE_RE` recognises only a column-zero opener closed by a fence of exactly
+# the same length. CommonMark allows up to three spaces of indentation and a
+# closer at least as long as the opener, so these two shapes are NOT masked: a
+# heading inside them is visible to the scanner, and a section write there
+# already deletes the opening fence and orphans the contents.
+#
+# That is a genuine destructive-write hazard and it is issue #150, not this
+# change. Widening the masker shifts which lines count as headings, which
+# re-addresses every `#N` ordinal on an affected note — a strictly larger
+# compat break. These are the bytes the tree wrote BEFORE the narrowing,
+# captured and frozen; they are the evidence for "not this change's bug".
+
+UNMASKED_FENCE_SHAPES = {
+    "indented_opener": (
+        "# A\n   ```\n# Hidden\nx\n   ```\n# B\nb\n",
+        [(1, "A", 0), (1, "Hidden", 11), (1, "B", 29)],
+        "# A\nnew\n# Hidden\nx\n   ```\n# B\nb\n",
+    ),
+    "longer_closer": (
+        "# A\n```\n# Hidden\nx\n`````\n# B\nb\n",
+        [(1, "A", 0), (1, "Hidden", 8), (1, "B", 25)],
+        "# A\nnew\n# Hidden\nx\n`````\n# B\nb\n",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(UNMASKED_FENCE_SHAPES))
+def test_an_unmasked_fence_behaves_exactly_as_before(name):
+    text, expected_headings, expected_write = UNMASKED_FENCE_SHAPES[name]
+    observed = [(h["depth"], h["text"], h["line_start"]) for h in _scan_headings(text)]
+    assert observed == expected_headings
+    new_text, err = replace_section(text, "#1", "new")
+    assert err is None
+    assert new_text == expected_write
+
+
+# ── 2.1b/spec scenarios: the empty body ─────────────────────────────────────
+
+
+def test_an_empty_section_between_headings_gains_nothing():
+    """Spec scenario. Unconditional separator insertion meant `# A\\n# B\\nb\\n`
+    became `# A\\n\\n# B\\nb\\n` on every round trip."""
+    new_text, err = replace_section("# A\n# B\nb\n", "#1", "")
+    assert err is None
+    assert new_text == "# A\n# B\nb\n"
+
+
+def test_an_unterminated_eof_heading_gains_nothing():
+    """Spec scenario. `# A` used to become `# A\\n`."""
+    new_text, err = replace_section("# A", "#1", "")
+    assert err is None
+    assert new_text == "# A"
+
+
+@pytest.mark.parametrize("eol", ["\n", "\r\n", "\r"])
+def test_an_empty_body_is_stable_in_every_dialect(eol):
+    text = "# A{0}# B{0}b{0}".format(eol)
+    new_text, err = replace_section(text, "#1", "")
+    assert err is None
+    assert new_text == text
+
+
+def test_emptying_a_populated_section_removes_the_whole_body():
+    """The other side of the same rule: an empty replacement is a deletion, and
+    it leaves no separator behind either."""
+    new_text, err = replace_section("# A\nold\n# B\nb\n", "#1", "")
+    assert err is None
+    assert new_text == "# A\n# B\nb\n"
+
+
+def test_a_non_empty_body_is_still_separated():
+    """Spec scenario, and the #5 behaviour the conditional must not disturb."""
+    assert replace_section("# Notes", "Notes", "- item")[0] == "# Notes\n- item"
+    assert replace_section("# A\n# B\nb\n", "#1", "x")[0] == "# A\nx\n# B\nb\n"
+
+
+# ── spec scenarios: what the body now contains ──────────────────────────────
+
+
+def test_a_blank_line_after_a_heading_belongs_to_the_body():
+    """Spec scenario, and the declared compat break in its mildest form."""
+    new_text, err = replace_section("# A\n\nold\n# B\nb\n", "#1", "new")
+    assert err is None
+    assert new_text == "# A\nnew\n# B\nb\n"
+
+
+def test_a_wanted_blank_separator_is_the_callers_to_send():
+    new_text, err = replace_section("# A\n\nold\n# B\nb\n", "#1", "\nnew\n")
+    assert err is None
+    assert new_text == "# A\n\nnew\n# B\nb\n"
+
+
+def test_a_fenced_block_under_a_heading_is_replaced_not_retained():
+    """Spec scenario. This is the destructive half of the declared break: the
+    block is gone unless `content` resends it."""
+    text = "# A\n```\n## Hidden\ntext\n```\n# B\nb\n"
+    new_text, err = replace_section(text, "#1", "new")
+    assert err is None
+    assert new_text == "# A\nnew\n# B\nb\n"
+    assert "```" not in new_text
+
+
+def test_the_declared_content_loss_is_exactly_what_the_docs_promise():
+    """The example `vault-tools.md` carries.
+
+    Note the exact bytes: `# A\\nnew`, with NO trailing newline. The proposal
+    and design for #140 render this example as `# A\\nnew\\n`; that extra
+    terminator is an illustration slip, not the contract. `A` is the last
+    heading, so no following heading needs separating from the new body, and
+    the trailing separator is only ever inserted to prevent that gluing — the
+    same rule `tests/test_issue_5_replace_section_eof_heading.py` has pinned
+    since #5. A caller who wants the note to end in a newline sends one.
+    """
+    text = "# A\n```\nimportant\n```\nold\n"
+    new_text, err = replace_section(text, "A", "new")
+    assert err is None
+    assert new_text == "# A\nnew"
+    # …and the caller's own terminator is respected, unchanged.
+    assert replace_section(text, "A", "new\n")[0] == "# A\nnew\n"
+
+
+def test_trailing_whitespace_stays_on_the_heading_line():
+    """Spec scenario. Horizontal whitespace after the heading text is part of
+    the heading line, never the body — and the trimmed text is unchanged, so
+    the exact-text and path-style selectors still reach it."""
+    for pad in ("   ", "\t\t", " "):
+        text = f"# A{pad}\nbody\n# B\nb\n"
+        headings = _scan_headings(text)
+        assert headings[0]["text"] == "A"
+        section, err = extract_section(text, "A")
+        assert err is None
+        assert section == f"# A{pad}\nbody\n"
+        assert body_of(section) == "body\n"
+        assert replace_section(text, "A", "new\n")[0] == f"# A{pad}\nnew\n# B\nb\n"
+
+
+def test_a_deeper_heading_stays_inside_its_parents_body():
+    text = "# A\nbody a\n## A1\nsub\n# B\nb\n"
+    section, err = extract_section(text, "#1")
+    assert err is None
+    assert section == "# A\nbody a\n## A1\nsub\n"
+    assert replace_section(text, "#1", "new\n")[0] == "# A\nnew\n# B\nb\n"
+
+
+# ── the tool layer ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def vault(monkeypatch, tmp_path):
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(vault_service.settings, "vault_path", str(tmp_path))
+    monkeypatch.setattr(tools, "_log_usage", noop)
+    vault_fs.reset_filesystem_probe_cache()
+    token = current_permission.set("readwrite")
+    yield tmp_path
+    current_permission.reset(token)
+    vault_fs.reset_filesystem_probe_cache()
+
+
+def write(vault, name, text):
+    (vault / name).write_text(text, encoding="utf-8", newline="")
+    return vault / name
+
+
+def read(vault, name):
+    return (vault / name).read_bytes().decode("utf-8")
+
+
+# 5.3 — an end-to-end exercise of the two tools an agent actually calls, using
+# note bytes the test itself authored rather than anything parsed out of a
+# response. Tools exercised: `create_note` (`create_note_impl`), `read_note`
+# (`read_note_impl`, with and without `section=`) and `edit_note`
+# (`edit_note_impl`, `section=`).
+
+TOOL_ROUND_TRIPS = {
+    # (note bytes, selector, the body those bytes put under that heading)
+    "body_starts_with_a_blank_line": ("# A\n\nbody\n# B\nb\n", "#1", "\nbody\n"),
+    "body_starts_with_a_fence": (
+        "# A\n```\n## Hidden\ntext\n```\ntail\n# B\nb\n",
+        "#1",
+        "```\n## Hidden\ntext\n```\ntail\n",
+    ),
+    "empty_section": ("# A\n# B\nb\n", "#1", ""),
+    "final_section": ("# A\na\n# B\n\nb\n", "#2", "\nb\n"),
+    "valid_frontmatter": (
+        "---\ntitle: T\n---\n# A\n\nbody\n# B\nb\n",
+        "#1",
+        "\nbody\n",
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(TOOL_ROUND_TRIPS))
+def test_a_tool_level_section_round_trip_leaves_the_note_byte_identical(vault, name):
+    note, selector, body = TOOL_ROUND_TRIPS[name]
+    created = asyncio.run(tools.create_note_impl("n.md", note))
+    assert "Created" in created or "created" in created, created
+    assert read(vault, "n.md") == note
+
+    # The read must actually carry the section it claims to. Section mode
+    # resolves over the frontmatter-stripped body (#128), so that is the text
+    # the expected section is taken from.
+    _, scanned = vault_service.parse_frontmatter(note)
+    section, err = extract_section(scanned, selector)
+    assert err is None
+    assert section.startswith("# ")
+    assert body_of(section) == body, "the test's own idea of the body is wrong"
+
+    response = asyncio.run(tools.read_note_impl("n.md", section=selector))
+    assert "not found" not in response
+    assert section in response
+
+    result = asyncio.run(tools.edit_note_impl("n.md", body, section=selector))
+    assert "Updated note" in result, result
+    assert read(vault, "n.md") == note
+
+    # And the whole-note read still shows the note it started as.
+    whole = asyncio.run(tools.read_note_impl("n.md"))
+    assert scanned in whole
+
+
+def test_the_declared_content_loss_is_reachable_from_the_tool(vault):
+    """The break, as a caller meets it: `content` that does not resend the
+    fenced block deletes it."""
+    write(vault, "n.md", "# A\n```\nimportant\n```\nold\n")
+    result = asyncio.run(tools.edit_note_impl("n.md", "new", section="A"))
+    assert "Updated note" in result
+    # No trailing newline: `A` is the last heading, so nothing needs separating
+    # from the new body. See the helper-level test above.
+    assert read(vault, "n.md") == "# A\nnew"
+
+
+# 3.3b — the declared newline residual, pinned as bytes so it cannot drift.
+
+
+def test_a_crlf_note_comes_back_with_an_lf_body(vault):
+    """`read_note` applies universal-newline translation; `edit_note` rewrites
+    raw bytes. So the *selected body* is rewritten LF while the heading line
+    and everything outside the section keep their own terminators."""
+    write(vault, "n.md", "# A\r\nold\r\n# B\r\nkeep\r\n")
+    # "old\n" is what the read path hands back for that body.
+    asyncio.run(tools.edit_note_impl("n.md", "old\n", section="#1"))
+    assert read(vault, "n.md") == "# A\r\nold\n# B\r\nkeep\r\n"
+
+
+def test_the_normalisation_is_per_terminator_not_per_note(vault):
+    """A mixed-ending note is not "a CRLF note": every terminator inside the
+    selected body comes back as LF, and only those."""
+    write(vault, "n.md", "# A\r\none\r\ntwo\nthree\r# B\rkeep\r")
+    asyncio.run(tools.edit_note_impl("n.md", "one\ntwo\nthree\n", section="#1"))
+    assert read(vault, "n.md") == "# A\r\none\ntwo\nthree\n# B\rkeep\r"
+
+
+# 4.2 — the frontmatter rules #128 established, unchanged by this change.
+
+
+def test_a_valid_block_is_reattached_byte_identically(vault):
+    block = "---\ntitle: Keep\ntags:\n  - a\n# a comment\n---\n"
+    write(vault, "n.md", block + "## Tasks\n\nold\n## Notes\nkeep\n")
+    asyncio.run(tools.edit_note_impl("n.md", "new\n", section="Tasks"))
+    assert read(vault, "n.md") == block + "## Tasks\nnew\n## Notes\nkeep\n"
+
+
+def test_a_defective_block_is_readable_by_section_and_refused_for_writes(vault):
+    """The asymmetry is deliberate and this change does not relax it (#128).
+
+    A read destroys nothing, so it proceeds over the raw bytes. A write over
+    those same bytes could select a `#` line inside the broken block and
+    replace across the closing fence — the corruption #128 removed. So the
+    round-trip property above deliberately does NOT extend here: the guarantee
+    such a note gets is the refusal.
+    """
+    original = "---\n# Tasks\n---\n# Body\nkeep\n"
+    write(vault, "n.md", original)
+
+    # The read succeeds, over the raw bytes: `# Tasks` is heading #1 there.
+    response = asyncio.run(tools.read_note_impl("n.md", section="#1"))
+    assert "not found" not in response
+    assert "malformed frontmatter block" not in response
+    assert "# Tasks" in response
+
+    # The write refuses, by name, and touches nothing.
+    for selector in ("#1", "Tasks", "Parent/Tasks"):
+        result = asyncio.run(tools.edit_note_impl("n.md", "x", section=selector))
+        assert "malformed frontmatter block" in result
+        assert "not a mapping" in result
+        assert "replace_frontmatter=True" in result
+    assert read(vault, "n.md") == original


### PR DESCRIPTION
Closes #140.

`read_note(section=…)` and `edit_note(section=…)` disagreed about where a section's *body* begins, so the natural agent round trip — read a section, change something, write it back — was not byte-stable on ordinary LF notes.

## Root cause

`_ATX_HEADING_RE`'s trailing whitespace run was `\s*`, which is not restricted to horizontal whitespace. `\s` includes `\n` and `\r`, and the lookahead only requires the run to *end* at a line boundary — so it crossed blank lines freely. A heading's `line_end`, documented as "byte pos at end of heading text, before any trailing newline", was nothing of the sort.

Read and write then split at different points:

| | span | consequence |
| --- | --- | --- |
| `extract_section` (read) | `line_start … body_end` | sees everything |
| `replace_section` (write) | `body_start … body_end` | starts *after* the swallowed run |

Everything in that gap was **readable but unwritable**. The two reported symptoms are two ways of filling it.

**Fenced-code duplication.** `mask_code` replaces a fenced block with an equal-length run of spaces, newlines included — so `\s*` ate the entire masked block. `body_start == body_end`: an empty span pointing at the next heading. The read still returned the fence, so writing it back left the original and inserted a second copy.

**Blank-line accumulation.** One `\n` fell inside the read and outside the write, so each round trip re-emitted it on top of the retained one. Measured growth: **+1, +2, +4** over three round trips.

## The fix

Narrow the trailing run to `[^\S\r\n]*`, so `line_end` means what its docstring already claimed. The separator class and the text capture are untouched, so **no selector changes meaning** — heading depth, trimmed text, `line_start` and every `#N` ordinal are bit-identical.

The regex alone isn't sufficient: `replace_section` inserted its separator newlines unconditionally, so an empty section (`# A\n# B\nb\n`) still gained a blank line per round trip and `# A` gained a newline. Both insertions are now conditional on a non-empty body. Issue #5's non-empty EOF cases are untouched and its test file is unmodified.

## Declared compat break — destructive, not cosmetic

A section write replaces the whole body, so content the caller does not resend is **deleted**:

- `edit_note(section="Tasks", content="- x")` on `## Tasks\n\n- old\n` now writes `## Tasks\n- x\n`. The blank separator belongs in `content`.
- A fenced block directly under a heading is now **replaced**. On ``# A\n```\nimportant\n```\nold\n``, `edit_note(section="A", content="new")` yields `# A\nnew`. Leaving the block behind *was* the duplication bug — but a caller that doesn't round-trip loses content, and both docstrings and `vault-tools.md` say so in those words.

The read→modify→write path an agent actually takes comes out strictly better: it now preserves what it used to duplicate.

## Scoped out, filed

The spec audit found two adjacent problems that are **not** this change's and would have been expensive to bundle:

- **#149** — `read_note`'s response envelope is forgeable by note content. Any documented "split the response on `\n---\n`" rule can be subverted by a multiline YAML title *or* a quoted frontmatter key into an instruction that writes `**Path:** …` into the note. Both reproduced. So this change documents **no** extraction procedure and forbids the docstrings from prescribing one; the round-trip guarantee is stated over note text and verified against the shared helpers. Closing it properly needs structural framing of the response.
- **#150** — `mask_code`'s fence grammar is narrower than CommonMark (no indented openers, no longer closers). Real destructive-write hazard, but measured **byte-identical before and after** this change, and fixing it re-addresses `#N` ordinals on existing notes.

## Verification

- **268** new tests in `tests/test_issue_140_section_round_trip.py`; full suite **2336 passed, 6 skipped**.
- Both reproductions were written as **failing** tests first and confirmed failing on the unmodified tree.
- The non-regression claim is *proven*, not asserted: `_scan_headings` and `outline_sections` output diffed between the pre- and post-change trees — byte-identical. The frozen expectation tables are pre-change values.
- **7 rounds of Codex spec review** before any code was written, then an adversarial Codex pass (**PASS**, 0 findings, incl. a 100,000-case differential fuzz finding no ordinal or heading-identity change) and an independent `openspec-verifier` pass (**0 blocking gaps**).

## Not done

No tool has been called against the live server. `CLAUDE.md` substitutes a live-tool exercise for the `user-representative` gate; the in-process test covers `create_note_impl` / `read_note_impl` / `edit_note_impl` against a temp vault, leaving transport, `_tracked` vault-root resolution and auth unexercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SakkpngBNXLiTpbRu6CPxw