### PR TITLE
fix(docs): double-escape surrogate examples in docstrings for Python 3.13

### DIFF
--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -424,7 +424,7 @@ def _response_size(result) -> int:
 def _first_unencodable_argument(bound) -> str | None:
     """The name of the first argument carrying an unpaired surrogate, or None.
 
-    A JSON-RPC argument can hold `"\ud800"`: a valid JSON string, a valid
+    A JSON-RPC argument can hold `"\\ud800"`: a valid JSON string, a valid
     Python `str`, and not a Unicode scalar value — so it cannot be encoded as
     UTF-8. Nothing good happens downstream. It cannot name a file. It cannot be
     written to one. And when a tool quotes it back in an error message — which

--- a/src/services/vault.py
+++ b/src/services/vault.py
@@ -361,7 +361,7 @@ def coerce_text(value) -> tuple[str | None, str | None]:
     * `title: 0x<5000 hex digits>` — PyYAML *constructs* the int happily
       (CPython's digit limit guards decimal parsing, not hex literals), and then
       `str()` on it raises `ValueError`. The value is fine; rendering it is not.
-    * `title: "\uD800"` — decodes to a lone surrogate, which is a valid Python
+    * `title: "\\uD800"` — decodes to a lone surrogate, which is a valid Python
       `str` and not a Unicode scalar value, so it cannot be encoded as UTF-8 and
       `pydantic_core` refuses to serialize it.
 
@@ -2835,7 +2835,7 @@ def _representability(value) -> str | None:
       on it raises `ValueError`. That crashed `read_note`, the control panel's
       note viewer, the indexer's batch (`_note_title`), and JSONB
       serialization of `notes_metadata.frontmatter`.
-    * `title: "\uD800"` — decodes to a lone surrogate, a valid Python `str`
+    * `title: "\\uD800"` — decodes to a lone surrogate, a valid Python `str`
       that is not a Unicode scalar value, so it cannot be UTF-8-encoded.
       `pydantic_core` raises on it, and it reaches the panel's HTML.
 


### PR DESCRIPTION
## Problem

Docstrings in `src/services/vault.py` and `src/mcp_server/tools.py` contain the literal escape `"\uD800"` (single backslash). In Python source this is an escape sequence, so the compiled docstring constant holds a real Unicode surrogate (U+D800). CPython 3.13's `compile()` refuses any module whose string constants contain surrogates — `UnicodeEncodeError: 'utf-8' codec can't encode character '\ud800' ... surrogates not allowed` — so **the entire app is unimportable on Python 3.13** (`import src.services.vault` fails).

3.12 tolerates it (the surrogate sits in the docstring, harmless), which is why CI — running 3.12 per the Dockerfile — never caught this. Anyone running the server under 3.13 gets a hard import failure.

## Fix

Double the backslash (`"\\uD800"`) so the docstring constant is the literal text `\uD800` rather than a surrogate character. The rendered docstring is identical on 3.12; the module now compiles on 3.13 too.

Verified:
- double-escape compiles + renders as literal text on 3.12 and 3.13
- single-escape fails on 3.13, embeds a real surrogate on 3.12

## Files
- `src/services/vault.py` (2 docstrings)
- `src/mcp_server/tools.py` (1 docstring)