### PR TITLE
feat(panel): search analytics — query visibility, zero-result detection, retrieval coverage (#161)

### DIFF
--- a/docs/architecture/control-panel.md
+++ b/docs/architecture/control-panel.md
@@ -116,6 +116,23 @@
   is that everything inline is nonced. Their security headers must stay
   byte-identical once each response's per-request nonce is canonicalized.
 
+- **A new page has to be added to the sweep's template list, and the sweep
+  has to be pointed at the templates.** `checks/literal_sweep.py` in the
+  light-mode change (now under `openspec/changes/archive/`) is what proves
+  "no color literal outside a token definition", but it scans a *recorded*
+  list — `colorscan.PANEL_TEMPLATES` — which is the set of templates that
+  existed when the sweep was written, and it resolves the templates directory
+  from `__file__` assuming the change still sits at
+  `openspec/changes/<id>/checks/`. Archiving moved it one level deeper, so an
+  unmodified run now finds no files and reports **zero declarations, zero
+  literals, exit 0** — a clean bill of health for a directory it never read.
+  Run it from a wrapper that repoints `colorscan.TEMPLATE_DIR` at
+  `src/control_panel/templates` and appends the new page (and
+  `performance.html`, added by #160, which is not in the recorded list
+  either), and assert the scan actually saw a nonzero number of declarations
+  before believing the result. Pages added since: `performance.html` (#160),
+  `search_analytics.html` (#161) — both token-only, verified that way.
+
 
 ## Flash messages
 

--- a/docs/architecture/search.md
+++ b/docs/architecture/search.md
@@ -126,3 +126,52 @@ lives in a service module only to avoid an import cycle (`tools` imports
 return types are unchanged — a direct call outside a tracked tool finds no
 holder and records nothing. No migration: `params` is JSONB.
 
+## Search result telemetry (#161)
+
+The same holder carries what a search *returned*, which is what
+`/admin/search-analytics` reads. Three keys, written by
+`timing.record_results` / `timing.record_source_path` in the place where each
+tool's result set is final — `full_text_search` (`src/services/search.py`),
+`semantic_search` (`src/services/embeddings.py`), and `find_related_impl`
+itself, after its dedupe and truncation to `limit`, so the telemetry names what
+the caller was handed and not what the overfetch scanned.
+
+- **`result_count`** — an int, always, and the **full** count. Not the number
+  of paths that fit the budget below: the zero-result view reads this value,
+  and a count clipped to the logging cap would report a search that found forty
+  notes as having found ten.
+- **`result_paths`** — at most the first `MAX_RESULT_PATHS` (10) paths, and at
+  most `MAX_RESULT_PATHS_BYTES` (2048) bytes of UTF-8 JSON for the value,
+  dropping paths **from the end** so what is logged stays a prefix of a ranked
+  list. A path that does not fit is dropped whole, never cut: a truncated path
+  names a note that does not exist, and it would land in the coverage ranking
+  as a real retrieval.
+- **`source_path`** (`find_related` only) — the grouping key for that tool's
+  analytics, recorded before anything can return so that the two failure
+  branches carry it too. The full path when it is at most
+  `MAX_SOURCE_PATH_BYTES` (1024) bytes, otherwise its sha256 hex digest. The
+  named `path` param cannot serve: `_truncate_params` cuts it at 200
+  characters, so two distinct long paths would collapse onto one row.
+
+**The budget is enforced at the record site, and it has to be.** `_tracked`
+builds its logged params as `_truncate_params(named args)` and *then*
+`update()`s the timing holder over the top — merged telemetry never meets the
+generic 200-character truncation, so there is no backstop downstream. A
+regression here does not fail a call; it writes a params blob orders of
+magnitude larger than every other row in `usage_logs`.
+
+**`find_related`'s two operational failures are marked** (`params.error`):
+`related_source_not_found` and `related_source_not_embedded`. Both branches
+used to return a plain string with no marker at all, which left them
+indistinguishable *in the log* from a call that ran and found nothing — and
+"the vault holds nothing near this note" is the one the analytics page exists
+to count. Both are **post-body** markers; the classification rule and what that
+implies live in [usage attribution](usage-attribution.md). A source that exists,
+is embedded, and has no neighbours after the exact fallback stays a true
+zero-result: `result_count` 0, no marker.
+
+Reading side: `src/services/search_analytics.py` and
+`/admin/search-analytics`. Its identity rule — every grouping and coverage join
+keys on `(usage_logs.user_id, path)` with `IS NOT DISTINCT FROM` — is written
+down there and in [usage attribution](usage-attribution.md).
+

--- a/docs/architecture/usage-attribution.md
+++ b/docs/architecture/usage-attribution.md
@@ -163,6 +163,23 @@ in `src/services/usage_stats.py`; two things about it are load-bearing.
   string; a new value costs nothing and a shared one mis-measures in a
   direction nobody can see from the page.
 
+  **The register, as of #161.** Pre-body: `no_vault_assigned`,
+  `argument_not_encodable`, and the boolean `over_quota` (#162). Post-body:
+  `vault_assignment_changed`, `vault_confirmation_unavailable`,
+  `vault_anchor_lost_at_publish`, and `find_related`'s two operational
+  failures, `related_source_not_found` and `related_source_not_embedded`.
+  Those last two were classified by the rule above and land on the post-body
+  side: the body ran, resolved the vault and queried the database before
+  either branch could be reached, so enumerating them as refusals would drop a
+  real database round trip out of the percentiles. They are two values rather
+  than one because they are different facts with different fixes — a caller
+  naming a note that does not exist, and the embed pass not having reached a
+  note that does. They exist at all because those branches used to log
+  nothing: a `find_related` that never got as far as looking was
+  indistinguishable in the log from one that looked and found nothing, and
+  `/admin/search-analytics` reads the second as the signature fact about what
+  a vault does not hold. The marker is what keeps the first out of that count.
+
   Both halves are `COALESCE(..., false)`: `params` is nullable and `->>` on a
   missing key yields NULL, so without them the negation used by the executed
   filter would be NULL and PostgreSQL would drop every ordinary row on the
@@ -207,3 +224,45 @@ Actor attribution on the slowest-requests table is the denormalised
 `_usage_actor` reader `/admin/usage` uses, for the same reason (#77): resolving
 by join alone renders "unknown" for precisely the credential an operator has
 just deleted and come to investigate.
+
+
+## Search result telemetry (#161)
+
+The search tools record three more `params` keys — `result_count`,
+`result_paths` and (`find_related` only) `source_path` — through the same
+`timing` holder the phase timings ride on. The contract, the byte budget and
+why the budget is enforced at the record site rather than downstream are
+written down in [search](search.md); what belongs here is what they mean for
+this table.
+
+- **They are reserved keys with declared types**, for the reason `embed_ms`,
+  `db_ms` and `over_quota` are: a reader casts and unnests them.
+  `result_count` is an int, `result_paths` a JSON array of strings,
+  `source_path` a string. A writer with something else to say about a result
+  set uses a different key.
+- **The reader guards its casts anyway.** The performance page's casts are
+  unguarded and that is a standing constraint on future writers; the analytics
+  page took the other half of the deal as well — it tests
+  `params->>'result_count'` against an integer pattern and
+  `jsonb_typeof(params->'result_paths') = 'array'` before reading either. Both
+  belts, because the failure mode is a 500 on the whole window for every user
+  until the bad row ages out, and the search keys are written on the hottest
+  read path in the server.
+- **`_truncate_params` does not see them.** `_tracked` truncates the *named*
+  arguments and then merges the holder over the top. That is why the paths
+  value carries its own 10-path / 2048-byte bound, and why `find_related`'s
+  grouping key is the separate `source_path` and not the named `path`, which
+  is cut at 200 characters and would collapse distinct long paths onto one row.
+
+**The identity rule for anything reading these keys: `(usage_logs.user_id,
+path)`, matched NULL-safely.** A path is unique only within an owner —
+`uq_notes_metadata_user_id_file_path` says so in the schema, with
+`NULLS NOT DISTINCT` — so `Daily/2026-08-29.md` names a different note in each
+user's vault. A grouping or coverage join on the path alone would merge two
+tenants' analytics into one row and tell each of them things about the other's
+vault. `IS NOT DISTINCT FROM` rather than `=` because both sides are nullable
+and both are NULL in exactly the shape that matters most: single-user mode
+writes NULL on every log row and every note, and `usage_logs.user_id` is
+`ON DELETE SET NULL`, so a deleted user's rows join the ownerless slice rather
+than vanishing. That is the honest reading — those rows *are* now unattributed
+— and it is the same treatment the ownerless indexer passes get.

--- a/openspec/changes/panel-search-analytics/tasks.md
+++ b/openspec/changes/panel-search-analytics/tasks.md
@@ -1,6 +1,6 @@
 ## 1. Telemetry
 
-- [ ] 1.1 timing.record result_count + result_paths (≤10 paths, ≤2048 bytes, enforced at record site) in keyword_search/semantic_search/find_related service returns, plus find_related's `source_path` key (full path ≤1024 bytes, else sha256 hex); verify params in usage_logs rows incl. a long-paths case
+- [x] 1.1 timing.record result_count + result_paths (≤10 paths, ≤2048 bytes, enforced at record site) in keyword_search/semantic_search/find_related service returns, plus find_related's `source_path` key (full path ≤1024 bytes, else sha256 hex); verify params in usage_logs rows incl. a long-paths case
 
 ## 2. Panel
 
@@ -10,5 +10,5 @@
 
 ## 3. Docs and verification
 
-- [ ] 3.1 docs/architecture/search.md + usage-attribution.md notes on the new param keys
+- [x] 3.1 docs/architecture/search.md + usage-attribution.md notes on the new param keys
 - [ ] 3.2 End-to-end against live server: issue searches incl. a guaranteed zero-result query; verify all page sections

--- a/openspec/changes/panel-search-analytics/tasks.md
+++ b/openspec/changes/panel-search-analytics/tasks.md
@@ -4,9 +4,9 @@
 
 ## 2. Panel
 
-- [ ] 2.1 Search-analytics page: top queries + zero-result queries for keyword/semantic search; find_related tables grouped by source path; window selector; error/refusal rows excluded
-- [ ] 2.2 Coverage section: top-logged retrievals (labeled as first-10-logged appearances) / never-retrieved, cap caveat beside both
-- [ ] 2.3 Nav entry; theme token partial
+- [x] 2.1 Search-analytics page: top queries + zero-result queries for keyword/semantic search; find_related tables grouped by source path; window selector; error/refusal rows excluded
+- [x] 2.2 Coverage section: top-logged retrievals (labeled as first-10-logged appearances) / never-retrieved, cap caveat beside both
+- [x] 2.3 Nav entry; theme token partial
 
 ## 3. Docs and verification
 

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -44,6 +44,17 @@ from src.oauth.scope import (
     token_has_write,
 )
 from src.services.indexer import invalidate_hnsw_index_cache
+from src.services.search_analytics import (
+    COVERAGE_LIMIT,
+    LOGGED_RESULTS_PER_CALL,
+    QUERY_TOOLS,
+    RELATED_TOOL,
+    TABLE_LIMIT,
+    never_retrieved,
+    top_logged_retrievals,
+    top_queries,
+    zero_result_queries,
+)
 from src.services.usage_stats import (
     RECENT_RUNS_LIMIT,
     WINDOW_LABELS,
@@ -1320,6 +1331,117 @@ async def performance_page(
             # deploy, a quiet weekend) and gets its own copy rather than a
             # table of zeroes that reads like a measurement.
             "has_data": any(t["executed"] or t["refusals"] for t in tools),
+        }),
+    )
+
+
+# --- Search analytics -----------------------------------------------------
+
+
+#: How the page labels each search tool. `find_related` is kept out of
+#: `QUERY_TOOLS` and rendered separately because it has no query — its tables
+#: are grouped by source note.
+_SEARCH_TOOL_LABELS = {
+    "keyword_search": "Keyword search",
+    "semantic_search": "Semantic search",
+    "find_related": "Related notes",
+}
+
+#: A `source_path` recorded as a digest rather than a path (over the telemetry
+#: contract's 1024-byte bound). Labelled as such on the page: showing 64 hex
+#: characters in a column of note paths, unmarked, would read as a note.
+_DIGEST_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+def _label_group_value(tool: str, value: str) -> dict:
+    """Render one grouping value: the query text, or a source path/digest."""
+    if tool != RELATED_TOOL:
+        return {"text": value, "is_digest": False}
+    return {"text": value, "is_digest": bool(_DIGEST_RE.match(value or ""))}
+
+
+@router.get("/search-analytics", response_class=HTMLResponse)
+async def search_analytics_page(
+    request: Request,
+    window: str | None = None,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_user_panel),
+):
+    """What agents searched for, what came back empty, and what retrieval never
+    surfaced — over a selectable window.
+
+    Read-only aggregation over the search result telemetry in
+    `usage_logs.params`; the SQL, the `(user_id, path)` identity rule and the
+    reason the error filter is broad here and enumerated on
+    `/admin/performance` all live in `src/services/search_analytics.py`.
+
+    Scoped exactly like `/admin/performance`: an admin sees every row — grouped
+    per owner, never merged, because a path names a different note in each
+    user's vault — and a regular user only their own. `window` is clamped
+    rather than validated, so a hand-edited query string renders the page.
+    """
+    uid = _scope_user_id(user)
+    window = normalize_window(window)
+
+    query_tables = []
+    for tool in QUERY_TOOLS:
+        top = await top_queries(session, window, uid, tool)
+        zero = await zero_result_queries(session, window, uid, tool)
+        query_tables.append({
+            "tool": tool,
+            "label": _SEARCH_TOOL_LABELS[tool],
+            "top": [dict(r, label=_label_group_value(tool, r["value"])) for r in top],
+            "zero": [dict(r, label=_label_group_value(tool, r["value"])) for r in zero],
+        })
+
+    related = {
+        "tool": RELATED_TOOL,
+        "label": _SEARCH_TOOL_LABELS[RELATED_TOOL],
+        "top": [
+            dict(r, label=_label_group_value(RELATED_TOOL, r["value"]))
+            for r in await top_queries(session, window, uid, RELATED_TOOL)
+        ],
+        "zero": [
+            dict(r, label=_label_group_value(RELATED_TOOL, r["value"]))
+            for r in await zero_result_queries(session, window, uid, RELATED_TOOL)
+        ],
+    }
+
+    retrievals = await top_logged_retrievals(session, window, uid)
+    missing, missing_total = await never_retrieved(session, window, uid)
+
+    tables = [*query_tables, related]
+    # The owner column earns its place only when the page is actually showing
+    # more than one owner's rows. In single-user mode every row is ownerless,
+    # and a column of "no owner" is noise that pushes the paths off the side.
+    owners = {
+        row["user_id"]
+        for table in tables
+        for row in (*table["top"], *table["zero"])
+    } | {row["user_id"] for row in (*retrievals, *missing)}
+    has_data = any(table["top"] for table in tables) or bool(retrievals)
+
+    return templates.TemplateResponse(
+        request,
+        "search_analytics.html",
+        _panel_context(request, user, {
+            "active": "search-analytics",
+            "window": window,
+            "window_label": WINDOW_LABELS[window],
+            "windows": [
+                {"key": key, "label": key, "selected": key == window}
+                for key in WINDOWS
+            ],
+            "query_tables": query_tables,
+            "related": related,
+            "retrievals": retrievals,
+            "never_retrieved": missing,
+            "never_retrieved_total": missing_total,
+            "table_limit": TABLE_LIMIT,
+            "coverage_limit": COVERAGE_LIMIT,
+            "logged_per_call": LOGGED_RESULTS_PER_CALL,
+            "show_owner": len(owners) > 1,
+            "has_data": has_data,
         }),
     )
 

--- a/src/control_panel/templates/base.html
+++ b/src/control_panel/templates/base.html
@@ -852,6 +852,13 @@
                 </svg>
                 Performance
             </a>
+            <a href="/admin/search-analytics" class="nav-item {% if active == 'search-analytics' %}active{% endif %}">
+                <svg class="nav-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                    <circle cx="7" cy="7" r="4.5"/>
+                    <line x1="10.4" y1="10.4" x2="14.5" y2="14.5"/>
+                </svg>
+                Search
+            </a>
 
             <div class="nav-section">Access</div>
             <a href="/admin/keys" class="nav-item {% if active == 'keys' %}active{% endif %}">

--- a/src/control_panel/templates/search_analytics.html
+++ b/src/control_panel/templates/search_analytics.html
@@ -1,0 +1,264 @@
+{% extends "base.html" %}
+{% block title %}Search analytics — Obsidian MCP{% endblock %}
+{% block content %}
+
+{#
+  Every color on this page comes from a token defined in `_theme.html`; there
+  are no literals here. See docs/architecture/control-panel.md — "one token
+  source, dark canonical". The light-mode change's
+  `checks/literal_sweep.py` is what enforces it.
+#}
+
+{#
+  The logging cap, written once and rendered beside *both* coverage sections.
+  It is the difference between a measurement and a claim: only the first
+  {{ logged_per_call }} results of each call reach `usage_logs`, so the ranking
+  counts appearances within that prefix and the never-retrieved list is an
+  upper bound. One `set` rather than two paragraphs so the two cannot drift —
+  a caveat that is only on one of them is worse than none, because it makes
+  the unlabelled list look exact by contrast.
+#}
+{% set cap_caveat %}
+Only the first {{ logged_per_call }} results of each call are recorded, so both
+lists below are bounded by what the log can see: the ranking counts appearances
+<em>within those first {{ logged_per_call }}</em>, not every time a note was
+returned, and a note can sit in the never-retrieved list having been returned
+further down a result list than the log keeps.
+{% endset %}
+
+{% macro group_cell(row) -%}
+    {% if row.label.is_digest %}
+        {# A source path over the telemetry contract's 1024-byte bound is
+           recorded as its sha256 digest, so the grouping stays non-colliding.
+           Rendered as 64 unmarked hex characters it would read as a note. #}
+        <span class="mono" style="font-size:11px;color:var(--text-3);"
+              title="This source path was too long to log whole, so it is grouped by its sha256 digest.">digest {{ row.label.text[:16] }}…</span>
+    {% else %}
+        <span class="mono" style="font-size:12px;color:var(--primary-text);word-break:break-word;">{{ row.label.text }}</span>
+    {% endif %}
+    {% if show_owner %}
+        <div class="mono" style="font-size:10px;color:var(--text-3);">
+            {% if row.owner %}{{ row.owner }}{% elif row.user_id %}user #{{ row.user_id }}{% else %}no owner{% endif %}
+        </div>
+    {% endif %}
+{%- endmacro %}
+
+{% macro group_tables(table, key_header) %}
+<div class="card anim-2" style="margin-bottom:20px;">
+    <div class="card-header">
+        <span class="card-title">{{ table.label }}</span>
+        <span class="mono" style="font-size:11px;color:var(--text-3);">{{ window_label }}</span>
+    </div>
+    <div class="table-scroll">
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>{{ key_header }}</th>
+                <th style="text-align:right;">Calls</th>
+                <th style="text-align:right;" title="Mean number of notes returned, over the calls that recorded a result count.">Mean results</th>
+                <th style="text-align:right;" title="Calls in this window that returned nothing.">Empty</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in table.top %}
+            <tr>
+                <td>{{ group_cell(row) }}</td>
+                <td class="mono" style="text-align:right;font-size:12px;">{{ row.calls }}</td>
+                {# NULL mean: no call in this group recorded a result count —
+                   every one predates the telemetry. An em dash says "not
+                   measured"; a 0 would say "this search finds nothing". #}
+                <td class="mono" style="text-align:right;font-size:12px;color:var(--text-2);">{% if row.mean_results is not none %}{{ row.mean_results }}{% else %}<span style="color:var(--text-3);" title="No call in this group recorded a result count.">—</span>{% endif %}</td>
+                <td class="mono" style="text-align:right;font-size:12px;">
+                    {% if row.zero_calls %}<span class="badge badge-yellow">{{ row.zero_calls }}</span>{% else %}<span style="color:var(--text-3);">0</span>{% endif %}
+                </td>
+            </tr>
+            {% endfor %}
+            {% if not table.top %}
+            <tr><td colspan="4" style="text-align:center;padding:32px;color:var(--text-3);">No {{ table.label | lower }} calls with recorded results in this window.</td></tr>
+            {% endif %}
+        </tbody>
+    </table>
+    </div>
+
+    <div class="card-body">
+        <p style="color:var(--text-3);font-size:12px;line-height:1.6;margin:0 0 8px;">
+            <strong style="color:var(--text-2);">Came back empty.</strong>
+            Searches that ran to completion and found nothing — memory the vault
+            was asked for and does not hold. Calls that failed before producing
+            a result set are excluded: a refused call, and for related-notes a
+            source that is missing or not yet embedded, are not the same fact.
+        </p>
+    </div>
+    <div class="table-scroll">
+    <table class="data-table">
+        <thead>
+            <tr>
+                <th>{{ key_header }}</th>
+                <th style="text-align:right;">Empty calls</th>
+                <th style="text-align:right;">Total calls</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in table.zero %}
+            <tr>
+                <td>{{ group_cell(row) }}</td>
+                <td class="mono" style="text-align:right;font-size:12px;"><span class="badge badge-yellow">{{ row.zero_calls }}</span></td>
+                <td class="mono" style="text-align:right;font-size:12px;color:var(--text-2);">{{ row.calls }}</td>
+            </tr>
+            {% endfor %}
+            {% if not table.zero %}
+            <tr><td colspan="3" style="text-align:center;padding:24px;color:var(--text-3);">Nothing came back empty in this window.</td></tr>
+            {% endif %}
+        </tbody>
+    </table>
+    </div>
+</div>
+{% endmacro %}
+
+<div class="page-top">
+    <h1 class="page-title">Search analytics</h1>
+</div>
+
+<div class="page-body">
+
+    <!-- Window selector -->
+    <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:20px;">
+        <span style="font-size:12px;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:var(--text-2);">Window</span>
+        {% for w in windows %}
+        <a href="/admin/search-analytics?window={{ w.key }}"
+           class="btn {% if w.selected %}btn-primary{% else %}btn-ghost{% endif %}"
+           style="padding:6px 14px;font-size:12px;"
+           {% if w.selected %}aria-current="page"{% endif %}>{{ w.label }}</a>
+        {% endfor %}
+        <span style="font-size:12px;color:var(--text-3);margin-left:4px;">{{ window_label }}</span>
+    </div>
+
+    {% if not has_data %}
+    <div class="card anim-1" style="margin-bottom:20px;">
+        <div class="card-body">
+            <p style="color:var(--text-2);font-size:14px;line-height:1.6;margin:0;">
+                No searches with recorded results were logged in this window.
+                Result telemetry starts at the first search after the deploy
+                that added it, so a window reaching further back than that will
+                look emptier than it was — pick a shorter window, run a search,
+                and reload.
+            </p>
+        </div>
+    </div>
+    {% endif %}
+
+    {% for table in query_tables %}
+        {{ group_tables(table, "Query") }}
+    {% endfor %}
+
+    {#
+      `find_related` takes a note, not a query, so it gets the same two tables
+      keyed by its source note. The grouping value is the `source_path`
+      telemetry key rather than the named `path` param, which is truncated at
+      200 characters in the log and would collapse distinct long paths onto one
+      row.
+    #}
+    {{ group_tables(related, "Source note") }}
+
+    <!-- Retrieval coverage -->
+    <div class="card anim-3" style="margin-bottom:20px;">
+        <div class="card-header">
+            <span class="card-title">Top-logged retrievals</span>
+            <span class="mono" style="font-size:11px;color:var(--text-3);">{{ window_label }}</span>
+        </div>
+        <div class="card-body">
+            <p style="color:var(--text-3);font-size:12px;line-height:1.6;margin:0;">{{ cap_caveat }}</p>
+        </div>
+        <div class="table-scroll">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Note</th>
+                    <th style="text-align:right;" title="Times this note appeared in the first {{ logged_per_call }} logged results of a call.">Logged appearances</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in retrievals %}
+                <tr>
+                    <td>
+                        <span class="mono" style="font-size:12px;color:var(--primary-text);word-break:break-word;">{{ row.path }}</span>
+                        {% if not row.indexed %}
+                            {# The path was retrieved in this window but no note
+                               with that path exists for that owner now: renamed
+                               or deleted since. Said plainly rather than shown
+                               as an ordinary row. #}
+                            <span class="badge badge-gray" title="No indexed note has this path for this owner any more — renamed or deleted since it was retrieved.">not in index</span>
+                        {% endif %}
+                        {% if show_owner %}
+                        <div class="mono" style="font-size:10px;color:var(--text-3);">
+                            {% if row.owner %}{{ row.owner }}{% elif row.user_id %}user #{{ row.user_id }}{% else %}no owner{% endif %}
+                        </div>
+                        {% endif %}
+                    </td>
+                    <td class="mono" style="text-align:right;font-size:12px;">{{ row.appearances }}</td>
+                </tr>
+                {% endfor %}
+                {% if not retrievals %}
+                <tr><td colspan="2" style="text-align:center;padding:32px;color:var(--text-3);">No search in this window logged a result path.</td></tr>
+                {% endif %}
+            </tbody>
+        </table>
+        </div>
+    </div>
+
+    <div class="card anim-3">
+        <div class="card-header">
+            <span class="card-title">Never retrieved</span>
+            <span class="mono" style="font-size:11px;color:var(--text-3);">
+                {% if never_retrieved_total > never_retrieved | length %}
+                    showing {{ never_retrieved | length }} of {{ never_retrieved_total }}
+                {% else %}
+                    {{ never_retrieved_total }} note{{ '' if never_retrieved_total == 1 else 's' }}
+                {% endif %}
+            </span>
+        </div>
+        <div class="card-body">
+            <p style="color:var(--text-3);font-size:12px;line-height:1.6;margin:0;">{{ cap_caveat }}</p>
+            <p style="color:var(--text-3);font-size:12px;line-height:1.6;margin:8px 0 0;">
+                Indexed notes that appear in no logged result of this window.
+                An <strong style="color:var(--text-2);">upper bound</strong> on
+                what retrieval is missing, not a list of dead notes — the longer
+                the window, the closer it gets.
+            </p>
+        </div>
+        <div class="table-scroll">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Note</th>
+                    <th>Title</th>
+                    <th style="text-align:right;">Modified</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for row in never_retrieved %}
+                <tr>
+                    <td>
+                        <span class="mono" style="font-size:12px;color:var(--primary-text);word-break:break-word;">{{ row.path }}</span>
+                        {% if show_owner %}
+                        <div class="mono" style="font-size:10px;color:var(--text-3);">
+                            {% if row.owner %}{{ row.owner }}{% elif row.user_id %}user #{{ row.user_id }}{% else %}no owner{% endif %}
+                        </div>
+                        {% endif %}
+                    </td>
+                    <td style="font-size:12px;color:var(--text-2);">{{ row.title }}</td>
+                    <td class="mono" style="text-align:right;font-size:11px;color:var(--text-2);">
+                        {% if row.modified_at %}<time datetime="{{ row.modified_at }}" data-localize>{{ row.modified_at }}</time>{% else %}<span style="color:var(--text-3);">—</span>{% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not never_retrieved %}
+                <tr><td colspan="3" style="text-align:center;padding:32px;color:var(--text-3);">Every indexed note appeared in at least one logged result in this window.</td></tr>
+                {% endif %}
+            </tbody>
+        </table>
+        </div>
+    </div>
+
+</div>
+{% endblock %}

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -319,6 +319,29 @@ _CONFIRMATION_UNAVAILABLE_MARKER = "vault_confirmation_unavailable"
 # an assignment we could read could not be named.
 _ANCHOR_LOST_AT_PUBLISH_MARKER = "vault_anchor_lost_at_publish"
 
+# Markers for `find_related`'s two operational failures (#161). Both are
+# **post-body**: the body ran, resolved the vault, and queried the database —
+# so, like every other post-body marker, they must never be added to
+# `src/services/usage_stats.py`'s pre-body refusal predicate, which would drop
+# these calls out of the latency percentiles.
+#
+# They exist because those two branches used to return a plain string with no
+# marker at all, which made them indistinguishable *in the log* from a search
+# that ran and found nothing. `/admin/search-analytics` reads
+# `result_count == 0` as "the vault was asked for something it does not hold" —
+# the signature question the page exists to answer — and a source note that is
+# missing or not yet embedded is not that. It is a call that never got as far
+# as looking, and counting it as a zero-result would put the operator's own
+# typos and the indexer's backlog into the list of gaps in the vault's memory.
+#
+# Two values and not one, for the reason the classification rule gives: they
+# are different facts with different fixes. `related_source_not_found` means
+# the caller named a note that does not exist (or is not theirs);
+# `related_source_not_embedded` means the note exists and the embed pass has
+# not reached it, which resolves itself and is a fact about the indexer.
+_RELATED_SOURCE_NOT_FOUND_MARKER = "related_source_not_found"
+_RELATED_SOURCE_NOT_EMBEDDED_MARKER = "related_source_not_embedded"
+
 
 class _TrashUnusable(Exception):
     """The trash probe failed for a reason that is not `UnsupportedFilesystem`.
@@ -1727,6 +1750,13 @@ async def find_related_impl(path: str, limit: int = 10) -> str:
     uid = current_user_id.get()
     limit = max(1, min(limit, 50))
 
+    # The grouping key for this tool's analytics, recorded before anything can
+    # return: every row this call writes — the two failures below included —
+    # has to name the source it was asked about, or the failures cannot be
+    # attributed to a note. The named `path` param is truncated at 200
+    # characters and would collapse distinct long paths onto one row.
+    timing.record_source_path(path)
+
     async with async_session() as session:
         # `db_ms` covers every database phase of this tool, the source-chunk
         # fetch included — it is accumulated, so the early returns below still
@@ -1738,6 +1768,13 @@ async def find_related_impl(path: str, limit: int = 10) -> str:
         source = (await session.execute(src_stmt)).scalar_one_or_none()
         if source is None:
             timing.add_ms("db_ms", time.monotonic() - db_start)
+            # Marked, and marked *distinctly*: this call never reached a
+            # vector query, so it is an operational failure and not a
+            # zero-result. `result_count` is still recorded so the key's type
+            # is uniform across every row this tool writes — the analytics
+            # page excludes the row on the marker, not on a missing key.
+            timing.record("error", _RELATED_SOURCE_NOT_FOUND_MARKER)
+            timing.record_results(())
             return f"Note not found: {path}"
 
         chunks = (await session.execute(
@@ -1745,6 +1782,12 @@ async def find_related_impl(path: str, limit: int = 10) -> str:
         )).scalars().all()
         timing.add_ms("db_ms", time.monotonic() - db_start)
         if not chunks:
+            # The other operational failure: the note is there, the embed pass
+            # has not reached it. A fact about the indexer, not about the
+            # vault's contents, so it carries its own marker and stays out of
+            # the zero-result view.
+            timing.record("error", _RELATED_SOURCE_NOT_EMBEDDED_MARKER)
+            timing.record_results(())
             return (
                 f"`{path}` has not been embedded yet — "
                 "the indexer is still catching up. Try again in a few minutes."
@@ -1793,6 +1836,11 @@ async def find_related_impl(path: str, limit: int = 10) -> str:
         rows = sorted(rows, key=lambda r: r.distance)
 
     if not rows:
+        # A **true** zero-result: the source exists, it is embedded, the exact
+        # fallback has already re-run the query, and the vault holds nothing
+        # near it. No marker — this is precisely the row the zero-result view
+        # is built to count.
+        timing.record_results(())
         return f"No related notes for `{path}`"
 
     # Dedupe by note_id, keeping the nearest chunk — ranked by the *same*
@@ -1816,6 +1864,9 @@ async def find_related_impl(path: str, limit: int = 10) -> str:
             }
 
     ranked = sorted(best.values(), key=lambda x: x["distance"])[:limit]
+    # After the dedupe and the truncation to `limit`: the telemetry names what
+    # the caller was handed, not what the overfetch scanned.
+    timing.record_results(r["path"] for r in ranked)
     lines = [f"Top {len(ranked)} related notes for `{path}`:\n"]
     for r in ranked:
         tags_str = f" [{', '.join(r['tags'])}]" if r["tags"] else ""

--- a/src/services/embeddings.py
+++ b/src/services/embeddings.py
@@ -569,7 +569,7 @@ async def semantic_search(
         if len(deduped) >= limit:
             break
 
-    return [
+    results = [
         {
             "path": nm.file_path,
             "title": nm.title,
@@ -582,3 +582,9 @@ async def semantic_search(
         }
         for ne, nm in deduped
     ]
+    # Result telemetry, recorded after the dedupe so the count and the paths
+    # are what the tool actually returns (#161) — an overfetched, not-yet-
+    # deduped row list would report a note twice. Bounds are enforced inside
+    # `record_results`; no-op outside a tracked tool call.
+    timing.record_results(r["path"] for r in results)
+    return results

--- a/src/services/search.py
+++ b/src/services/search.py
@@ -2,6 +2,7 @@ from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.models.db import NoteMetadata
+from src.services import timing
 from src.services.filters import apply_note_filters
 from src.services.fts import combined_tsquery
 
@@ -50,7 +51,7 @@ async def full_text_search(
 
     result = await session.execute(stmt)
     rows = result.all()
-    return [
+    results = [
         {
             "path": nm.file_path,
             "title": nm.title,
@@ -59,3 +60,10 @@ async def full_text_search(
         }
         for nm, row_rank in rows
     ]
+    # Result telemetry, recorded where the result set is final (#161). The
+    # bounds live in `timing.record_results`, which is the record site the
+    # `_tracked` merge cannot truncate — see `src/services/timing.py`. Outside
+    # a tracked tool call (the panel, the benchmarks) there is no holder and
+    # this is a no-op.
+    timing.record_results(r["path"] for r in results)
+    return results

--- a/src/services/search_analytics.py
+++ b/src/services/search_analytics.py
@@ -1,0 +1,380 @@
+"""Read-only aggregation for the panel's search-analytics view (#161).
+
+One source, `usage_logs`, read through the result telemetry
+`src/services/timing.py` records — `result_count`, `result_paths`, and
+`find_related`'s `source_path`. Nothing here writes anything. The contract for
+those keys, including why their byte budget is enforced at the record site,
+is in `docs/architecture/search.md`.
+
+The question the page answers is "what do my agents think this vault knows":
+which queries they run, which come back empty, which notes retrieval surfaces
+and which it never does. Three properties of this module are load-bearing.
+
+## 1. Identity is `(user_id, path)`, matched NULL-safely
+
+A path is unique only within an owner — `uq_notes_metadata_user_id_file_path`
+says exactly that in the schema, with `NULLS NOT DISTINCT` — so
+`Daily/2026-08-29.md` names a different note in every user's vault. **Every**
+grouping and every coverage join here therefore keys on the pair, and joins it
+with `IS NOT DISTINCT FROM` rather than `=`.
+
+Both halves matter. Dropping `user_id` from the key would merge two tenants'
+analytics into one row and show each of them facts about the other's vault —
+a coverage list is a list of note paths, which is exactly the thing a tenant
+must not learn about another. Using `=` would silently drop the ownerless
+slice: `user_id` is nullable on both tables, single-user mode writes NULL on
+every log row and every note, and `usage_logs.user_id` is `ON DELETE SET NULL`,
+so a deleted user's history joins the ownerless notes rather than disappearing.
+That is the honest reading — those rows genuinely are unattributed now — and it
+matches how the ownerless indexer passes are treated on `/admin/performance`.
+
+The per-user scope on top of that is the panel's usual one: an admin passes
+`user_id=None` and sees every row (grouped per owner, never merged); a regular
+user passes their id and sees only their own.
+
+## 2. "Not a result set" is a *broad* error match here, deliberately
+
+`/admin/performance` enumerates exactly the pre-body refusal markers and warns
+at length that a broad `params->>'error' IS NOT NULL` is wrong there. It is
+wrong there because a post-body refusal is still an expensive call and belongs
+in a latency percentile. Here the question is the opposite one: did this call
+produce a result set an operator can reason about? A row carrying *any* error
+marker did not — the body may have run and even done real database work, but
+it returned an error string, not results. So the filter is
+`pre_body_refusal_sql()` (imported, never re-written — one predicate, no drift)
+**plus** `params->>'error' IS NULL`.
+
+`find_related`'s two operational markers are the reason the second half exists.
+A missing or not-yet-embedded source note comes back with no neighbours, and
+without a marker it would land in the zero-result view as "the vault holds
+nothing near this note" — the one claim this page makes that an operator would
+act on, applied to a note the tool never got as far as looking at.
+
+## 3. The casts are guarded
+
+`/admin/performance` evaluates `(params->>'embed_ms')::double precision`
+unguarded, which makes those keys reserved: one row carrying a non-numeric
+value takes the page down with a 500 for the whole window, for every user,
+until it ages out. The same reservation is declared for these keys
+(`docs/architecture/usage-attribution.md`) *and* this module guards anyway —
+an integer pattern before the `::bigint`, a `jsonb_typeof(...) = 'array'`
+before the unnest. Two belts, because these keys are written on the busiest
+read path in the server and a bad row here would break a page nobody could
+then use to find the bad row.
+"""
+from __future__ import annotations
+
+from sqlalchemy import text
+
+from src.services.usage_stats import (
+    PRE_BODY_REFUSAL_BINDS,
+    WINDOWS,
+    pre_body_refusal_sql,
+)
+
+#: The two tools whose calls are grouped by their query text, in the order the
+#: page shows them.
+QUERY_TOOLS: tuple[str, ...] = ("keyword_search", "semantic_search")
+
+#: `find_related` takes a note, not a query, so it gets its own tables keyed by
+#: the source note. Kept separate from `QUERY_TOOLS` everywhere rather than
+#: folded in with a NULL query: "the query was empty" and "this tool has no
+#: query" are different rows on a page about what agents ask for.
+RELATED_TOOL = "find_related"
+
+#: The `params` key each tool is grouped by. Interpolated into SQL, so it is
+#: resolved through this map and never taken from a caller — `_group_key`
+#: refuses anything else.
+GROUP_KEYS: dict[str, str] = {
+    "keyword_search": "query",
+    "semantic_search": "query",
+    RELATED_TOOL: "source_path",
+}
+
+#: Rows per table. A page, not an export: the tail of a long-tail query
+#: distribution is not something an operator reads down.
+TABLE_LIMIT = 20
+
+#: Rows in each coverage list. Longer than a query table because the
+#: never-retrieved list is the one an operator scans for a note they expected
+#: to see, and it carries its own total so the cap is never mistaken for the
+#: answer.
+COVERAGE_LIMIT = 50
+
+#: What `timing.record_results` logs per call, mirrored for the page's copy.
+#: The ranking is named after this number — "top-logged retrievals" — because
+#: it bounds what the log can see, not what the tools returned.
+LOGGED_RESULTS_PER_CALL = 10
+
+_WINDOW_CLAUSE = "ul.created_at >= now() - (:window_seconds * INTERVAL '1 second')"
+
+#: `result_count` as a number, or NULL when the row does not carry one that can
+#: be read as an integer. Bounded to nine digits so the cast cannot overflow on
+#: a hand-written row; see the module docstring on why this is guarded at all.
+_RESULT_COUNT = (
+    "CASE WHEN ul.params->>'result_count' ~ '^-?[0-9]{1,9}$' "
+    "THEN (ul.params->>'result_count')::bigint END"
+)
+
+#: The unnest guard. `jsonb_array_elements_text` raises on a non-array, which
+#: on this path would be a 500 for the whole window rather than one missing row.
+_PATHS_ARRAY = "jsonb_typeof(ul.params->'result_paths') = 'array'"
+
+
+def analysable_sql(alias: str = "ul", params_column: str = "params") -> str:
+    """A boolean fragment: this row carries a result set worth aggregating.
+
+    The imported refusal predicate (never a second copy of it) plus "no error
+    marker of any kind". See the module docstring for why the broad error match
+    that would be wrong on `/admin/performance` is right here.
+
+    Never NULL: `params` is nullable and `->>` on a missing key yields NULL, so
+    the error half is `COALESCE`d the way the imported predicate's halves are.
+    """
+    params = f"{alias}.{params_column}"
+    return (
+        f"(NOT {pre_body_refusal_sql(alias, params_column)}"
+        f" AND COALESCE({params}->>'error' IS NULL, true))"
+    )
+
+
+def _group_key(tool: str) -> str:
+    """The `params` key `tool` is grouped by, or a refusal.
+
+    This value is interpolated into SQL. It is resolved from `GROUP_KEYS` and
+    nothing else, so a caller cannot reach the string that gets interpolated —
+    the same stance `usage_stats` takes with its marker binds.
+    """
+    try:
+        return GROUP_KEYS[tool]
+    except KeyError:
+        raise ValueError(f"no analytics grouping is defined for tool {tool!r}")
+
+
+def _scope(user_id: int | None, alias: str = "ul", column: str = "user_id") -> str:
+    """The owner filter: admins (`None`) see every row, a user only their own.
+
+    Identical in shape to `usage_stats._scope`; it takes an alias because this
+    module also scopes `notes_metadata` for the coverage lists.
+    """
+    return "" if user_id is None else f" AND {alias}.{column} = :uid"
+
+
+def _params(window: str, user_id: int | None, **extra) -> dict:
+    params: dict = {"window_seconds": WINDOWS[window], **PRE_BODY_REFUSAL_BINDS}
+    if user_id is not None:
+        params["uid"] = user_id
+    params.update(extra)
+    return params
+
+
+async def _grouped(
+    session,
+    window: str,
+    user_id: int | None,
+    tool: str,
+    *,
+    zero_only: bool,
+    limit: int,
+) -> list[dict]:
+    """One table: calls per (owner, group key) for `tool` in `window`.
+
+    `zero_only` switches the ordering and adds the `zero_calls > 0` filter, so
+    the "most frequent" and "came back empty" tables are the same aggregation
+    read two ways rather than two hand-written queries that agree until one of
+    them is edited.
+    """
+    key = _group_key(tool)
+    having = " WHERE g.zero_calls > 0" if zero_only else ""
+    order = (
+        "g.zero_calls DESC, g.calls DESC, g.grp ASC"
+        if zero_only
+        else "g.calls DESC, g.grp ASC"
+    )
+    sql = f"""
+        WITH calls AS (
+            SELECT
+                ul.user_id                 AS user_id,
+                ul.params->>'{key}'        AS grp,
+                {_RESULT_COUNT}            AS result_count
+            FROM usage_logs ul
+            WHERE {_WINDOW_CLAUSE}{_scope(user_id)}
+              AND ul.tool = :tool
+              AND {analysable_sql()}
+              AND ul.params->>'{key}' IS NOT NULL
+        ),
+        grouped AS (
+            SELECT
+                user_id,
+                grp,
+                count(*)                                        AS calls,
+                count(result_count)                             AS measured,
+                avg(result_count)                               AS mean_results,
+                count(*) FILTER (WHERE result_count = 0)        AS zero_calls
+            FROM calls
+            GROUP BY user_id, grp
+        )
+        SELECT g.user_id, g.grp, g.calls, g.measured, g.mean_results,
+               g.zero_calls, u.username AS owner
+        FROM grouped g
+        LEFT JOIN users u ON u.id = g.user_id
+        {having}
+        ORDER BY {order}
+        LIMIT :limit
+    """
+    rows = (
+        await session.execute(
+            text(sql), _params(window, user_id, tool=tool, limit=limit)
+        )
+    ).fetchall()
+    return [
+        {
+            "user_id": r.user_id,
+            "owner": r.owner,
+            "value": r.grp,
+            "calls": int(r.calls or 0),
+            "zero_calls": int(r.zero_calls or 0),
+            # NULL when no row in the group carried a readable `result_count`
+            # — every call predates the telemetry. Rendered as "—", never as a
+            # zero, which would read as "this query finds nothing".
+            "mean_results": (
+                None if r.mean_results is None else round(float(r.mean_results), 1)
+            ),
+            "measured": int(r.measured or 0),
+        }
+        for r in rows
+    ]
+
+
+async def top_queries(
+    session, window: str, user_id: int | None, tool: str, limit: int = TABLE_LIMIT
+) -> list[dict]:
+    """The window's most frequent calls for `tool`, with their mean result count."""
+    return await _grouped(
+        session, window, user_id, tool, zero_only=False, limit=limit
+    )
+
+
+async def zero_result_queries(
+    session, window: str, user_id: int | None, tool: str, limit: int = TABLE_LIMIT
+) -> list[dict]:
+    """The window's calls for `tool` that came back empty, most-empty first.
+
+    Every row here is a search that ran to completion and found nothing: the
+    error-marked rows — including `find_related`'s missing and not-yet-embedded
+    sources — are already excluded by `analysable_sql`.
+    """
+    return await _grouped(
+        session, window, user_id, tool, zero_only=True, limit=limit
+    )
+
+
+# --- Retrieval coverage ---------------------------------------------------
+#
+# Both lists are bounded by what the log holds, which is the first
+# `LOGGED_RESULTS_PER_CALL` paths of each call. The ranking is named for that
+# ("top-logged retrievals") and the never-retrieved list is an upper bound, and
+# the page states the caveat beside both — a coverage figure read as exact is
+# worse than no coverage figure, because it is the kind of number an operator
+# would delete notes on.
+
+_LOGGED_PATHS_CTE = f"""
+    SELECT ul.user_id AS user_id, p.path AS path
+    FROM usage_logs ul
+    CROSS JOIN LATERAL
+        jsonb_array_elements_text(ul.params->'result_paths') AS p(path)
+    WHERE {{window}}{{scope}}
+      AND {analysable_sql()}
+      AND {_PATHS_ARRAY}
+"""
+
+
+async def top_logged_retrievals(
+    session, window: str, user_id: int | None, limit: int = COVERAGE_LIMIT
+) -> list[dict]:
+    """Notes ranked by appearances in the window's logged result lists.
+
+    `indexed` is resolved through the `(user_id, path)` identity, not the path
+    alone: a retrieved path with no matching row for that owner is a note that
+    has since been renamed or deleted, and saying so is the point of showing it.
+    """
+    logged = _LOGGED_PATHS_CTE.format(window=_WINDOW_CLAUSE, scope=_scope(user_id))
+    sql = f"""
+        WITH logged AS ({logged})
+        SELECT
+            l.user_id,
+            l.path,
+            count(*) AS appearances,
+            EXISTS (
+                SELECT 1 FROM notes_metadata nm
+                WHERE nm.file_path = l.path
+                  AND nm.user_id IS NOT DISTINCT FROM l.user_id
+            ) AS indexed,
+            (SELECT u.username FROM users u WHERE u.id = l.user_id) AS owner
+        FROM logged l
+        GROUP BY l.user_id, l.path
+        ORDER BY count(*) DESC, l.path ASC
+        LIMIT :limit
+    """
+    rows = (
+        await session.execute(text(sql), _params(window, user_id, limit=limit))
+    ).fetchall()
+    return [
+        {
+            "user_id": r.user_id,
+            "owner": r.owner,
+            "path": r.path,
+            "appearances": int(r.appearances or 0),
+            "indexed": bool(r.indexed),
+        }
+        for r in rows
+    ]
+
+
+async def never_retrieved(
+    session, window: str, user_id: int | None, limit: int = COVERAGE_LIMIT
+) -> tuple[list[dict], int]:
+    """Indexed notes absent from every logged result in the window.
+
+    Returns `(rows, total)`; `total` is the full count, so the page can say
+    "50 of 1,204" rather than letting the cap read as the answer.
+
+    Newest-modified first: a note nobody's search has surfaced since it was
+    last edited is the interesting end of this list, and alphabetical order
+    would bury it under a folder name.
+    """
+    logged = _LOGGED_PATHS_CTE.format(window=_WINDOW_CLAUSE, scope=_scope(user_id))
+    note_scope = _scope(user_id, alias="nm")
+    sql = f"""
+        WITH logged AS (SELECT DISTINCT user_id, path FROM ({logged}) AS l)
+        SELECT
+            nm.user_id,
+            nm.file_path AS path,
+            nm.title     AS title,
+            nm.modified_at,
+            (SELECT u.username FROM users u WHERE u.id = nm.user_id) AS owner,
+            count(*) OVER () AS total
+        FROM notes_metadata nm
+        WHERE true{note_scope}
+          AND NOT EXISTS (
+              SELECT 1 FROM logged l
+              WHERE l.path = nm.file_path
+                AND l.user_id IS NOT DISTINCT FROM nm.user_id
+          )
+        ORDER BY nm.modified_at DESC NULLS LAST, nm.file_path ASC
+        LIMIT :limit
+    """
+    rows = (
+        await session.execute(text(sql), _params(window, user_id, limit=limit))
+    ).fetchall()
+    total = int(rows[0].total) if rows else 0
+    return [
+        {
+            "user_id": r.user_id,
+            "owner": r.owner,
+            "path": r.path,
+            "title": r.title,
+            "modified_at": r.modified_at.isoformat() if r.modified_at else None,
+        }
+        for r in rows
+    ], total

--- a/src/services/timing.py
+++ b/src/services/timing.py
@@ -1,4 +1,4 @@
-"""Call-scoped holder for per-phase search timings.
+"""Call-scoped holder for per-phase search timings and result telemetry.
 
 `semantic_search` and `find_related` measure their own phases (`embed_ms`,
 `db_ms`) and whether they had to fall back to an exact scan, but the thing that
@@ -19,9 +19,36 @@ services cannot import from `tools` at module scope. Ownership is still
 
 A `ContextVar` is per-task, and each MCP tool call runs in its own task, so
 concurrent calls cannot see each other's phases.
+
+## The result-telemetry contract (#161)
+
+The same holder carries what a search *returned* — `result_count`,
+`result_paths`, and `find_related`'s `source_path` — because
+`/admin/search-analytics` needs to know which queries came back empty and which
+notes retrieval never surfaces, and nothing else in the log records it.
+
+**The size bound is enforced here, at the record site, and it has to be.**
+`_tracked` builds its logged params as `_truncate_params(named args)` and *then*
+`update()`s the holder over the top, so anything recorded here reaches
+`usage_logs.params` untouched by the generic 200-character truncation. There is
+no backstop downstream: a 500-result search whose paths were merged verbatim
+would write a params blob orders of magnitude larger than every other row in the
+table. Hence `MAX_RESULT_PATHS` and `MAX_RESULT_PATHS_BYTES` below, applied by
+`record_results` itself.
+
+The keys are **reserved and typed**, for the same reason `embed_ms` and
+`db_ms` are (see `docs/architecture/usage-attribution.md`): the analytics page
+casts and unnests them. `result_count` is an int, `result_paths` a list of
+strings, `source_path` a string. A writer that wants to record something else
+about a result set uses a different key. The page guards its casts anyway —
+a bad row must not be able to take a whole window's page down — but the
+contract is what keeps the numbers meaningful.
 """
 from __future__ import annotations
 
+import hashlib
+import json
+from collections.abc import Iterable
 from contextvars import ContextVar, Token
 
 _phase_timing: ContextVar[dict | None] = ContextVar("_phase_timing", default=None)
@@ -60,3 +87,88 @@ def add_ms(key: str, elapsed_seconds: float) -> None:
     if holder is None:
         return
     holder[key] = int(holder.get(key, 0)) + max(0, int(elapsed_seconds * 1000))
+
+
+# --- Result telemetry (#161) ----------------------------------------------
+
+#: How many of a call's returned paths are logged. The ranking on
+#: `/admin/search-analytics` is named after this number ("top-logged
+#: retrievals") because it is a bound on what the log can see, not a fact about
+#: what the tool returned.
+MAX_RESULT_PATHS = 10
+
+#: The paths value's total budget, in bytes of its UTF-8 JSON encoding. Paths
+#: are dropped **from the end** — the head of a ranked result list is the part
+#: worth keeping, and dropping from the end keeps `result_paths` a prefix of
+#: what the tool returned rather than an arbitrary subset.
+MAX_RESULT_PATHS_BYTES = 2048
+
+#: Above this many bytes, `find_related`'s source is recorded as a digest.
+#: A path this long is pathological, but the grouping key on the analytics page
+#: must stay bounded *and* non-colliding: the tool's named `path` param is
+#: truncated at 200 characters, so two distinct long paths collapse onto one
+#: row there. That is exactly the mistake `source_path` exists to avoid.
+MAX_SOURCE_PATH_BYTES = 1024
+
+
+def _json_bytes(value) -> int:
+    """The size of `value` as it will be stored, in bytes.
+
+    Measured on the JSON encoding rather than on the paths' own bytes, so the
+    budget covers the quoting and separators too: whichever way "the paths
+    value" is read, the recorded list is within 2048 bytes. `ensure_ascii` is
+    off so a non-ASCII path is measured in UTF-8, the encoding the column
+    actually stores, and not in `\\uXXXX` escapes.
+    """
+    return len(json.dumps(value, ensure_ascii=False).encode("utf-8"))
+
+
+def fit_result_paths(paths: Iterable[str]) -> list[str]:
+    """The logged prefix of `paths` under both bounds. Pure, for testing."""
+    kept: list[str] = []
+    for path in list(paths)[:MAX_RESULT_PATHS]:
+        candidate = kept + [str(path)]
+        if _json_bytes(candidate) > MAX_RESULT_PATHS_BYTES:
+            # Dropping from the end: everything after the first path that does
+            # not fit goes too, so the kept list stays a prefix.
+            break
+        kept = candidate
+    return kept
+
+
+def record_results(paths: Iterable[str]) -> None:
+    """Record a search's `result_count` and its bounded `result_paths`.
+
+    `result_count` is the **full** count of what the tool returned, not the
+    number of paths that fit the budget: it is the value the zero-result view
+    reads, and a count clipped to the logging cap would report a search that
+    found 40 notes as having found 10.
+
+    No-op outside a tracked call, like every other writer here.
+    """
+    holder = _phase_timing.get()
+    if holder is None:
+        return
+    paths = list(paths)
+    holder["result_count"] = len(paths)
+    holder["result_paths"] = fit_result_paths(paths)
+
+
+def source_path_value(path: str) -> str:
+    """`find_related`'s grouping key: the path, or its digest when too long."""
+    # `surrogatepass` rather than a bare encode: an unpaired surrogate is
+    # already refused at admission (`argument_not_encodable`), so this is only
+    # about staying total — a telemetry helper must not be the thing that
+    # raises inside a tool that has already done its work.
+    encoded = path.encode("utf-8", "surrogatepass")
+    if len(encoded) <= MAX_SOURCE_PATH_BYTES:
+        return path
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def record_source_path(path: str) -> None:
+    """Record `find_related`'s source under the telemetry key `source_path`."""
+    holder = _phase_timing.get()
+    if holder is None:
+        return
+    holder["source_path"] = source_path_value(path)

--- a/tests/integration/test_issue_161_search_analytics_pg.py
+++ b/tests/integration/test_issue_161_search_analytics_pg.py
@@ -1,0 +1,644 @@
+"""Real-Postgres gate for the search analytics aggregates (#161).
+
+Everything asserted here *is* database behaviour and has no meaningful
+fake-session equivalent:
+
+* **Tenancy.** Two users with a note at the same path is the case the identity
+  rule exists for. Whether `(user_id, path)` with `IS NOT DISTINCT FROM` keeps
+  their analytics apart — and keeps the ownerless slice visible instead of
+  dropping it, which `=` would do silently — is a fact about NULL semantics,
+  not about a string in the SQL.
+* **The exclusions.** Whether a pre-body refusal, and whether a row carrying
+  `find_related`'s operational markers, stay out of the zero-result view is a
+  fact about JSONB operators. Getting it wrong is invisible: the page just
+  reports the operator's typos as gaps in the vault's memory.
+* **The guards.** A row with `result_count: "lots"` or `result_paths: "a.md"`
+  must cost one row, not the whole window's page.
+* **`jsonb_array_elements_text` over a window**, which is the coverage lists.
+
+Skipped unless `PGVECTOR_TEST_ADMIN_URL` names a throwaway Postgres *server*
+(the harness creates and drops its own database):
+
+    docker run --rm -d --name omcp-161 -e POSTGRES_PASSWORD=test \\
+        -p 55495:5432 pgvector/pgvector:pg16
+    PGVECTOR_TEST_ADMIN_URL=postgresql+asyncpg://postgres:test@localhost:55495/postgres \\
+        pytest -q tests/integration/test_issue_161_search_analytics_pg.py
+    docker rm -f omcp-161
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+import _harness
+from src.models.db import NoteMetadata, UsageLog, User
+from src.services.search_analytics import (
+    LOGGED_RESULTS_PER_CALL,
+    QUERY_TOOLS,
+    RELATED_TOOL,
+    never_retrieved,
+    top_logged_retrievals,
+    top_queries,
+    zero_result_queries,
+)
+
+DIM = 64
+
+pytestmark = [
+    pytest.mark.asyncio(loop_scope="module"),
+    _harness.requires_pgvector,
+]
+
+
+@pytest.fixture(scope="module")
+def migrated_url():
+    yield from _harness.throwaway_database("search_161", DIM)
+
+
+@pytest_asyncio.fixture(loop_scope="module", scope="module")
+async def sessionmaker(migrated_url):
+    engine = create_async_engine(migrated_url, poolclass=None)
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield maker
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture(loop_scope="module")
+async def clean(sessionmaker):
+    async def _wipe():
+        async with sessionmaker() as session:
+            await session.execute(delete(UsageLog))
+            await session.execute(delete(NoteMetadata))
+            await session.execute(delete(User))
+            await session.commit()
+
+    await _wipe()
+    yield sessionmaker
+    await _wipe()
+
+
+def _search(tool, *, query=None, source=None, count=None, paths=None,
+            error=None, over_quota=None, ago_minutes=1, user_id=None):
+    """One `usage_logs` row shaped like the telemetry writes them."""
+    params: dict = {}
+    if query is not None:
+        params["query"] = query
+    if source is not None:
+        params["source_path"] = source
+    if count is not None:
+        params["result_count"] = count
+    if paths is not None:
+        params["result_paths"] = paths
+    if error is not None:
+        params["error"] = error
+    if over_quota is not None:
+        params["over_quota"] = over_quota
+    return UsageLog(
+        tool=tool,
+        params=params,
+        duration_ms=10,
+        response_size=100,
+        user_id=user_id,
+        created_at=datetime.now(timezone.utc) - timedelta(minutes=ago_minutes),
+    )
+
+
+def _note(path, *, user_id=None, title=None, ago_days=1):
+    return NoteMetadata(
+        user_id=user_id,
+        file_path=path,
+        title=title or path,
+        content_hash="x" * 8,
+        modified_at=datetime.now(timezone.utc) - timedelta(days=ago_days),
+    )
+
+
+# --------------------------------------------------------------------------
+# 1. Query tables.
+# --------------------------------------------------------------------------
+
+
+async def test_top_and_zero_result_queries_per_tool(clean):
+    """The spec's scenario: top queries with call counts and mean result count,
+    and the zero-result queries, listed per query tool."""
+    async with clean() as session:
+        session.add_all([
+            _search("keyword_search", query="alpha", count=4,
+                    paths=["a.md", "b.md", "c.md", "d.md"]),
+            _search("keyword_search", query="alpha", count=2, paths=["a.md", "b.md"]),
+            _search("keyword_search", query="alpha", count=0, paths=[]),
+            _search("keyword_search", query="beta", count=1, paths=["b.md"]),
+            # A different tool's identical query must not join this one's rows.
+            _search("semantic_search", query="alpha", count=9, paths=["z.md"]),
+            _search("semantic_search", query="gamma", count=0, paths=[]),
+        ])
+        await session.commit()
+
+        keyword = await top_queries(session, "24h", None, "keyword_search")
+        semantic = await top_queries(session, "24h", None, "semantic_search")
+        keyword_zero = await zero_result_queries(
+            session, "24h", None, "keyword_search"
+        )
+
+    alpha = next(r for r in keyword if r["value"] == "alpha")
+    assert alpha["calls"] == 3
+    assert alpha["mean_results"] == pytest.approx(2.0)  # (4 + 2 + 0) / 3
+    assert alpha["zero_calls"] == 1
+    assert [r["value"] for r in keyword] == ["alpha", "beta"], "most frequent first"
+
+    assert {r["value"]: r["calls"] for r in semantic} == {"alpha": 1, "gamma": 1}
+    assert [(r["value"], r["zero_calls"]) for r in keyword_zero] == [("alpha", 1)]
+
+
+async def test_a_refused_call_is_not_a_zero_result(clean):
+    """A pre-body refusal has no result set at all. Counting it as a search
+    that found nothing would report a credential problem as a gap in the
+    vault."""
+    async with clean() as session:
+        session.add_all([
+            _search("keyword_search", query="alpha", count=0, paths=[]),
+            _search("keyword_search", query="alpha", error="no_vault_assigned"),
+            _search("keyword_search", query="alpha", error="argument_not_encodable"),
+            _search("keyword_search", query="alpha", over_quota=True, count=0),
+        ])
+        await session.commit()
+
+        rows = await top_queries(session, "24h", None, "keyword_search")
+        zero = await zero_result_queries(session, "24h", None, "keyword_search")
+
+    assert len(rows) == 1
+    assert rows[0]["calls"] == 1, f"three refusals leaked in: {rows[0]}"
+    assert zero[0]["zero_calls"] == 1
+
+
+async def test_an_over_quota_false_row_is_an_ordinary_search(clean):
+    """The #160 predicate reads the boolean, not the key's presence."""
+    async with clean() as session:
+        session.add(
+            _search("keyword_search", query="alpha", count=3,
+                    paths=["a.md"], over_quota=False)
+        )
+        await session.commit()
+        rows = await top_queries(session, "24h", None, "keyword_search")
+
+    assert rows[0]["calls"] == 1 and rows[0]["mean_results"] == 3.0
+
+
+async def test_windows_bound_the_aggregation(clean):
+    async with clean() as session:
+        session.add_all([
+            _search("keyword_search", query="alpha", count=1, paths=["a.md"],
+                    ago_minutes=30),
+            _search("keyword_search", query="alpha", count=1, paths=["a.md"],
+                    ago_minutes=60 * 72),
+            _search("keyword_search", query="alpha", count=1, paths=["a.md"],
+                    ago_minutes=60 * 24 * 20),
+        ])
+        await session.commit()
+
+        seen = {
+            window: (await top_queries(session, window, None, "keyword_search"))
+            for window in ("24h", "7d", "30d")
+        }
+
+    assert [seen[w][0]["calls"] for w in ("24h", "7d", "30d")] == [1, 2, 3]
+
+
+async def test_an_empty_window_is_an_empty_result_not_an_error(clean):
+    async with clean() as session:
+        for tool in (*QUERY_TOOLS, RELATED_TOOL):
+            assert await top_queries(session, "7d", None, tool) == []
+            assert await zero_result_queries(session, "7d", None, tool) == []
+        assert await top_logged_retrievals(session, "7d", None) == []
+        assert await never_retrieved(session, "7d", None) == ([], 0)
+
+
+async def test_a_row_predating_the_telemetry_counts_but_does_not_average(clean):
+    """Rows written before #161 carry a query and no `result_count`. They are
+    real calls and must appear; a missing count read as 0 would report a query
+    that works as one that finds nothing."""
+    async with clean() as session:
+        session.add_all([
+            _search("keyword_search", query="alpha"),
+            _search("keyword_search", query="alpha", count=6, paths=["a.md"]),
+            _search("keyword_search", query="legacy-only"),
+        ])
+        await session.commit()
+
+        rows = await top_queries(session, "24h", None, "keyword_search")
+        zero = await zero_result_queries(session, "24h", None, "keyword_search")
+
+    by_query = {r["value"]: r for r in rows}
+    assert by_query["alpha"]["calls"] == 2
+    assert by_query["alpha"]["measured"] == 1
+    assert by_query["alpha"]["mean_results"] == pytest.approx(6.0)
+    assert by_query["legacy-only"]["mean_results"] is None
+    assert zero == [], "an absent count is not a zero result"
+
+
+async def test_a_non_numeric_result_count_costs_one_row_not_the_page(clean):
+    """The guarded cast. Unguarded, this row is a 500 for the whole window —
+    for every user — until it ages out."""
+    async with clean() as session:
+        session.add_all([
+            _search("keyword_search", query="alpha", count="lots", paths=["a.md"]),
+            _search("keyword_search", query="alpha", count=2, paths=["a.md"]),
+        ])
+        await session.commit()
+
+        rows = await top_queries(session, "24h", None, "keyword_search")
+
+    assert rows[0]["calls"] == 2
+    assert rows[0]["measured"] == 1
+    assert rows[0]["mean_results"] == pytest.approx(2.0)
+
+
+# --------------------------------------------------------------------------
+# 2. find_related, grouped by source.
+# --------------------------------------------------------------------------
+
+
+async def test_find_related_groups_by_source_path(clean):
+    """The spec's scenario: five calls on one source, one of them empty."""
+    async with clean() as session:
+        session.add_all(
+            [
+                _search(RELATED_TOOL, source="Projects/Alpha.md", count=3,
+                        paths=["a.md", "b.md", "c.md"])
+                for _ in range(4)
+            ] + [
+                _search(RELATED_TOOL, source="Projects/Alpha.md", count=0, paths=[]),
+            ]
+        )
+        await session.commit()
+
+        rows = await top_queries(session, "24h", None, RELATED_TOOL)
+        zero = await zero_result_queries(session, "24h", None, RELATED_TOOL)
+
+    assert len(rows) == 1
+    assert rows[0]["value"] == "Projects/Alpha.md"
+    assert rows[0]["calls"] == 5
+    assert rows[0]["zero_calls"] == 1
+    assert [(r["value"], r["zero_calls"]) for r in zero] == [
+        ("Projects/Alpha.md", 1)
+    ]
+
+
+async def test_find_related_operational_failures_are_not_zero_results(clean):
+    """The distinction the change turns on, at the reading end.
+
+    A source note that is missing or not yet embedded produced no result set;
+    a source that exists, is embedded and has no neighbours did. Only the
+    second is a fact about what the vault holds.
+    """
+    from src.mcp_server import tools
+
+    async with clean() as session:
+        session.add_all([
+            _search(RELATED_TOOL, source="Gone.md", count=0,
+                    error=tools._RELATED_SOURCE_NOT_FOUND_MARKER),
+            _search(RELATED_TOOL, source="Fresh.md", count=0,
+                    error=tools._RELATED_SOURCE_NOT_EMBEDDED_MARKER),
+            _search(RELATED_TOOL, source="Lonely.md", count=0, paths=[]),
+        ])
+        await session.commit()
+
+        rows = await top_queries(session, "24h", None, RELATED_TOOL)
+        zero = await zero_result_queries(session, "24h", None, RELATED_TOOL)
+
+    assert [r["value"] for r in rows] == ["Lonely.md"]
+    assert [r["value"] for r in zero] == ["Lonely.md"]
+
+
+async def test_two_over_long_sources_stay_apart_as_digests(clean):
+    """Why the grouping key is `source_path` and not the named `path` param:
+    that one is truncated at 200 characters, so two distinct long paths would
+    collapse onto a single row and the page would attribute one note's calls to
+    another."""
+    from src.services.timing import source_path_value
+
+    long_a = "d" * 1100 + "/a.md"
+    long_b = "d" * 1100 + "/b.md"
+    digest_a, digest_b = source_path_value(long_a), source_path_value(long_b)
+    assert digest_a != digest_b and len(digest_a) == 64
+
+    async with clean() as session:
+        session.add_all([
+            _search(RELATED_TOOL, source=digest_a, count=1, paths=["x.md"]),
+            _search(RELATED_TOOL, source=digest_a, count=1, paths=["x.md"]),
+            _search(RELATED_TOOL, source=digest_b, count=0, paths=[]),
+        ])
+        await session.commit()
+
+        rows = await top_queries(session, "24h", None, RELATED_TOOL)
+
+    assert {r["value"]: r["calls"] for r in rows} == {digest_a: 2, digest_b: 1}
+
+
+# --------------------------------------------------------------------------
+# 3. Coverage.
+# --------------------------------------------------------------------------
+
+
+async def test_top_logged_retrievals_counts_appearances(clean):
+    async with clean() as session:
+        session.add_all([
+            _search("semantic_search", query="a", count=3,
+                    paths=["hub.md", "b.md", "c.md"]),
+            _search("semantic_search", query="b", count=2, paths=["hub.md", "b.md"]),
+            _search("keyword_search", query="c", count=1, paths=["hub.md"]),
+            # Excluded: no result set.
+            _search("semantic_search", query="d", error="no_vault_assigned",
+                    paths=["never.md"]),
+        ])
+        session.add_all([_note("hub.md"), _note("b.md")])
+        await session.commit()
+
+        rows = await top_logged_retrievals(session, "24h", None)
+
+    ranked = [(r["path"], r["appearances"]) for r in rows]
+    assert ranked[0] == ("hub.md", 3)
+    assert ("b.md", 2) in ranked
+    assert all(p != "never.md" for p, _ in ranked), (
+        "a refused call's params must not feed the coverage ranking"
+    )
+    # `c.md` was retrieved but is not in the index: renamed or deleted since.
+    by_path = {r["path"]: r for r in rows}
+    assert by_path["hub.md"]["indexed"] is True
+    assert by_path["c.md"]["indexed"] is False
+
+
+async def test_never_retrieved_lists_only_indexed_notes_absent_from_the_window(clean):
+    async with clean() as session:
+        session.add_all([
+            _note("seen.md", ago_days=5),
+            _note("unseen-new.md", ago_days=1),
+            _note("unseen-old.md", ago_days=30),
+        ])
+        session.add(_search("keyword_search", query="a", count=1, paths=["seen.md"]))
+        await session.commit()
+
+        rows, total = await never_retrieved(session, "24h", None)
+
+    assert [r["path"] for r in rows] == ["unseen-new.md", "unseen-old.md"], (
+        "newest-modified first — the interesting end of the list"
+    )
+    assert total == 2
+
+
+async def test_a_row_with_a_non_array_result_paths_costs_one_row(clean):
+    """`jsonb_array_elements_text` raises on a scalar. Unguarded that is a 500
+    for both coverage lists."""
+    async with clean() as session:
+        session.add_all([
+            _search("keyword_search", query="a", count=1, paths="a.md"),  # scalar
+            _search("keyword_search", query="b", count=1, paths=["a.md"]),
+        ])
+        session.add_all([_note("a.md"), _note("b.md")])
+        await session.commit()
+
+        rows = await top_logged_retrievals(session, "24h", None)
+        missing, total = await never_retrieved(session, "24h", None)
+
+    assert [(r["path"], r["appearances"]) for r in rows] == [("a.md", 1)]
+    assert [r["path"] for r in missing] == ["b.md"] and total == 1
+
+
+async def test_the_logging_cap_is_what_the_page_claims(clean):
+    """The ranking counts appearances *within the logged prefix*. A call that
+    returned forty notes contributes ten paths and a `result_count` of 40 —
+    which is precisely why the page labels the ranking and calls the
+    never-retrieved list an upper bound."""
+    from src.services.timing import fit_result_paths
+
+    returned = [f"n{i}.md" for i in range(40)]
+    logged = fit_result_paths(returned)
+    assert len(logged) == LOGGED_RESULTS_PER_CALL
+
+    async with clean() as session:
+        session.add(
+            _search("semantic_search", query="wide", count=len(returned), paths=logged)
+        )
+        session.add_all([_note(p) for p in returned])
+        await session.commit()
+
+        rows = await top_logged_retrievals(session, "24h", None)
+        missing, total = await never_retrieved(session, "24h", None)
+        top = await top_queries(session, "24h", None, "semantic_search")
+
+    assert len(rows) == LOGGED_RESULTS_PER_CALL
+    assert total == 30, "the notes below the logging cap read as never-retrieved"
+    assert {r["path"] for r in missing} == set(returned[LOGGED_RESULTS_PER_CALL:])
+    assert top[0]["mean_results"] == pytest.approx(40.0), (
+        "result_count is the full count, not the logged one"
+    )
+
+
+# --------------------------------------------------------------------------
+# 4. Tenancy: the identity rule, against two users sharing a path.
+# --------------------------------------------------------------------------
+
+
+async def test_two_users_sharing_a_path_are_never_merged(clean):
+    """The case `(user_id, path)` exists for. Both users have
+    `Daily/2026-08-29.md`; they are different notes, and a coverage list is a
+    list of note paths, so merging them would be one tenant reading the
+    other's vault."""
+    shared = "Daily/2026-08-29.md"
+
+    async with clean() as session:
+        alice = User(username="alice-161", password_hash="x")
+        bob = User(username="bob-161", password_hash="x")
+        session.add_all([alice, bob])
+        await session.flush()
+        a, b = alice.id, bob.id
+
+        session.add_all([
+            _note(shared, user_id=a),
+            _note("alice-only.md", user_id=a),
+            _note(shared, user_id=b),
+            _note("bob-only.md", user_id=b),
+        ])
+        session.add_all([
+            _search("keyword_search", query="daily", count=1, paths=[shared],
+                    user_id=a),
+            _search("keyword_search", query="daily", count=1, paths=[shared],
+                    user_id=a),
+            _search("keyword_search", query="daily", count=1, paths=[shared],
+                    user_id=b),
+        ])
+        await session.commit()
+
+        mine = await top_logged_retrievals(session, "24h", a)
+        mine_missing, mine_total = await never_retrieved(session, "24h", a)
+        mine_queries = await top_queries(session, "24h", a, "keyword_search")
+        everyone = await top_logged_retrievals(session, "24h", None)
+        all_queries = await top_queries(session, "24h", None, "keyword_search")
+
+    # Alice sees her own two appearances, not the three in the table.
+    assert [(r["path"], r["appearances"]) for r in mine] == [(shared, 2)]
+    assert [r["path"] for r in mine_missing] == ["alice-only.md"], (
+        "bob's notes must not appear in alice's never-retrieved list"
+    )
+    assert mine_total == 1
+    assert [(r["value"], r["calls"]) for r in mine_queries] == [("daily", 2)]
+
+    # The admin view keeps them as separate rows rather than one row of 3.
+    assert sorted((r["appearances"], r["owner"]) for r in everyone) == [
+        (1, "bob-161"), (2, "alice-161")
+    ]
+    assert sorted((r["calls"], r["owner"]) for r in all_queries) == [
+        (1, "bob-161"), (2, "alice-161")
+    ]
+
+
+async def test_the_ownerless_slice_is_not_dropped(clean):
+    """`IS NOT DISTINCT FROM`, not `=`. Single-user mode writes NULL on every
+    log row and every note; `usage_logs.user_id` is also ON DELETE SET NULL, so
+    a deleted user's history lands here. `=` would silently make every one of
+    those notes look never-retrieved."""
+    async with clean() as session:
+        session.add_all([_note("solo.md"), _note("unread.md")])
+        session.add(_search("keyword_search", query="q", count=1, paths=["solo.md"]))
+        await session.commit()
+
+        rows = await top_logged_retrievals(session, "24h", None)
+        missing, total = await never_retrieved(session, "24h", None)
+
+    assert [(r["path"], r["appearances"], r["indexed"]) for r in rows] == [
+        ("solo.md", 1, True)
+    ]
+    assert [r["path"] for r in missing] == ["unread.md"] and total == 1
+
+
+async def test_an_owned_search_does_not_match_an_ownerless_note(clean):
+    """The other half of NULL-safety: NULL is *its own* owner, not a wildcard.
+    A named user's retrieval must not mark an ownerless note as retrieved."""
+    async with clean() as session:
+        user = User(username="named-161", password_hash="x")
+        session.add(user)
+        await session.flush()
+        session.add(_note("shared-name.md", user_id=None))
+        session.add(
+            _search("keyword_search", query="q", count=1, paths=["shared-name.md"],
+                    user_id=user.id)
+        )
+        await session.commit()
+
+        rows = await top_logged_retrievals(session, "24h", None)
+        missing, _ = await never_retrieved(session, "24h", None)
+
+    assert [(r["path"], r["indexed"]) for r in rows] == [("shared-name.md", False)], (
+        "the retrieved path belongs to the named user, and no note of theirs "
+        "has it — the ownerless note with the same path is a different note"
+    )
+    assert [r["path"] for r in missing] == ["shared-name.md"]
+
+
+# --------------------------------------------------------------------------
+# 5. The page, end to end over a real database.
+# --------------------------------------------------------------------------
+
+
+async def test_all_three_windows_render_against_seeded_data(clean):
+    from jinja2 import (
+        ChainableUndefined,
+        ChoiceLoader,
+        DictLoader,
+        Environment,
+        FileSystemLoader,
+    )
+
+    from src.control_panel.routes import _label_group_value
+    from src.services.usage_stats import WINDOW_LABELS, WINDOWS
+
+    templates_dir = _harness.ROOT / "src" / "control_panel" / "templates"
+    env = Environment(
+        loader=ChoiceLoader([
+            DictLoader({
+                "base.html":
+                    "{% block title %}{% endblock %}{% block content %}{% endblock %}"
+            }),
+            FileSystemLoader(str(templates_dir)),
+        ]),
+        undefined=ChainableUndefined,
+        autoescape=True,
+    )
+
+    digest = "f" * 64
+    async with clean() as session:
+        session.add_all([
+            _search("keyword_search", query="alpha", count=2, paths=["a.md", "b.md"]),
+            _search("semantic_search", query="beta", count=0, paths=[],
+                    ago_minutes=60 * 40),
+            _search(RELATED_TOOL, source="Projects/Alpha.md", count=1, paths=["a.md"]),
+            _search(RELATED_TOOL, source=digest, count=0, paths=[],
+                    ago_minutes=60 * 24 * 12),
+        ])
+        session.add_all([_note("a.md"), _note("b.md"), _note("lonely.md")])
+        await session.commit()
+
+        for window in WINDOWS:
+            tables = []
+            for tool in QUERY_TOOLS:
+                tables.append({
+                    "tool": tool,
+                    "label": tool,
+                    "top": [
+                        dict(r, label=_label_group_value(tool, r["value"]))
+                        for r in await top_queries(session, window, None, tool)
+                    ],
+                    "zero": [
+                        dict(r, label=_label_group_value(tool, r["value"]))
+                        for r in await zero_result_queries(session, window, None, tool)
+                    ],
+                })
+            related = {
+                "tool": RELATED_TOOL,
+                "label": "Related notes",
+                "top": [
+                    dict(r, label=_label_group_value(RELATED_TOOL, r["value"]))
+                    for r in await top_queries(session, window, None, RELATED_TOOL)
+                ],
+                "zero": [
+                    dict(r, label=_label_group_value(RELATED_TOOL, r["value"]))
+                    for r in await zero_result_queries(
+                        session, window, None, RELATED_TOOL
+                    )
+                ],
+            }
+            retrievals = await top_logged_retrievals(session, window, None)
+            missing, missing_total = await never_retrieved(session, window, None)
+
+            html = env.get_template("search_analytics.html").render(
+                active="search-analytics",
+                window=window,
+                window_label=WINDOW_LABELS[window],
+                windows=[
+                    {"key": k, "label": k, "selected": k == window} for k in WINDOWS
+                ],
+                query_tables=tables,
+                related=related,
+                retrievals=retrievals,
+                never_retrieved=missing,
+                never_retrieved_total=missing_total,
+                logged_per_call=LOGGED_RESULTS_PER_CALL,
+                show_owner=False,
+                has_data=bool(retrievals),
+            )
+
+            assert "Top-logged retrievals" in html
+            assert WINDOW_LABELS[window] in html
+            assert html.count(
+                f"Only the first {LOGGED_RESULTS_PER_CALL} results of each call"
+            ) == 2
+            if window == "24h":
+                assert "alpha" in html and "a.md" in html
+                assert "lonely.md" in html, "never-retrieved renders"
+                assert "beta" not in html, "a 7d-only row is outside this window"
+            if window == "30d":
+                # The over-long source is shown as a digest, not as a note path.
+                assert "digest ffffffffffffffff" in html
+                assert digest not in html

--- a/tests/test_issue_161_result_telemetry.py
+++ b/tests/test_issue_161_result_telemetry.py
@@ -1,0 +1,486 @@
+"""Search result telemetry in `usage_logs.params` (#161).
+
+What `/admin/search-analytics` can say is exactly what this contract records,
+so the parts worth pinning are the ones that are silent when they break:
+
+* **The byte budget is enforced at the record site.** `_tracked` merges
+  `timing.current()` over its logged params *after* `_truncate_params` has run,
+  so nothing downstream bounds these keys. A regression here does not fail a
+  call — it writes a params blob orders of magnitude larger than every other
+  row in `usage_logs`.
+* **`result_count` is the full count**, not the number of paths that fit. The
+  zero-result view reads it, and a count clipped to the logging cap would
+  report a search that found forty notes as having found ten.
+* **`find_related`'s two operational failures carry distinct error markers.**
+  They used to return a plain string with no marker at all, which made "the
+  note you named does not exist" indistinguishable *in the log* from "the vault
+  holds nothing near this note" — and the second is the whole point of the
+  zero-result view.
+
+Fully offline; the fake session is the one `test_search_phase_timing.py` uses.
+"""
+
+import asyncio
+import os
+import tempfile
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+import src.mcp_server.tools as tools  # noqa: E402
+from src.services import timing  # noqa: E402
+from src.services.usage_stats import (  # noqa: E402
+    PRE_BODY_REFUSAL_ERROR_MARKERS,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+class _Result:
+    def __init__(self, rows=()):
+        self._rows = list(rows)
+
+    def fetchall(self):
+        return self._rows
+
+    def all(self):
+        return self._rows
+
+    def scalars(self):
+        return self
+
+    def scalar_one_or_none(self):
+        return self._rows[0] if self._rows else None
+
+
+class _Session:
+    def __init__(self, batches=()):
+        self._batches = list(batches)
+
+    async def execute(self, clause, *_a, **_k):
+        if str(clause).lstrip().upper().startswith("SET LOCAL"):
+            return _Result()
+        return _Result(self._batches.pop(0) if self._batches else [])
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return None
+
+
+class _FindRelatedSession(_Session):
+    """`find_related` reads the source note and its chunks before the vector
+    query; those two come off a preamble so a test can make either empty."""
+
+    def __init__(self, source, chunks, batches=()):
+        super().__init__(batches)
+        self._preamble = [[source] if source else [], chunks]
+
+    async def execute(self, clause, *_a, **_k):
+        if not str(clause).lstrip().upper().startswith("SET LOCAL") and self._preamble:
+            return _Result(self._preamble.pop(0))
+        return await super().execute(clause, *_a, **_k)
+
+
+class _Note:
+    def __init__(self, note_id=1, path="a.md"):
+        self.id = note_id
+        self.file_path = path
+        self.title = "a"
+        self.tags = []
+
+
+def _keyword_row(path):
+    return (_Note(1, path), 0.5)
+
+
+def _semantic_row(note_id, path):
+    chunk = type("C", (), {
+        "note_id": note_id, "chunk_index": 0, "embedding": [1.0, 0.0, 0.0],
+        "chunk_text": "x",
+    })()
+    return (chunk, _Note(note_id, path), 0.1)
+
+
+def _related_row(note_id, path, distance=0.1):
+    return type("R", (), {
+        "note_id": note_id, "file_path": path, "title": path, "tags": [],
+        "chunk_text": "x", "distance": distance,
+    })()
+
+
+class _Captured:
+    def __init__(self):
+        self.rows: list[tuple[str, dict, int]] = []
+
+    async def __call__(self, tool, params, duration_ms, response_size):
+        self.rows.append((tool, params, duration_ms))
+
+    def params_for(self, tool):
+        return next(p for t, p, _ in self.rows if t == tool)
+
+
+@pytest.fixture
+def captured(monkeypatch):
+    cap = _Captured()
+    monkeypatch.setattr(tools, "_log_usage", cap)
+    return cap
+
+
+@pytest.fixture(autouse=True)
+def _fake_embedding(monkeypatch):
+    async def _fake(_text):
+        return [1.0, 0.0, 0.0]
+
+    monkeypatch.setattr("src.services.embeddings.get_embedding", _fake)
+
+
+@pytest.fixture(autouse=True)
+def _no_tsquery(monkeypatch):
+    monkeypatch.setattr("src.services.search.combined_tsquery", lambda _q: "tsq")
+
+
+# --------------------------------------------------------------------------- #
+# 1. The pure budget helper.
+# --------------------------------------------------------------------------- #
+def test_at_most_ten_paths_are_kept():
+    paths = [f"n{i}.md" for i in range(40)]
+    assert timing.fit_result_paths(paths) == paths[:10]
+
+
+def test_the_byte_budget_drops_from_the_end_and_keeps_a_prefix():
+    """Ten paths that are individually fine and collectively are not.
+
+    The kept list must be a *prefix* — the head of a ranked result set is the
+    part worth having — and it must fit the budget with the JSON quoting
+    counted, because that is what the column stores.
+    """
+    paths = [f"{'d' * 300}/{i}.md" for i in range(10)]
+    kept = timing.fit_result_paths(paths)
+
+    assert kept == paths[:len(kept)], "the kept paths must be a prefix"
+    assert 0 < len(kept) < 10, f"the budget must have bitten; kept {len(kept)}"
+    assert timing._json_bytes(kept) <= timing.MAX_RESULT_PATHS_BYTES
+    assert timing._json_bytes(paths[:len(kept) + 1]) > timing.MAX_RESULT_PATHS_BYTES, (
+        "one more path would have fit — the budget is being applied too early"
+    )
+
+
+def test_a_single_path_over_the_whole_budget_is_dropped_rather_than_cut():
+    """A truncated path is a path to a note that does not exist. Dropping it
+    leaves `result_paths` a shorter but *true* prefix; cutting it would put a
+    fabricated path into the coverage ranking."""
+    kept = timing.fit_result_paths(["x" * 4000 + ".md", "b.md"])
+    assert kept == []
+
+
+def test_non_ascii_paths_are_measured_in_utf8():
+    """The column stores UTF-8. Measuring `\\uXXXX` escapes would over-count by
+    a factor of three and silently drop paths that fit."""
+    # ["é"] -> [ " <2 bytes> " ] = 6, not the 10 an escaped é would cost.
+    assert timing._json_bytes(["é"]) == 6
+    # 700 two-byte characters: 1,404 bytes of UTF-8 and inside the budget, but
+    # 4,206 bytes of `\uXXXX` escapes and outside it.
+    paths = ["é" * 700 + ".md"]
+    assert timing.fit_result_paths(paths) == paths
+
+
+# --------------------------------------------------------------------------- #
+# 2. record_results / record_source_path
+# --------------------------------------------------------------------------- #
+def test_the_helpers_are_no_ops_without_a_holder():
+    assert timing.current() is None
+    timing.record_results(["a.md"])
+    timing.record_source_path("a.md")
+    assert timing.current() is None
+
+
+def test_result_count_is_the_full_count_not_the_logged_one():
+    token = timing.begin()
+    try:
+        timing.record_results([f"n{i}.md" for i in range(40)])
+        holder = timing.current()
+    finally:
+        timing.clear(token)
+
+    assert holder["result_count"] == 40
+    assert len(holder["result_paths"]) == 10
+
+
+def test_source_path_is_the_path_when_it_fits():
+    token = timing.begin()
+    try:
+        timing.record_source_path("Projects/Alpha.md")
+        assert timing.current()["source_path"] == "Projects/Alpha.md"
+    finally:
+        timing.clear(token)
+
+
+def test_source_path_falls_back_to_a_sha256_digest_when_it_does_not():
+    """Two distinct over-long paths must not collapse onto one analytics row —
+    which is exactly what the truncated `path` param would do."""
+    import hashlib
+
+    long_a = "d" * 1100 + "/a.md"
+    long_b = "d" * 1100 + "/b.md"
+    assert len(long_a.encode()) > timing.MAX_SOURCE_PATH_BYTES
+
+    values = []
+    for path in (long_a, long_b):
+        token = timing.begin()
+        try:
+            timing.record_source_path(path)
+            values.append(timing.current()["source_path"])
+        finally:
+            timing.clear(token)
+
+    assert values[0] != values[1], "the digest must keep the grouping non-colliding"
+    assert values[0] == hashlib.sha256(long_a.encode()).hexdigest()
+    assert all(len(v) == 64 and set(v) <= set("0123456789abcdef") for v in values)
+
+
+def test_a_path_exactly_on_the_bound_is_recorded_whole():
+    path = "x" * timing.MAX_SOURCE_PATH_BYTES
+    token = timing.begin()
+    try:
+        timing.record_source_path(path)
+        assert timing.current()["source_path"] == path
+    finally:
+        timing.clear(token)
+
+
+# --------------------------------------------------------------------------- #
+# 3. The three tools, end to end through `_tracked`.
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_keyword_search_logs_count_and_paths(monkeypatch, captured):
+    rows = [_keyword_row(f"n{i}.md") for i in range(4)]
+    monkeypatch.setattr(tools, "async_session", lambda: _Session([rows]))
+
+    await tools.search_notes_impl("needle")
+
+    params = captured.params_for("keyword_search")
+    assert params["result_count"] == 4
+    assert params["result_paths"] == ["n0.md", "n1.md", "n2.md", "n3.md"]
+    # The existing param keys are untouched.
+    assert params["query"] == "needle"
+    assert "error" not in params
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_logs_count_and_paths(monkeypatch, captured):
+    """The spec's scenario: four notes returned, four paths and a count of 4."""
+    rows = [_semantic_row(i, f"n{i}.md") for i in range(4)]
+    monkeypatch.setattr(tools, "async_session", lambda: _Session([rows]))
+
+    await tools.semantic_search_impl("needle", limit=5)
+
+    params = captured.params_for("semantic_search")
+    assert params["result_count"] == 4
+    assert params["result_paths"] == ["n0.md", "n1.md", "n2.md", "n3.md"]
+    assert "error" not in params
+
+
+@pytest.mark.asyncio
+async def test_the_budget_reaches_usage_logs_untruncated_by_the_wrapper(
+    monkeypatch, captured
+):
+    """The whole reason the budget lives at the record site.
+
+    `_tracked` truncates *named* params at 200 characters and then merges the
+    timing holder over the top, so `result_paths` never meets that truncation.
+    Fifty long results must therefore arrive already bounded.
+    """
+    rows = [_keyword_row(f"{'d' * 300}/{i}.md") for i in range(50)]
+    monkeypatch.setattr(tools, "async_session", lambda: _Session([rows]))
+
+    await tools.search_notes_impl("needle")
+
+    params = captured.params_for("keyword_search")
+    assert params["result_count"] == 50, "the count is not clipped by the budget"
+    assert len(params["result_paths"]) < 10
+    assert timing._json_bytes(params["result_paths"]) <= timing.MAX_RESULT_PATHS_BYTES
+    # And nothing shortened the individual paths: a cut path is a path to a
+    # note that does not exist.
+    assert all(p in [r[0].file_path for r in rows] for p in params["result_paths"])
+
+
+@pytest.mark.asyncio
+async def test_a_zero_result_search_logs_zero_and_no_marker(monkeypatch, captured):
+    monkeypatch.setattr(tools, "async_session", lambda: _Session([[], []]))
+
+    await tools.search_notes_impl("nothing-matches-this")
+    await tools.semantic_search_impl("nothing-matches-this")
+
+    for tool in ("keyword_search", "semantic_search"):
+        params = captured.params_for(tool)
+        assert params["result_count"] == 0
+        assert params["result_paths"] == []
+        assert "error" not in params, f"{tool} logged a marker for a real zero-result"
+
+
+# --------------------------------------------------------------------------- #
+# 4. find_related: the three ways a call comes back with nothing.
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_find_related_logs_source_path_count_and_paths(monkeypatch, captured):
+    rows = [_related_row(2, "b.md", 0.1), _related_row(3, "c.md", 0.2)]
+    monkeypatch.setattr(
+        tools, "async_session",
+        lambda: _FindRelatedSession(_Note(), [[1.0, 0.0, 0.0]], [rows]),
+    )
+
+    await tools.find_related_impl("a.md", limit=5)
+
+    params = captured.params_for("find_related")
+    assert params["source_path"] == "a.md"
+    assert params["result_count"] == 2
+    assert params["result_paths"] == ["b.md", "c.md"]
+    assert "error" not in params
+
+
+@pytest.mark.asyncio
+async def test_find_related_missing_source_is_marked_not_a_zero_result(
+    monkeypatch, captured
+):
+    monkeypatch.setattr(
+        tools, "async_session", lambda: _FindRelatedSession(None, [])
+    )
+
+    out = await tools.find_related_impl("gone.md")
+
+    assert "Note not found" in out
+    params = captured.params_for("find_related")
+    assert params["error"] == tools._RELATED_SOURCE_NOT_FOUND_MARKER
+    assert params["source_path"] == "gone.md", (
+        "a failure that cannot be attributed to a note is not actionable"
+    )
+    assert params["result_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_find_related_unembedded_source_is_marked_distinctly(
+    monkeypatch, captured
+):
+    monkeypatch.setattr(
+        tools, "async_session", lambda: _FindRelatedSession(_Note(), [])
+    )
+
+    out = await tools.find_related_impl("a.md")
+
+    assert "has not been embedded yet" in out
+    params = captured.params_for("find_related")
+    assert params["error"] == tools._RELATED_SOURCE_NOT_EMBEDDED_MARKER
+    assert params["result_count"] == 0
+    # The pre-existing phase timing is untouched by the new keys.
+    assert "db_ms" in params
+
+
+@pytest.mark.asyncio
+async def test_find_related_on_a_lonely_note_is_a_true_zero_result(
+    monkeypatch, captured
+):
+    """The distinction the whole change turns on. The source exists, it is
+    embedded, the exact fallback has already re-run the query, and the vault
+    holds nothing near it: that is memory the vault was asked for and does not
+    have, and it must reach the zero-result view unmarked."""
+    monkeypatch.setattr(
+        tools, "async_session",
+        lambda: _FindRelatedSession(_Note(), [[1.0, 0.0, 0.0]], [[], []]),
+    )
+
+    out = await tools.find_related_impl("a.md")
+
+    assert "No related notes" in out
+    params = captured.params_for("find_related")
+    assert params["result_count"] == 0
+    assert params["result_paths"] == []
+    assert "error" not in params, "a lonely note is not an operational failure"
+    assert params["exact_fallback"] is True, (
+        "the zero-result claim is only honest after the exact re-run"
+    )
+
+
+def test_the_three_find_related_outcomes_are_told_apart_by_their_markers():
+    """One value per side of the body/no-body line, and no sharing.
+
+    `vault_anchor_lost_at_publish` exists because that rule was broken once:
+    a post-body refusal filed under a pre-body marker vanished from every
+    latency percentile. These two are post-body — the body ran and queried the
+    database — so they must not appear in the pre-body predicate.
+    """
+    markers = {
+        tools._RELATED_SOURCE_NOT_FOUND_MARKER,
+        tools._RELATED_SOURCE_NOT_EMBEDDED_MARKER,
+    }
+    assert len(markers) == 2, "the two failures must be distinguishable"
+    assert not markers & set(PRE_BODY_REFUSAL_ERROR_MARKERS), (
+        "these bodies ran; enumerating them as pre-body refusals would drop "
+        "them out of the performance page's percentiles"
+    )
+    assert not markers & {
+        tools._NO_VAULT_MARKER,
+        tools._UNENCODABLE_ARG_MARKER,
+        tools._VAULT_REASSIGNED_MARKER,
+        tools._CONFIRMATION_UNAVAILABLE_MARKER,
+        tools._ANCHOR_LOST_AT_PUBLISH_MARKER,
+    }
+
+
+@pytest.mark.asyncio
+async def test_result_telemetry_does_not_leak_between_calls(monkeypatch, captured):
+    """A ContextVar per call, as with the phase timings: a search that returned
+    nothing must not inherit the previous call's paths and report them as its
+    own retrievals."""
+    rows = [_keyword_row("n0.md")]
+    monkeypatch.setattr(tools, "async_session", lambda: _Session([rows]))
+    await tools.search_notes_impl("first")
+
+    monkeypatch.setattr(tools, "async_session", lambda: _Session([[]]))
+    await tools.search_notes_impl("second")
+
+    first, second = [p for t, p, _ in captured.rows if t == "keyword_search"]
+    assert first["result_paths"] == ["n0.md"]
+    assert second["result_count"] == 0 and second["result_paths"] == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_searches_keep_their_own_results(monkeypatch, captured):
+    class _SlowSession(_Session):
+        async def execute(self, clause, *_a, **_k):
+            await asyncio.sleep(0.01)
+            return await super().execute(clause, *_a, **_k)
+
+    sessions = iter([
+        _SlowSession([[_keyword_row("one.md")]]),
+        _SlowSession([[_keyword_row("two.md"), _keyword_row("three.md")]]),
+    ])
+    monkeypatch.setattr(tools, "async_session", lambda: next(sessions))
+
+    await asyncio.gather(
+        tools.search_notes_impl("one"),
+        tools.search_notes_impl("two"),
+    )
+
+    by_query = {p["query"]: p for _, p, _ in captured.rows}
+    assert by_query["one"]["result_paths"] == ["one.md"]
+    assert by_query["two"]["result_paths"] == ["two.md", "three.md"]
+
+
+@pytest.mark.asyncio
+async def test_a_direct_service_call_outside_a_tracked_tool_records_nothing():
+    """The panel and the benchmarks call the services directly. With no holder
+    installed every telemetry write must be a silent no-op."""
+    from src.services.embeddings import semantic_search
+    from src.services.search import full_text_search
+
+    assert timing.current() is None
+    assert await semantic_search(_Session([[]]), "needle", limit=5) == []
+    assert await full_text_search(_Session([[]]), "needle") == []
+    assert timing.current() is None

--- a/tests/test_issue_161_search_analytics.py
+++ b/tests/test_issue_161_search_analytics.py
@@ -1,0 +1,342 @@
+"""The search-analytics page's contract, offline (#161).
+
+What a real database has to answer — do the aggregates come out right — is
+`tests/integration/test_issue_161_search_analytics_pg.py`. What is pinned here
+is the shape of the queries and the page, because these are the properties that
+break silently:
+
+* **Every grouping and every coverage join keys on `(user_id, path)`, matched
+  `IS NOT DISTINCT FROM`.** Dropping the owner would merge two tenants'
+  analytics into one row — and a coverage list *is* a list of note paths, so
+  that is one tenant reading another's vault. Using `=` would silently drop
+  every ownerless row, which in single-user mode is all of them.
+* **The refusal predicate is imported, never re-typed.** A second copy agrees
+  with the first until somebody adds a marker to one of them.
+* **The casts are guarded.** An unguarded `::bigint` or `jsonb_array_elements`
+  on a bad row is a 500 for the whole window, for every user, until it ages out.
+* **The logging-cap caveat renders beside *both* coverage sections.** A caveat
+  on one of them makes the other look exact by contrast.
+"""
+
+import os
+import re
+import tempfile
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+from src.services import search_analytics as sa  # noqa: E402
+from src.services.usage_stats import (  # noqa: E402
+    WINDOWS,
+    pre_body_refusal_sql,
+)
+
+
+class _Result:
+    def fetchall(self):
+        return []
+
+
+class _Capturing:
+    """Records the SQL and bind parameters each aggregate would issue."""
+
+    def __init__(self):
+        self.calls: list[tuple[str, dict]] = []
+
+    async def execute(self, clause, params=None):
+        self.calls.append((str(clause), params or {}))
+        return _Result()
+
+    @property
+    def sql(self) -> str:
+        return self.calls[-1][0]
+
+    @property
+    def params(self) -> dict:
+        return self.calls[-1][1]
+
+
+async def _issue_every_query(user_id):
+    """Run each public aggregate against a capturing session."""
+    session = _Capturing()
+    for tool in (*sa.QUERY_TOOLS, sa.RELATED_TOOL):
+        await sa.top_queries(session, "24h", user_id, tool)
+        await sa.zero_result_queries(session, "24h", user_id, tool)
+    await sa.top_logged_retrievals(session, "24h", user_id)
+    await sa.never_retrieved(session, "24h", user_id)
+    return session
+
+
+# --------------------------------------------------------------------------- #
+# 1. The predicate is imported, and broadened deliberately.
+# --------------------------------------------------------------------------- #
+def test_the_refusal_predicate_is_the_shared_one():
+    """One helper, two consumers, no drift — the #160 rule, kept."""
+    assert pre_body_refusal_sql() in sa.analysable_sql()
+
+
+def test_an_error_marked_row_is_not_a_result_set():
+    """Broader than `/admin/performance`'s predicate, on purpose. There, a
+    post-body refusal is still an expensive call and belongs in a percentile.
+    Here the question is whether the call produced results an operator can
+    reason about, and an error-marked row did not."""
+    fragment = sa.analysable_sql()
+    assert "->>'error' IS NULL" in fragment
+    # Never NULL: `params` is nullable, so the missing-key case must read as
+    # "no error", not as NULL propagating through the AND.
+    assert "COALESCE" in fragment
+
+
+def test_find_relateds_operational_markers_are_excluded_by_that_filter():
+    """The scenario the change turns on: a missing or not-yet-embedded source
+    must not reach the zero-result view. Both are `params.error` values, so the
+    broad filter is what excludes them — asserted here so a future narrowing of
+    that filter to an enumeration fails loudly."""
+    from src.mcp_server import tools
+
+    for marker in (
+        tools._RELATED_SOURCE_NOT_FOUND_MARKER,
+        tools._RELATED_SOURCE_NOT_EMBEDDED_MARKER,
+    ):
+        # The filter is value-blind: any error marker excludes the row.
+        assert marker not in sa.analysable_sql()
+    assert "->>'error' IS NULL" in sa.analysable_sql()
+
+
+# --------------------------------------------------------------------------- #
+# 2. Identity: (user_id, path), NULL-safe.
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+@pytest.mark.parametrize("user_id", [None, 7])
+async def test_every_grouping_carries_the_owner(user_id):
+    session = await _issue_every_query(user_id)
+    for sql, _ in session.calls:
+        if "GROUP BY" in sql:
+            group_by = re.search(r"GROUP BY ([^\n]+)", sql).group(1)
+            assert "user_id" in group_by, (
+                f"a grouping without the owner merges tenants: {group_by}"
+            )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("user_id", [None, 7])
+async def test_every_path_join_is_null_safe(user_id):
+    """`=` would drop the ownerless slice — which is every row in single-user
+    mode, and every row of a deleted user (`usage_logs.user_id` is
+    ON DELETE SET NULL)."""
+    session = await _issue_every_query(user_id)
+    joins = [
+        line.strip()
+        for sql, _ in session.calls
+        for line in sql.splitlines()
+        if "user_id" in line and ("nm." in line or "l." in line) and "AND" in line
+    ]
+    assert joins, "the coverage queries must join on the owner at all"
+    for line in joins:
+        assert "IS NOT DISTINCT FROM" in line or ":uid" in line, line
+
+
+@pytest.mark.asyncio
+async def test_a_regular_user_is_scoped_on_both_tables():
+    """The log rows *and* the notes: a coverage list built from a scoped log
+    against every user's notes would report another tenant's notes as
+    never-retrieved, listing their paths."""
+    session = _Capturing()
+    await sa.never_retrieved(session, "24h", 7)
+    sql, params = session.calls[-1]
+
+    assert sql.count("= :uid") == 2, "both usage_logs and notes_metadata scope"
+    assert "ul.user_id = :uid" in sql and "nm.user_id = :uid" in sql
+    assert params["uid"] == 7
+
+
+@pytest.mark.asyncio
+async def test_an_admin_scopes_neither_and_still_groups_per_owner():
+    session = _Capturing()
+    await sa.never_retrieved(session, "24h", None)
+    sql, params = session.calls[-1]
+
+    assert ":uid" not in sql
+    assert "uid" not in params
+    assert "IS NOT DISTINCT FROM" in sql, (
+        "an admin sees every owner's rows, so the join is the only thing "
+        "keeping two owners' identical paths apart"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 3. Guards, binds, and windows.
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_the_result_count_cast_is_guarded():
+    session = _Capturing()
+    await sa.top_queries(session, "24h", None, "keyword_search")
+    sql = session.sql
+    assert "~ '^-?[0-9]{1,9}$'" in sql, "an unguarded cast is a 500 per bad row"
+    assert "::bigint" in sql
+
+
+@pytest.mark.asyncio
+async def test_the_unnest_is_guarded_by_jsonb_typeof():
+    """`jsonb_array_elements_text` raises on a non-array value."""
+    session = _Capturing()
+    await sa.top_logged_retrievals(session, "24h", None)
+    assert "jsonb_typeof(ul.params->'result_paths') = 'array'" in session.sql
+
+
+@pytest.mark.asyncio
+async def test_values_travel_as_binds_not_literals():
+    session = _Capturing()
+    await sa.top_queries(session, "7d", 3, "semantic_search")
+    sql, params = session.calls[-1]
+
+    assert params["tool"] == "semantic_search"
+    assert "'semantic_search'" not in sql
+    assert params["window_seconds"] == WINDOWS["7d"]
+    assert ":window_seconds" in sql
+    # The refusal markers ride along as binds too.
+    assert any(k.startswith("omcp_pre_body_refusal_") for k in params)
+
+
+def test_an_unknown_tool_has_no_grouping_key():
+    """The group key is interpolated into SQL, so it is resolved from the map
+    and never from a caller."""
+    with pytest.raises(ValueError):
+        sa._group_key("read_note")
+    assert sa.GROUP_KEYS["find_related"] == "source_path", (
+        "grouping find_related by its named `path` param would collapse "
+        "distinct long paths — that param is truncated at 200 characters"
+    )
+    assert set(sa.GROUP_KEYS) == {*sa.QUERY_TOOLS, sa.RELATED_TOOL}
+
+
+# --------------------------------------------------------------------------- #
+# 4. The page.
+# --------------------------------------------------------------------------- #
+def _render(**overrides):
+    from jinja2 import (
+        ChainableUndefined,
+        ChoiceLoader,
+        DictLoader,
+        Environment,
+        FileSystemLoader,
+    )
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    templates = os.path.join(here, "..", "src", "control_panel", "templates")
+    env = Environment(
+        loader=ChoiceLoader([
+            DictLoader({
+                "base.html":
+                    "{% block title %}{% endblock %}{% block content %}{% endblock %}"
+            }),
+            FileSystemLoader(templates),
+        ]),
+        undefined=ChainableUndefined,
+        autoescape=True,
+    )
+
+    def group(value, digest=False, **kw):
+        return dict({
+            "user_id": None, "owner": None, "value": value, "calls": 3,
+            "zero_calls": 1, "mean_results": 2.5, "measured": 3,
+            "label": {"text": value, "is_digest": digest},
+        }, **kw)
+
+    ctx = dict(
+        active="search-analytics", window="24h", window_label="Last 24 hours",
+        windows=[{"key": "24h", "label": "24h", "selected": True}],
+        query_tables=[
+            {"tool": "keyword_search", "label": "Keyword search",
+             "top": [group("alpha")], "zero": [group("alpha")]},
+            {"tool": "semantic_search", "label": "Semantic search",
+             "top": [], "zero": []},
+        ],
+        related={"tool": "find_related", "label": "Related notes",
+                 "top": [group("d" * 64, digest=True)], "zero": []},
+        retrievals=[{"user_id": None, "owner": None, "path": "A.md",
+                     "appearances": 5, "indexed": True}],
+        never_retrieved=[{"user_id": None, "owner": None, "path": "C.md",
+                          "title": "C", "modified_at": None}],
+        never_retrieved_total=1204, table_limit=20, coverage_limit=50,
+        logged_per_call=sa.LOGGED_RESULTS_PER_CALL,
+        show_owner=False, has_data=True,
+    )
+    ctx.update(overrides)
+    return env.get_template("search_analytics.html").render(**ctx)
+
+
+def test_the_cap_caveat_renders_beside_both_coverage_sections():
+    html = _render()
+    caveat = f"Only the first {sa.LOGGED_RESULTS_PER_CALL} results of each call"
+    assert html.count(caveat) == 2, (
+        "the caveat has to sit beside the ranking *and* the never-retrieved "
+        "list; on one of them it makes the other look exact"
+    )
+
+
+def test_the_ranking_is_labelled_as_logged_appearances():
+    html = _render()
+    assert "Top-logged retrievals" in html
+    assert "Logged appearances" in html
+    assert "upper bound" in html, "never-retrieved must not read as exact"
+
+
+def test_a_digest_source_is_labelled_as_one():
+    """64 unmarked hex characters in a column of note paths reads as a note."""
+    html = _render()
+    assert "digest dddddddddddddddd" in html
+    assert "d" * 64 not in html
+
+
+def test_the_never_retrieved_cap_never_reads_as_the_total():
+    assert "showing 1 of 1204" in _render()
+
+
+def test_an_unmeasured_group_renders_an_em_dash_not_a_zero():
+    """A group whose calls all predate the telemetry has no mean. Rendering 0
+    would say "this query finds nothing", which is a different claim."""
+    html = _render(query_tables=[{
+        "tool": "keyword_search", "label": "Keyword search",
+        "top": [{"user_id": None, "owner": None, "value": "q", "calls": 2,
+                 "zero_calls": 0, "mean_results": None, "measured": 0,
+                 "label": {"text": "q", "is_digest": False}}],
+        "zero": [],
+    }])
+    assert "No call in this group recorded a result count" in html
+
+
+def test_the_owner_column_appears_only_when_owners_differ():
+    assert "bob" not in _render()
+    html = _render(show_owner=True, retrievals=[{
+        "user_id": 2, "owner": "bob", "path": "A.md",
+        "appearances": 5, "indexed": True,
+    }])
+    assert "bob" in html
+
+
+def test_the_page_is_reachable_and_in_the_nav():
+    from src.control_panel.routes import router
+
+    paths = {r.path for r in router.routes}
+    assert "/admin/search-analytics" in paths
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    base = os.path.join(here, "..", "src", "control_panel", "templates", "base.html")
+    with open(base) as fh:
+        nav = fh.read()
+    assert "/admin/search-analytics" in nav
+    assert "active == 'search-analytics'" in nav
+
+
+def test_the_digest_label_recognises_a_digest_and_nothing_else():
+    from src.control_panel.routes import _label_group_value
+
+    assert _label_group_value("find_related", "a" * 64)["is_digest"] is True
+    assert _label_group_value("find_related", "Projects/A.md")["is_digest"] is False
+    # A query is never a digest, whatever it looks like.
+    assert _label_group_value("keyword_search", "a" * 64)["is_digest"] is False


### PR DESCRIPTION
Second wave-2 change: the panel now shows what agents actually ask the vault — and what the vault couldn't answer.

- Search tools record result telemetry (`result_count` always; `result_paths` ≤10 paths / ≤2048 bytes at the record site; find_related's `source_path` with digest fallback) — proven pure observation: tool outputs byte-identical pre/post across a differential harness (SHA256-matched)
- `/admin/search-analytics`: top + zero-result queries per query tool, find_related grouped by source, top-logged retrievals + never-retrieved coverage (cap caveat beside both), windows 24h/7d/30d
- find_related's missing/unembedded-source failures get post-body error markers (`related_source_not_found` / `related_source_not_embedded`) so operational failures never masquerade as zero-result memories; pinned disjoint from the #160 pre-body refusal set
- Tenant-safe by construction: every grouping/join keys on (user_id, path) NULL-safely — mutation-tested (breaking it fails 5 PG tests)
- Guarded JSONB casts: a malformed row costs one row, not the page
- No migration

Gates: spec 5 Codex rounds to PASS; openspec-verifier audit — 0 blocking gaps, 6/6 scenarios, mutations reproduced. pytest 2679 passed/0 failed (+42); PG integration 18.

Known follow-up: archived colorscan path bug (#170). Live end-to-end (task 3.2) after deploy.

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SakkpngBNXLiTpbRu6CPxw