### PR TITLE
feat(panel): ops health — pass history, error buffer, backup recency (#163)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -471,6 +471,27 @@ deployment; on a compose-file deployment the equivalents are plain
 - **Backups.** `pg_dump` the database on a schedule; the vault itself is
   covered by whatever sync you chose in Step 4. Note that a soft delete
   moves files into `.trash/` inside the vault, so your sync sees them.
+
+  `make db-backup` also **records** each dump it takes — filename and size —
+  in a `backups_log` row, which is what the panel's Health page reads to
+  report backup age. It has to be a database row: the container cannot see
+  the backups directory, and giving it a mount into the host's backup
+  storage was the alternative rejected. So the age shown on that page is
+  the age of the last backup *taken through `make db-backup`*; a dump you
+  take by hand with `pg_dump` will not appear there, and the page will keep
+  warning after 8 days as though none had been taken.
+
+  **On the deploy that first ships this** (migration 021): `make deploy`
+  takes its backup *before* it migrates — deliberately, because the backup
+  is the only way back from a bad migration — so that one dump runs against
+  a database with no `backups_log` in it yet. The target prints
+  `WARNING: backup taken but not recorded` and **succeeds**; the dump is on
+  disk and valid. The first *recorded* backup is the next one, i.e. the next
+  deploy or a manual `make db-backup`. Until then the Health page reads "no
+  backup recorded yet", which is a fresh-table state and not a failure. Once
+  the table exists the disposition inverts: a backup that cannot record
+  itself fails the target loudly, because a missing row makes the page
+  report a staler safety net than you actually have.
 - **Dependency audit.** `make audit` (pip-audit) and `make trivy` (image
   CVE scan) work from a checkout regardless of which compose file runs
   the container.

--- a/Makefile
+++ b/Makefile
@@ -214,6 +214,17 @@ test-schema:
 # with exit 0 (pg_dump can write nothing and still succeed when it is pointed
 # at the wrong thing), and a failed gzip. The partial file is removed so a
 # later `db-restore` cannot pick a truncated dump out of the backups directory.
+#
+# The dump is then **recorded** in `backups_log` (migration 021, #163) so the
+# panel's health page can report backup age without the container being able to
+# see the backups directory — it deliberately cannot, and mounting a host path
+# into a public repo's compose file is the alternative that was rejected. The
+# recording goes through `docker/record-backup.sh`, which uses the same
+# `docker exec … psql` channel `pg_dump` just used and carries the three-branch
+# guard the deploy ordering forces: `make deploy` backs up BEFORE it migrates,
+# so on the deploy that ships 021 the table does not exist yet and the target
+# must warn and still succeed. Its exit status is the target's: once the table
+# exists, a backup that fails to record itself fails the backup.
 db-backup:
 	@mkdir -p $(DATA_DIR)/backups
 	@TIMESTAMP=$$(date +%Y%m%d_%H%M%S); \
@@ -234,7 +245,8 @@ db-backup:
 		echo "$(RED)Backup FAILED: could not gzip $$BACKUP_FILE$(NC)"; \
 		exit 1; \
 	fi; \
-	echo "$(GREEN)Backup: $$BACKUP_FILE.gz$(NC)"
+	echo "$(GREEN)Backup: $$BACKUP_FILE.gz$(NC)"; \
+	DB_CONTAINER=$(DB_CONTAINER) bash docker/record-backup.sh $$BACKUP_FILE.gz
 
 db-restore:
 	@if [ -z "$(FILE)" ]; then echo "$(RED)Usage: make db-restore FILE=<path>$(NC)"; exit 1; fi

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,7 @@ db-backup:
 	@mkdir -p $(DATA_DIR)/backups
 	@TIMESTAMP=$$(date +%Y%m%d_%H%M%S); \
 	BACKUP_FILE="$(DATA_DIR)/backups/backup_$$TIMESTAMP.sql"; \
+	: "the database named here is mirrored as DB_NAME's default in docker/record-backup.sh; keep the two in step"; \
 	if ! docker exec $(DB_CONTAINER) pg_dump -U postgres obsidian_mcp > $$BACKUP_FILE; then \
 		rm -f $$BACKUP_FILE; \
 		echo "$(RED)Backup FAILED: pg_dump against container '$(DB_CONTAINER)' returned non-zero$(NC)"; \

--- a/alembic/versions/021_backups_log.py
+++ b/alembic/versions/021_backups_log.py
@@ -67,14 +67,34 @@ The table carries a COMMENT marker, exactly as 013/015/016/017/018/019/020 mark
 what they create, and that marker is what `downgrade()` keys on: a table of this
 name that 021 did not create is never dropped.
 
-**The verification is of definitions, not of names** (019's rule, verbatim). The
-CHECK predicate is compared against the server's own normalization of the same
-declaration, derived at runtime from a scratch `TEMP` table rather than pinned
-to one PostgreSQL major — which needs the TEMP privilege on the database, as
-013 already requires. The index is read as a column list plus uniqueness,
-validity and whether it is partial or over an expression: an index of this name
-recreated on `filename` keeps the name an existence check looks for while the
-newest-first read the page and the strip both perform has nothing to lean on.
+**The verification is of definitions, not of names** (019's rule, verbatim).
+The CHECK predicate and the `created_at` default are both compared against the
+server's own normalization of the same declaration, derived at runtime from a
+scratch `TEMP` table rather than pinned to one PostgreSQL major — which needs
+the TEMP privilege on the database, as 013 already requires. The index is read
+as a column list plus uniqueness, validity and whether it is partial or over an
+expression: an index of this name recreated on `filename` keeps the name an
+existence check looks for while the newest-first read the page and the strip
+both perform has nothing to lean on.
+
+The **primary key and both server defaults** are read for a reason `alembic
+check` makes necessary: autogenerate compares neither. It reports a table whose
+PK has been dropped as being in perfect agreement with the model, and it never
+looks at a server default at all. The default is the quietest of the two:
+`ALTER COLUMN created_at SET DEFAULT now() + interval '100 years'` leaves every
+column, type, nullability, constraint and index exactly as 021 made them, and
+every backup recorded afterwards reads as permanently fresh — so the staleness
+warning this whole feature exists to raise can never fire again. `id`'s default
+is compared against `nextval` on the sequence `pg_get_serial_sequence` says the
+column actually owns, both sides rendered by the server so neither is a guess
+about the schema prefix.
+
+**Every catalog lookup resolves `public.backups_log`, qualified.** The writer
+and the panel both name it that way, and an unqualified reference resolves
+through `search_path` — so the three could otherwise be addressing three
+different tables. `op.create_table` still takes no schema (matching 019/020),
+so `upgrade()` asserts afterwards that what it created is the object those two
+consumers address, and `downgrade()` asserts the same before it drops anything.
 
 ## Locks
 
@@ -101,6 +121,18 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 TABLE = "backups_log"
+
+# **Every catalog lookup below resolves this**, not the bare name. The writer
+# (`docker/record-backup.sh`) inserts into `public.backups_log` and the panel
+# (`src/services/ops_health.py`) selects from it, both qualified, because an
+# unqualified reference resolves through `search_path` — so a role or database
+# pointing somewhere else would have the writer, the reader and this migration
+# each addressing a different table of that name. `op.create_table` has no
+# schema argument here (repo convention, matching 019/020), so `upgrade()` ends
+# by asserting that what it created or adopted really is the object those two
+# address; see `_assert_is_the_qualified_table`.
+QUALIFIED = "public.backups_log"
+
 CHECK_NAME = "ck_backups_log_size_bytes"
 CREATED_INDEX = "ix_backups_log_created_at"
 
@@ -136,23 +168,21 @@ def _quote(value: str) -> str:
     return "'" + value.replace("'", "''") + "'"
 
 
+def _oid(bind, name: str):
+    """The OID `name` resolves to, or None. `to_regclass` never raises."""
+    return bind.execute(
+        sa.text("SELECT CAST(to_regclass(:name) AS oid)"), {"name": name}
+    ).scalar()
+
+
 def _table_exists(bind) -> bool:
-    return bool(
-        bind.execute(
-            sa.text("SELECT to_regclass(:qualified)"), {"qualified": TABLE}
-        ).scalar()
-    )
+    return _oid(bind, QUALIFIED) is not None
 
 
 def _table_comment(bind) -> str | None:
     return bind.execute(
-        sa.text(
-            "SELECT obj_description(c.oid, 'pg_class') "
-            "FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace "
-            "WHERE c.relname = :table AND c.relkind = 'r' "
-            "  AND n.nspname = ANY (current_schemas(false))"
-        ),
-        {"table": TABLE},
+        sa.text("SELECT obj_description(CAST(:qualified AS regclass), 'pg_class')"),
+        {"qualified": QUALIFIED},
     ).scalar()
 
 
@@ -167,9 +197,46 @@ def _columns(bind):
                 "  AND a.attnum > 0 AND NOT a.attisdropped "
                 "ORDER BY a.attnum"
             ),
-            {"table": TABLE},
+            {"table": QUALIFIED},
         ).fetchall()
     ]
+
+
+def _column_default(bind, column: str) -> str | None:
+    """The rendered server default for `column`, or None when it has none."""
+    return bind.execute(
+        sa.text(
+            "SELECT pg_get_expr(d.adbin, d.adrelid) "
+            "FROM pg_attribute a "
+            "LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum "
+            "WHERE a.attrelid = CAST(:table AS regclass) AND a.attname = :column "
+            "  AND a.attnum > 0 AND NOT a.attisdropped"
+        ),
+        {"table": QUALIFIED, "column": column},
+    ).scalar()
+
+
+def _primary_key_columns(bind):
+    """The PK's columns **in order**, or None when there is no PK.
+
+    Not tidiness. Without a primary key the `id` an operator (or a future
+    reader) uses to name one backup row is not unique, and `alembic check` does
+    not compare primary keys at all — it reports a table of the right columns as
+    perfectly in agreement with the model while the constraint the model
+    declares is simply gone.
+    """
+    row = bind.execute(
+        sa.text(
+            "SELECT (SELECT array_agg(a.attname ORDER BY k.ord) "
+            "          FROM unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord) "
+            "          JOIN pg_attribute a ON a.attrelid = c.conrelid "
+            "                             AND a.attnum = k.attnum) AS columns "
+            "FROM pg_constraint c "
+            "WHERE c.conrelid = CAST(:table AS regclass) AND c.contype = 'p'"
+        ),
+        {"table": QUALIFIED},
+    ).first()
+    return list(row.columns) if row is not None and row.columns else None
 
 
 def _canonical_check(bind) -> str:
@@ -200,6 +267,59 @@ def _canonical_check(bind) -> str:
     return rendered
 
 
+def _canonical_created_at_default(bind) -> str:
+    """What this server renders `now()` as for a `timestamptz` column.
+
+    The CHECK's scratch-`TEMP`-table device, applied to a default. The threat it
+    closes is specific and silent: `ALTER COLUMN created_at SET DEFAULT now() +
+    interval '100 years'` leaves every column, type, nullability, constraint and
+    index exactly as 021 made them — `alembic check` does not compare server
+    defaults at all — and every backup recorded afterwards reads as permanently
+    fresh, so the staleness warning this whole feature exists to raise can never
+    fire again.
+    """
+    scratch = "_omcp_021_default_probe"
+    bind.execute(sa.text(f"DROP TABLE IF EXISTS pg_temp.{scratch}"))
+    bind.execute(
+        sa.text(
+            f"CREATE TEMP TABLE {scratch} "
+            "(created_at timestamptz NOT NULL DEFAULT now())"
+        )
+    )
+    rendered = bind.execute(
+        sa.text(
+            "SELECT pg_get_expr(d.adbin, d.adrelid) "
+            "FROM pg_attribute a "
+            "JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum "
+            "WHERE a.attrelid = CAST(:scratch AS regclass) AND a.attname = 'created_at'"
+        ),
+        {"scratch": f"pg_temp.{scratch}"},
+    ).scalar()
+    bind.execute(sa.text(f"DROP TABLE IF EXISTS pg_temp.{scratch}"))
+    return rendered
+
+
+def _canonical_id_default(bind) -> str | None:
+    """`nextval('<this table's own id sequence>'::regclass)`, or None.
+
+    Derived, never written out: `pg_get_serial_sequence` names the sequence the
+    column actually owns, and the regclass is rendered back to text by the same
+    code path `pg_get_expr` uses — so the two sides of the comparison cannot
+    disagree about whether the schema prefix is included. None means the column
+    owns no sequence at all, which is a serial that stopped being one.
+    """
+    sequence = bind.execute(
+        sa.text("SELECT pg_get_serial_sequence(:qualified, 'id')"),
+        {"qualified": QUALIFIED},
+    ).scalar()
+    if sequence is None:
+        return None
+    rendered = bind.execute(
+        sa.text("SELECT CAST(CAST(:seq AS regclass) AS text)"), {"seq": sequence}
+    ).scalar()
+    return f"nextval('{rendered}'::regclass)"
+
+
 def _check_state(bind):
     """`(constraintdef, convalidated)` for the size CHECK, or None.
 
@@ -215,7 +335,7 @@ def _check_state(bind):
             "WHERE c.conrelid = CAST(:table AS regclass) AND c.contype = 'c' "
             "  AND c.conname = :name"
         ),
-        {"table": TABLE, "name": CHECK_NAME},
+        {"table": QUALIFIED, "name": CHECK_NAME},
     ).first()
 
 
@@ -247,7 +367,7 @@ def _index_definitions(bind) -> dict:
             "FROM pg_index i JOIN pg_class ic ON ic.oid = i.indexrelid "
             "WHERE i.indrelid = CAST(:table AS regclass)"
         ),
-        {"table": TABLE},
+        {"table": QUALIFIED},
     ).fetchall()
     return {
         row.name: (
@@ -321,6 +441,89 @@ def _check_problems(bind) -> list:
     return problems
 
 
+def _assert_is_the_qualified_table(bind) -> None:
+    """What `op.create_table` just made is what the writer and reader address.
+
+    `op.create_table` takes no schema here (repo convention: 019 and 020 do the
+    same), so it creates in the first schema of `search_path`. Both consumers —
+    `docker/record-backup.sh`'s INSERT and `src/services/ops_health.py`'s
+    SELECT — name `public.backups_log` explicitly. On a database whose
+    `search_path` does not start with `public` those are two different tables,
+    and the failure is silent in the worst direction: the target records
+    backups into a table the panel never reads, so the page warns that no
+    backup has been taken while one is taken every day.
+    """
+    qualified = _oid(bind, QUALIFIED)
+    unqualified = _oid(bind, TABLE)
+    if qualified is None or qualified != unqualified:
+        raise RuntimeError(
+            f"021 created {TABLE} in a schema that is not the one "
+            f"{QUALIFIED} resolves to (search_path-relative oid "
+            f"{unqualified!r}, qualified oid {qualified!r}). `make db-backup` "
+            "writes to the qualified name and the panel reads it, so the table "
+            "just created would never be written to or read. Set the migration "
+            "role's search_path so `public` comes first, then re-run."
+        )
+
+
+def _primary_key_problems(bind) -> list:
+    """The PK is `(id)`, and it is there at all.
+
+    `alembic check` does not compare primary keys, so a table whose PK has been
+    dropped reports as being in perfect agreement with the model — while the
+    `id` the dashboard strip puts in a `#run-…`-style anchor, and the column
+    `ORDER BY created_at DESC, id DESC` breaks ties on, is no longer unique.
+    """
+    pk = _primary_key_columns(bind)
+    if pk == ["id"]:
+        return []
+    if pk is None:
+        return [
+            "it has no primary key at all, so its id is not unique and the "
+            "newest-row read has no deterministic tie-break"
+        ]
+    return [f"its primary key is {pk}, not ['id']"]
+
+
+def _default_problems(bind) -> list:
+    """Both server defaults, compared exactly against server-derived canonicals.
+
+    `alembic check` does not compare server defaults (`compare_server_default`
+    is off by default), so this comparison is the only thing that sees either
+    drift — and one of them is the quietest failure this table has:
+    `created_at DEFAULT now() + interval '100 years'` leaves every column, type,
+    constraint and index exactly as 021 made them, and every backup recorded
+    afterwards reads as permanently fresh, so the staleness warning can never
+    fire again.
+    """
+    problems = []
+
+    live_created = _column_default(bind, "created_at")
+    canonical_created = _canonical_created_at_default(bind)
+    if live_created != canonical_created:
+        problems.append(
+            f"its created_at default is {live_created!r}, not {canonical_created!r} "
+            "— a default that is not the current time makes every backup this "
+            "table records read as a different age than it is, and the "
+            "staleness warning is computed from exactly that value"
+        )
+
+    live_id = _column_default(bind, "id")
+    canonical_id = _canonical_id_default(bind)
+    if canonical_id is None:
+        problems.append(
+            "its id column owns no sequence, so it is not the serial 021 "
+            f"creates (its default is {live_id!r})"
+        )
+    elif live_id != canonical_id:
+        problems.append(
+            f"its id default is {live_id!r}, not {canonical_id!r} — the "
+            "sequence the column owns is not the one it draws from"
+        )
+
+    return problems
+
+
 def _verify(bind) -> None:
     """Accept a pre-existing table only if it is exactly 021's."""
     problems = []
@@ -332,6 +535,8 @@ def _verify(bind) -> None:
     if columns != list(EXPECTED_COLUMNS):
         problems.append(f"its columns are {columns}, not {list(EXPECTED_COLUMNS)}")
 
+    problems.extend(_primary_key_problems(bind))
+    problems.extend(_default_problems(bind))
     problems.extend(_check_problems(bind))
     problems.extend(_index_problems(bind))
 
@@ -361,6 +566,7 @@ def upgrade() -> None:
         _verify(bind)
     else:
         _create()
+        _assert_is_the_qualified_table(bind)
 
     # **No backfill**, deliberately — see the module docstring. The dumps on
     # disk live on a host this migration cannot read.
@@ -388,6 +594,9 @@ def downgrade() -> None:
     bind = op.get_bind()
     if not _table_exists(bind):
         return
+    # `op.drop_table` resolves through `search_path`; every check above resolved
+    # `public.backups_log`. Refuse rather than drop a table we did not inspect.
+    _assert_is_the_qualified_table(bind)
     if _table_comment(bind) != MARKER:
         raise RuntimeError(
             f"{TABLE} does not carry 021's comment marker ({MARKER!r}), so 021 "

--- a/alembic/versions/021_backups_log.py
+++ b/alembic/versions/021_backups_log.py
@@ -1,0 +1,398 @@
+"""Record one row per successful database backup (#163).
+
+Backups are written **host-side** by `make db-backup` into `$(DATA_DIR)/backups`
+— a directory the container deliberately cannot see, and must not: mounting it
+would put a host-specific path into a public repo's compose file and give the
+application write access to its own backups. So backup freshness reaches the
+panel through the database instead. The target inserts a row here through the
+same `docker exec … psql` channel it already uses for `pg_dump`, and the health
+page answers "when was the last backup" without touching the filesystem it is
+reporting on.
+
+## Shape
+
+`id, created_at, filename, size_bytes`. `filename` is the **basename** of the
+dump, not its path — the directory is a deployment-local constant that differs
+between the repo default and the real host (`Makefile.local`), and writing it
+into a shared table would put a host path in the one place this repo keeps them
+out of. `size_bytes` is `bigint`: a dump gzips to megabytes today and an
+`integer` stops being able to hold one at 2 GiB, which a few hundred thousand
+notes reach without anything going wrong.
+
+The CHECK `size_bytes >= 1` is the one invariant worth enforcing here. `db-backup`
+already refuses a zero-byte dump before it records anything (that refusal is
+issue-era history: `pg_dump` can write nothing and still exit 0 when it is
+pointed at the wrong thing); this makes the same refusal true of the *database*
+rather than of one shell script, because a recorded backup of zero bytes is not
+a backup and the page would render it as one. Mirrored in `src/models/db.py` as
+`BACKUP_MIN_SIZE_BYTES` and written out here as a literal rather than imported:
+a migration must keep describing the schema it created even after the model
+moves on.
+
+## Bootstrap, and why the writer is guarded rather than this migration
+
+`make deploy` runs `db-backup` **before** `db-migrate`, so on the deploy that
+ships this revision the dump is taken against a database that has no
+`backups_log` in it yet. That ordering is not a bug to fix here — the backup is
+the only way back from a bad migration, so it has to precede the migration. The
+guard therefore lives in the writer: `docker/record-backup.sh` checks
+`to_regclass('public.backups_log')`, warns loudly and exits 0 when the table is
+absent, and fails the target when the table exists and the insert does not
+land. The first recorded backup is the first one taken after this revision is
+live.
+
+## No backfill
+
+There is nothing to backfill from. The dumps on disk are the only record any
+deployment has, they live on a host this migration cannot read, and their
+filenames encode a timestamp in the *host's* local time. Inventing rows from
+them would put a claim in the table that nothing verified. A fresh table is the
+honest starting point, and the page renders "no backup recorded yet" until the
+next `db-backup`.
+
+## Reconciliation, and why it is not a bare CREATE TABLE
+
+The schema gate exercises idempotence by `alembic stamp 020` then
+`upgrade head`, so this revision runs against a database that already carries
+its table. A bare `CREATE TABLE` raises there; `IF NOT EXISTS` is worse, because
+it adopts *any* table of that name — including one whose `created_at` is
+nullable (a row the page would sort to nowhere), one with no size CHECK, or one
+whose `ix_backups_log_created_at` was recreated on `size_bytes` — and the panel
+then reports whatever it holds to an operator as the age of their last backup.
+That is a claim about disaster recovery, which is the worst possible thing to
+be casually wrong about. So 013's rule applies: reconcile a database that
+demonstrably has our shape, refuse to guess for one that does not.
+
+The table carries a COMMENT marker, exactly as 013/015/016/017/018/019/020 mark
+what they create, and that marker is what `downgrade()` keys on: a table of this
+name that 021 did not create is never dropped.
+
+**The verification is of definitions, not of names** (019's rule, verbatim). The
+CHECK predicate is compared against the server's own normalization of the same
+declaration, derived at runtime from a scratch `TEMP` table rather than pinned
+to one PostgreSQL major — which needs the TEMP privilege on the database, as
+013 already requires. The index is read as a column list plus uniqueness,
+validity and whether it is partial or over an expression: an index of this name
+recreated on `filename` keeps the name an existence check looks for while the
+newest-first read the page and the strip both perform has nothing to lean on.
+
+## Locks
+
+`CREATE TABLE` blocks nothing already in use — there is no foreign key here, so
+not even the `ACCESS SHARE` that 019 takes to validate one. `lock_timeout` /
+`statement_timeout` make a blocked migration fail fast instead of stalling the
+deploy, and both are `RESET` at the end because alembic runs every pending
+revision in one transaction and `SET LOCAL` would otherwise leak into a later
+revision (013 through 020 do the same).
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-08-29
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "021"
+down_revision: Union[str, None] = "020"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+TABLE = "backups_log"
+CHECK_NAME = "ck_backups_log_size_bytes"
+CREATED_INDEX = "ix_backups_log_created_at"
+
+# Mirrored from `src.models.db.BACKUP_MIN_SIZE_BYTES`. Written out as a literal
+# rather than imported, for the reason 019 and 020 give: a migration must keep
+# describing the schema it created even after the model moves on.
+MIN_SIZE_BYTES = 1
+
+SIZE_PREDICATE = f"size_bytes >= {MIN_SIZE_BYTES}"
+
+# 013's device, and 015's through 020's: the migration marks what it created,
+# so `downgrade()` can tell its own work from somebody else's and drop only the
+# former. Must stay byte identical to its mirror in `src/models/db.py`.
+MARKER = "one row per recorded database backup (021_backups_log)"
+
+# `(column, format_type, attnotnull)` — the whole shape, in creation order.
+EXPECTED_COLUMNS = (
+    ("id", "integer", True),
+    ("created_at", "timestamp with time zone", True),
+    ("filename", "text", True),
+    ("size_bytes", "bigint", True),
+)
+
+#: `(columns, unique, usable, restricted)` for the one index `_create` makes.
+EXPECTED_INDEXES = {
+    CREATED_INDEX: (["created_at"], False, True, False),
+}
+
+
+def _quote(value: str) -> str:
+    """A single-quoted SQL string literal. `MARKER` is a module constant with
+    no quotes in it; the doubling is here so it stays correct if that changes."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _table_exists(bind) -> bool:
+    return bool(
+        bind.execute(
+            sa.text("SELECT to_regclass(:qualified)"), {"qualified": TABLE}
+        ).scalar()
+    )
+
+
+def _table_comment(bind) -> str | None:
+    return bind.execute(
+        sa.text(
+            "SELECT obj_description(c.oid, 'pg_class') "
+            "FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace "
+            "WHERE c.relname = :table AND c.relkind = 'r' "
+            "  AND n.nspname = ANY (current_schemas(false))"
+        ),
+        {"table": TABLE},
+    ).scalar()
+
+
+def _columns(bind):
+    return [
+        (row[0], row[1], row[2])
+        for row in bind.execute(
+            sa.text(
+                "SELECT a.attname, format_type(a.atttypid, a.atttypmod), a.attnotnull "
+                "FROM pg_attribute a "
+                "WHERE a.attrelid = CAST(:table AS regclass) "
+                "  AND a.attnum > 0 AND NOT a.attisdropped "
+                "ORDER BY a.attnum"
+            ),
+            {"table": TABLE},
+        ).fetchall()
+    ]
+
+
+def _canonical_check(bind) -> str:
+    """What this server renders `SIZE_PREDICATE` as, measured not guessed.
+
+    013's scratch-`TEMP`-table device. A hand-written expected string pins the
+    migration to one PostgreSQL major's normalization of a comparison;
+    deriving it from an empty temp table carrying the identical declaration
+    cannot drift.
+    """
+    scratch = "_omcp_021_check_probe"
+    bind.execute(sa.text(f"DROP TABLE IF EXISTS pg_temp.{scratch}"))
+    bind.execute(
+        sa.text(
+            f"CREATE TEMP TABLE {scratch} "
+            f"(size_bytes bigint, CONSTRAINT {CHECK_NAME}_probe "
+            f"CHECK ({SIZE_PREDICATE}))"
+        )
+    )
+    rendered = bind.execute(
+        sa.text(
+            "SELECT pg_get_constraintdef(c.oid) FROM pg_constraint c "
+            "WHERE c.conrelid = CAST(:scratch AS regclass) AND c.contype = 'c'"
+        ),
+        {"scratch": f"pg_temp.{scratch}"},
+    ).scalar()
+    bind.execute(sa.text(f"DROP TABLE IF EXISTS pg_temp.{scratch}"))
+    return rendered
+
+
+def _check_state(bind):
+    """`(constraintdef, convalidated)` for the size CHECK, or None.
+
+    Resolved by name *and* re-read as a definition. A same-named `CHECK (true)`
+    satisfies a lookup by name and enforces nothing — that is issue #53, which
+    is why every migration since 013 compares the rendered predicate rather
+    than the constraint's existence.
+    """
+    return bind.execute(
+        sa.text(
+            "SELECT pg_get_constraintdef(c.oid) AS def, c.convalidated "
+            "FROM pg_constraint c "
+            "WHERE c.conrelid = CAST(:table AS regclass) AND c.contype = 'c' "
+            "  AND c.conname = :name"
+        ),
+        {"table": TABLE, "name": CHECK_NAME},
+    ).first()
+
+
+def _index_definitions(bind) -> dict:
+    """`{name: (columns, unique, usable, restricted)}` — 019's reader verbatim.
+
+    Names are not definitions. `ix_backups_log_created_at` dropped and recreated
+    on `filename` keeps the name an existence check looks for while the
+    newest-first read the health page and the dashboard strip both perform has
+    nothing to lean on.
+
+    `indkey` is an `int2vector`, which has no direct array cast; going through
+    its text rendering is the portable idiom. An expression index has `attnum`
+    0 there and joins to nothing, which is why `restricted` is read separately
+    rather than inferred from a short column list.
+    """
+    rows = bind.execute(
+        sa.text(
+            "SELECT ic.relname AS name, "
+            "       (SELECT array_agg(a.attname ORDER BY k.ord) "
+            "          FROM unnest(string_to_array(CAST(i.indkey AS text), ' ')) "
+            "               WITH ORDINALITY AS k(attnum, ord) "
+            "          JOIN pg_attribute a ON a.attrelid = i.indrelid "
+            "                             AND a.attnum = CAST(k.attnum AS smallint)"
+            "       ) AS columns, "
+            "       i.indisunique, "
+            "       (i.indisvalid AND i.indisready) AS usable, "
+            "       (i.indpred IS NOT NULL OR i.indexprs IS NOT NULL) AS restricted "
+            "FROM pg_index i JOIN pg_class ic ON ic.oid = i.indexrelid "
+            "WHERE i.indrelid = CAST(:table AS regclass)"
+        ),
+        {"table": TABLE},
+    ).fetchall()
+    return {
+        row.name: (
+            list(row.columns or []),
+            row.indisunique,
+            row.usable,
+            row.restricted,
+        )
+        for row in rows
+    }
+
+
+def _create() -> None:
+    op.create_table(
+        TABLE,
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("filename", sa.Text(), nullable=False),
+        sa.Column("size_bytes", sa.BigInteger(), nullable=False),
+        sa.CheckConstraint(SIZE_PREDICATE, name=CHECK_NAME),
+    )
+    op.create_index(CREATED_INDEX, TABLE, ["created_at"])
+    # Stamped in the same transaction as the CREATE, so the marker and the
+    # table can never disagree about who made it. `COMMENT ON` is utility DDL
+    # and takes no bind parameter, so the literal is quoted.
+    op.execute(f"COMMENT ON TABLE {TABLE} IS {_quote(MARKER)}")
+
+
+def _index_problems(bind) -> list:
+    """The index present *and defined as 021 defines it*."""
+    live = _index_definitions(bind)
+    problems = []
+    for name, expected in EXPECTED_INDEXES.items():
+        actual = live.get(name)
+        if actual is None:
+            problems.append(f"it is missing index {name}")
+            continue
+        if actual != expected:
+            columns, unique, usable, restricted = actual
+            problems.append(
+                f"its index {name} is on {columns} "
+                f"(unique={unique}, usable={usable}, partial-or-expression="
+                f"{restricted}), not {expected[0]} as a plain, valid, "
+                "non-unique index"
+            )
+    return problems
+
+
+def _check_problems(bind) -> list:
+    state = _check_state(bind)
+    if state is None:
+        return [
+            "it carries no size CHECK, so a zero-byte backup can be recorded "
+            "and the page will render it as a backup"
+        ]
+    live_def, validated = state
+    canonical = _canonical_check(bind)
+    problems = []
+    if live_def != canonical:
+        problems.append(f"its CHECK is {live_def!r}, not the size predicate {canonical!r}")
+    if not validated:
+        problems.append(
+            "its size CHECK is NOT VALID, so the existing rows were never "
+            "checked and the table may already record a zero-byte backup"
+        )
+    return problems
+
+
+def _verify(bind) -> None:
+    """Accept a pre-existing table only if it is exactly 021's."""
+    problems = []
+
+    if _table_comment(bind) != MARKER:
+        problems.append("it does not carry 021's comment marker")
+
+    columns = _columns(bind)
+    if columns != list(EXPECTED_COLUMNS):
+        problems.append(f"its columns are {columns}, not {list(EXPECTED_COLUMNS)}")
+
+    problems.extend(_check_problems(bind))
+    problems.extend(_index_problems(bind))
+
+    if problems:
+        raise RuntimeError(
+            f"{TABLE} already exists but {'; '.join(problems)}. 021 will not "
+            "adopt a table of unknown provenance: the panel reads its newest "
+            "row and tells an operator that is the age of their last database "
+            "backup, which is a claim about disaster recovery and the worst "
+            "possible thing to be casually wrong about. Resolve by hand — drop "
+            "it and let 021 create it, or make it match — then re-run. Nothing "
+            "has been changed."
+        )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    # Fail fast rather than queueing behind a long-lived transaction: the
+    # deploy migrates before recreating the container, so a stalled migration
+    # is a stalled deploy while the old container is still serving. Per
+    # statement and per lock acquisition, not a budget for the transaction.
+    op.execute("SET LOCAL lock_timeout = '10s'")
+    op.execute("SET LOCAL statement_timeout = '60s'")
+
+    if _table_exists(bind):
+        _verify(bind)
+    else:
+        _create()
+
+    # **No backfill**, deliberately — see the module docstring. The dumps on
+    # disk live on a host this migration cannot read.
+
+    # `SET LOCAL` is scoped to the transaction and alembic runs every pending
+    # revision in *one*, so without this the next revision would silently
+    # inherit these timeouts and blame its own SQL when it tripped them.
+    op.execute("RESET lock_timeout")
+    op.execute("RESET statement_timeout")
+
+
+def downgrade() -> None:
+    """Drop the table only if it carries 021's marker.
+
+    013's rule: a downgrade must undo *this* migration, not delete a table
+    somebody else put there under this name. The marker is the only evidence of
+    authorship.
+
+    Dropping loses the record of which backups were taken and nothing else —
+    the dumps themselves are files on the host and are untouched, and no code
+    reads this table for a decision. The page renders its "no backup recorded
+    yet" empty state, and the next `db-backup` after a re-upgrade starts a
+    fresh history.
+    """
+    bind = op.get_bind()
+    if not _table_exists(bind):
+        return
+    if _table_comment(bind) != MARKER:
+        raise RuntimeError(
+            f"{TABLE} does not carry 021's comment marker ({MARKER!r}), so 021 "
+            "did not create it and will not drop it. Nothing has been changed. "
+            "Remove it by hand if you mean to."
+        )
+    op.drop_index(CREATED_INDEX, table_name=TABLE)
+    op.drop_table(TABLE)

--- a/alembic/versions/021_backups_log.py
+++ b/alembic/versions/021_backups_log.py
@@ -89,12 +89,29 @@ is compared against `nextval` on the sequence `pg_get_serial_sequence` says the
 column actually owns, both sides rendered by the server so neither is a guess
 about the schema prefix.
 
-**Every catalog lookup resolves `public.backups_log`, qualified.** The writer
-and the panel both name it that way, and an unqualified reference resolves
-through `search_path` — so the three could otherwise be addressing three
-different tables. `op.create_table` still takes no schema (matching 019/020),
-so `upgrade()` asserts afterwards that what it created is the object those two
-consumers address, and `downgrade()` asserts the same before it drops anything.
+## search_path
+
+The writer (`docker/record-backup.sh`) and the panel
+(`src/services/ops_health.py`) both name `public.backups_log` explicitly, so
+this revision has to put the table where those two look. Three layers, in order
+of who does the work:
+
+1. **`upgrade()` and `downgrade()` pin `SET LOCAL search_path TO public`
+   first.** That is what makes the unqualified DDL — `op.create_table`,
+   `op.create_index`, `COMMENT ON`, `op.drop_index`, `op.drop_table` — land in
+   and act on `public`. Pinning rather than passing `schema="public"` to each
+   `op.*` call is deliberate: a schema-qualified table in alembic's eyes does
+   not match a model that declares no schema, and `alembic check` would report
+   drift forever after. Both `RESET` it at the end, because alembic runs every
+   pending revision in one transaction and `SET LOCAL` would otherwise leak
+   into a later one (013 through 020 do the same for their timeouts).
+2. **Every catalog lookup here resolves the qualified name** rather than
+   trusting the pin, so what is verified is what the consumers address.
+3. **`upgrade()` asserts afterwards that what it created really is
+   `public.backups_log`, and `downgrade()` asserts it before dropping
+   anything.** Belt and braces: if the pin ever fails to take effect, this
+   fails closed instead of silently recording backups into a table the panel
+   never reads.
 
 ## Locks
 
@@ -441,6 +458,31 @@ def _check_problems(bind) -> list:
     return problems
 
 
+def _pin_search_path() -> None:
+    """Pin `search_path` to `public` for the rest of this transaction.
+
+    **This is the fix for the unqualified DDL, and it is deliberately a pin
+    rather than a set of qualified `op.*` calls.** `op.create_table`,
+    `op.create_index`, `COMMENT ON`, `op.drop_index` and `op.drop_table` all
+    resolve through `search_path`; giving each one `schema="public"` would make
+    the table a *schema-qualified* object in alembic's eyes, and the ORM model
+    declares no schema — so autogenerate would then see the model and the
+    database disagree and `alembic check` would never be clean again. Pinning
+    the path instead makes the unqualified names resolve to `public` while
+    leaving both sides schema-less, which is the state `alembic check` is
+    happy with.
+
+    `SET LOCAL` is transaction-scoped, and that is exactly how this migration
+    runs: `alembic/env.py` configures an online migration on a real connection
+    inside `context.begin_transaction()` with no `transaction_per_migration`,
+    so every pending revision executes in one transaction. That is the same
+    property 013 through 020 already depend on for `lock_timeout` — and the
+    same reason `upgrade()` and `downgrade()` `RESET` it at the end, so a later
+    revision in that shared transaction does not silently inherit it.
+    """
+    op.execute("SET LOCAL search_path TO public")
+
+
 def _assert_is_the_qualified_table(bind) -> None:
     """What `op.create_table` just made is what the writer and reader address.
 
@@ -561,6 +603,7 @@ def upgrade() -> None:
     # statement and per lock acquisition, not a budget for the transaction.
     op.execute("SET LOCAL lock_timeout = '10s'")
     op.execute("SET LOCAL statement_timeout = '60s'")
+    _pin_search_path()
 
     if _table_exists(bind):
         _verify(bind)
@@ -573,9 +616,10 @@ def upgrade() -> None:
 
     # `SET LOCAL` is scoped to the transaction and alembic runs every pending
     # revision in *one*, so without this the next revision would silently
-    # inherit these timeouts and blame its own SQL when it tripped them.
+    # inherit these settings and blame its own SQL when it tripped them.
     op.execute("RESET lock_timeout")
     op.execute("RESET statement_timeout")
+    op.execute("RESET search_path")
 
 
 def downgrade() -> None:
@@ -592,10 +636,14 @@ def downgrade() -> None:
     fresh history.
     """
     bind = op.get_bind()
+    # `op.drop_index` / `op.drop_table` resolve through `search_path`, so the
+    # path is pinned here for the same reason `upgrade()` pins it — and the
+    # identity assertion below stays as the belt-and-braces check that the pin
+    # took effect before anything is dropped.
+    _pin_search_path()
     if not _table_exists(bind):
+        op.execute("RESET search_path")
         return
-    # `op.drop_table` resolves through `search_path`; every check above resolved
-    # `public.backups_log`. Refuse rather than drop a table we did not inspect.
     _assert_is_the_qualified_table(bind)
     if _table_comment(bind) != MARKER:
         raise RuntimeError(
@@ -605,3 +653,4 @@ def downgrade() -> None:
         )
     op.drop_index(CREATED_INDEX, table_name=TABLE)
     op.drop_table(TABLE)
+    op.execute("RESET search_path")

--- a/docker/record-backup.sh
+++ b/docker/record-backup.sh
@@ -12,7 +12,11 @@
 #
 #   DB_CONTAINER   the PostgreSQL container (the Makefile passes its own value,
 #                  which `Makefile.local` may override)
-#   DB_NAME        the database, defaulting to the deployment's `obsidian_mcp`
+#   DB_NAME        the database, defaulting to the deployment's `obsidian_mcp`.
+#                  That default is the **same database name the Makefile's
+#                  `pg_dump -U postgres obsidian_mcp` names** — the two are
+#                  written out separately and must stay in step; the override
+#                  exists so the guard can be exercised against a throwaway.
 #
 # ## The three branches, and why they differ
 #
@@ -74,36 +78,73 @@ SIZE=$(wc -c < "$BACKUP_PATH" | tr -d '[:space:]')
 # typed, and `:'filename'` is a syntax error there — while a statement read from
 # stdin is interpolated and quoted by psql itself. That quoting is the point:
 # the filename never becomes shell text inside a SQL string.
+#
+# **stderr is kept separate from stdout, and that is load-bearing.** A perfectly
+# healthy server writes warnings to stderr — a collation-version mismatch after
+# a libc upgrade is the common one, and it is emitted on connection. Folded into
+# stdout with `2>&1` the probe's value becomes `WARNING: …\nt`, which is not the
+# string `t`, and the "table absent" branch then exits 0 without recording
+# anything. Forever, on a table that exists. So stdout is captured on its own and
+# the classification below is exact.
+STDERR_FILE=$(mktemp)
+trap 'rm -f "$STDERR_FILE"' EXIT
+
 psql_run() {
     docker exec -i "$DB_CONTAINER" psql -U postgres -d "$DB_NAME" \
-        -v ON_ERROR_STOP=1 -qtAX "$@"
+        -v ON_ERROR_STOP=1 -qtAX "$@" 2>"$STDERR_FILE"
 }
 
-if ! TABLE_PRESENT=$(psql_run <<<"SELECT to_regclass('public.backups_log') IS NOT NULL" 2>&1); then
+if ! PROBE_STDOUT=$(psql_run <<<"SELECT to_regclass('public.backups_log') IS NOT NULL"); then
     echo -e "${RED}Backup RECORDING FAILED: could not ask the database whether backups_log exists${NC}" >&2
-    echo "$TABLE_PRESENT" >&2
+    cat "$STDERR_FILE" >&2
     echo -e "${YELLOW}The dump itself is intact at $BACKUP_PATH. This is the same docker exec psql channel pg_dump just used, so a failure here is a real fault rather than a missing table.${NC}" >&2
     exit 1
 fi
 
 # `-qtAX` prints the bare value; trim in case a future psql pads it.
-TABLE_PRESENT=$(printf '%s' "$TABLE_PRESENT" | tr -d '[:space:]')
+VERDICT=$(printf '%s' "$PROBE_STDOUT" | tr -d '[:space:]')
 
-if [ "$TABLE_PRESENT" != "t" ]; then
-    echo -e "${YELLOW}WARNING: backup taken but not recorded; table arrives with migration 021.${NC}"
-    echo -e "${YELLOW}         $FILENAME is on disk and valid — backups_log does not exist on this database yet,${NC}"
-    echo -e "${YELLOW}         which is expected on the deploy that ships 021 (db-backup runs before db-migrate).${NC}"
-    echo -e "${YELLOW}         The health page will keep reporting the previous recorded backup, or none at all,${NC}"
-    echo -e "${YELLOW}         until the next db-backup after 021 is live.${NC}"
-    exit 0
-fi
+# Exactly three outcomes, and the third is a failure rather than a guess.
+# `to_regclass(...) IS NOT NULL` is a boolean and can only print `t` or `f`;
+# anything else on a *successful* exit means the value we are reading is not the
+# value we asked for — an extra NOTICE routed to stdout, a psql option changing
+# the output format, a wrapper injecting a banner. Classifying that as "absent"
+# is how a healthy database silently stops recording backups, so it is treated
+# as branch 3 and fails the target.
+case "$VERDICT" in
+    t)
+        ;;
+    f)
+        echo -e "${YELLOW}WARNING: backup taken but not recorded; table arrives with migration 021.${NC}"
+        echo -e "${YELLOW}         $FILENAME is on disk and valid — backups_log does not exist on this database yet,${NC}"
+        echo -e "${YELLOW}         which is expected on the deploy that ships 021 (db-backup runs before db-migrate).${NC}"
+        echo -e "${YELLOW}         The health page will keep reporting the previous recorded backup, or none at all,${NC}"
+        echo -e "${YELLOW}         until the next db-backup after 021 is live.${NC}"
+        if [ -s "$STDERR_FILE" ]; then
+            echo -e "${YELLOW}         The server also wrote to stderr:${NC}" >&2
+            cat "$STDERR_FILE" >&2
+        fi
+        exit 0
+        ;;
+    *)
+        echo -e "${RED}Backup RECORDING FAILED: the existence probe answered ${VERDICT@Q}, which is neither 't' nor 'f'${NC}" >&2
+        cat "$STDERR_FILE" >&2
+        echo -e "${YELLOW}The dump itself is intact at $BACKUP_PATH. Refusing to guess: reading an unrecognised answer as 'the table is absent' is how a healthy database silently stops recording backups while this target keeps exiting 0.${NC}" >&2
+        exit 1
+        ;;
+esac
 
-if ! INSERT_OUTPUT=$(psql_run -v filename="$FILENAME" -v size_bytes="$SIZE" 2>&1 <<'SQL'
-INSERT INTO backups_log (filename, size_bytes) VALUES (:'filename', :'size_bytes');
+# `public.backups_log`, qualified, and the probe above asks about the same
+# qualified name. An unqualified INSERT resolves through `search_path`, so a
+# role or database with `search_path` pointing somewhere else writes the row
+# into a *different* table of that name while this target reports success and
+# the panel — which reads `public.backups_log` — never sees it.
+if ! INSERT_STDOUT=$(psql_run -v filename="$FILENAME" -v size_bytes="$SIZE" <<'SQL'
+INSERT INTO public.backups_log (filename, size_bytes) VALUES (:'filename', :'size_bytes');
 SQL
 ); then
     echo -e "${RED}Backup RECORDING FAILED: backups_log exists but the row did not land${NC}" >&2
-    echo "$INSERT_OUTPUT" >&2
+    cat "$STDERR_FILE" >&2
     echo -e "${YELLOW}The dump itself is intact at $BACKUP_PATH. Failing loudly because the panel reads the newest backups_log row as the age of the last backup: an unrecorded backup makes it report a staler safety net than you have.${NC}" >&2
     exit 1
 fi

--- a/docker/record-backup.sh
+++ b/docker/record-backup.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Record a completed database backup in `backups_log` (migration 021, #163).
+#
+# Called by `make db-backup` after the dump has been written, gzipped and
+# checked. It exists as a script rather than as five more continuation lines in
+# the Makefile recipe for one reason: the guard below has three branches with
+# three different exit dispositions, and a guard nobody can run in a test is a
+# guard nobody has ever seen take its unhappy path. `make db-init` already
+# delegates to `docker/db-init.sh` the same way.
+#
+#   record-backup.sh <path-to-dump>
+#
+#   DB_CONTAINER   the PostgreSQL container (the Makefile passes its own value,
+#                  which `Makefile.local` may override)
+#   DB_NAME        the database, defaulting to the deployment's `obsidian_mcp`
+#
+# ## The three branches, and why they differ
+#
+# The insert goes through **the same `docker exec … psql` channel the dump
+# itself used**. It has to: the container that runs the application cannot see
+# the backups directory (deliberately — mounting it would put a host path into
+# a public repo's compose file), so this script is host-side, and the only
+# database handle a host-side script has is the one `pg_dump` just used.
+#
+#   1. `backups_log` absent → **warn loudly, exit 0.** `make deploy` runs
+#      `db-backup` *before* `db-migrate`, so on the deploy that ships migration
+#      021 the table does not exist yet when the backup runs. The backup is the
+#      only way back from a bad migration; failing the target here would abort
+#      the very deploy that creates the table, which is a bookkeeping row
+#      blocking a disaster-recovery step. The dump is on disk and is valid — it
+#      is simply unrecorded, and the message says so.
+#   2. `backups_log` present, insert lands → silent success, one line printed.
+#   3. `backups_log` present, insert fails → **exit non-zero.** Once the table
+#      exists, the record is part of what a backup *is*: the panel reports the
+#      newest row as the age of the last backup, so a dump that silently failed
+#      to record itself makes the page claim the database has not been backed
+#      up for longer than it has — which is the direction that gets a deploy
+#      run against a stale safety net.
+#
+# A probe that cannot answer at all is treated as branch 3. The database
+# answered a full `pg_dump` seconds ago through this exact channel; a `psql`
+# that then cannot run one catalog lookup is a real fault, and guessing "the
+# table is probably absent" would convert every such fault into branch 1's
+# warning-and-continue.
+set -u
+
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+RED='\033[0;31m'
+NC='\033[0m'
+
+BACKUP_PATH="${1:-}"
+DB_CONTAINER="${DB_CONTAINER:-}"
+DB_NAME="${DB_NAME:-obsidian_mcp}"
+
+if [ -z "$BACKUP_PATH" ] || [ -z "$DB_CONTAINER" ]; then
+    echo -e "${RED}record-backup.sh: usage: DB_CONTAINER=<container> record-backup.sh <dump-path>${NC}" >&2
+    exit 2
+fi
+
+if [ ! -f "$BACKUP_PATH" ]; then
+    echo -e "${RED}record-backup.sh: $BACKUP_PATH does not exist${NC}" >&2
+    exit 2
+fi
+
+# The basename, never the path: the backups directory is a deployment-local
+# constant (`DATA_DIR`, overridden in the gitignored `Makefile.local`) and a
+# host path does not belong in a shared table.
+FILENAME=$(basename "$BACKUP_PATH")
+SIZE=$(wc -c < "$BACKUP_PATH" | tr -d '[:space:]')
+
+# The SQL arrives on **stdin**, not through `-c`. psql does not interpolate its
+# `:'var'` variables into a `-c` command — that string goes to the server as
+# typed, and `:'filename'` is a syntax error there — while a statement read from
+# stdin is interpolated and quoted by psql itself. That quoting is the point:
+# the filename never becomes shell text inside a SQL string.
+psql_run() {
+    docker exec -i "$DB_CONTAINER" psql -U postgres -d "$DB_NAME" \
+        -v ON_ERROR_STOP=1 -qtAX "$@"
+}
+
+if ! TABLE_PRESENT=$(psql_run <<<"SELECT to_regclass('public.backups_log') IS NOT NULL" 2>&1); then
+    echo -e "${RED}Backup RECORDING FAILED: could not ask the database whether backups_log exists${NC}" >&2
+    echo "$TABLE_PRESENT" >&2
+    echo -e "${YELLOW}The dump itself is intact at $BACKUP_PATH. This is the same docker exec psql channel pg_dump just used, so a failure here is a real fault rather than a missing table.${NC}" >&2
+    exit 1
+fi
+
+# `-qtAX` prints the bare value; trim in case a future psql pads it.
+TABLE_PRESENT=$(printf '%s' "$TABLE_PRESENT" | tr -d '[:space:]')
+
+if [ "$TABLE_PRESENT" != "t" ]; then
+    echo -e "${YELLOW}WARNING: backup taken but not recorded; table arrives with migration 021.${NC}"
+    echo -e "${YELLOW}         $FILENAME is on disk and valid — backups_log does not exist on this database yet,${NC}"
+    echo -e "${YELLOW}         which is expected on the deploy that ships 021 (db-backup runs before db-migrate).${NC}"
+    echo -e "${YELLOW}         The health page will keep reporting the previous recorded backup, or none at all,${NC}"
+    echo -e "${YELLOW}         until the next db-backup after 021 is live.${NC}"
+    exit 0
+fi
+
+if ! INSERT_OUTPUT=$(psql_run -v filename="$FILENAME" -v size_bytes="$SIZE" 2>&1 <<'SQL'
+INSERT INTO backups_log (filename, size_bytes) VALUES (:'filename', :'size_bytes');
+SQL
+); then
+    echo -e "${RED}Backup RECORDING FAILED: backups_log exists but the row did not land${NC}" >&2
+    echo "$INSERT_OUTPUT" >&2
+    echo -e "${YELLOW}The dump itself is intact at $BACKUP_PATH. Failing loudly because the panel reads the newest backups_log row as the age of the last backup: an unrecorded backup makes it report a staler safety net than you have.${NC}" >&2
+    exit 1
+fi
+
+echo -e "${GREEN}Recorded: $FILENAME ($SIZE bytes)${NC}"

--- a/docs/architecture/control-panel.md
+++ b/docs/architecture/control-panel.md
@@ -131,8 +131,75 @@
   `performance.html`, added by #160, which is not in the recorded list
   either), and assert the scan actually saw a nonzero number of declarations
   before believing the result. Pages added since: `performance.html` (#160),
-  `search_analytics.html` (#161) — both token-only, verified that way.
+  `search_analytics.html` (#161), `health.html` (#163) — all token-only,
+  verified that way.
 
+
+## The health page (#163)
+
+- **Three sections, three sources, and only one of them is a table this
+  application writes.** `/admin/health` shows the newest 50 rows of
+  `indexer_runs` (the same `recent_indexer_runs` the performance page reads,
+  asked for a longer window rather than given a second query with its own
+  scoping rule), the in-process error ring buffer, and the age of the newest
+  `backups_log` row. The dashboard's health strip reads the same three and
+  links to the page; a failed pass links to `#run-<id>`, which is why every
+  row on the page carries that id.
+
+- **Backup recency is a database row because the container cannot see the
+  backups directory — and must not.** Dumps are written host-side by
+  `make db-backup` into `$(DATA_DIR)/backups`; mounting that path would put a
+  host-specific volume into a public repo's compose file and hand the
+  application write access to its own backups. So `docker/record-backup.sh`
+  inserts `(filename, size_bytes)` through the same `docker exec … psql`
+  channel `pg_dump` just used. `filename` is the **basename**: the directory
+  differs between the repo default and the real host's `Makefile.local`, and a
+  host path does not belong in a shared table.
+
+- **The recording guard has three branches and they do not agree, deliberately.**
+  `make deploy` runs `db-backup` *before* `db-migrate` — the backup is the only
+  way back from a bad migration, so that ordering is not negotiable — which
+  means the deploy that ships migration 021 dumps against a database with no
+  `backups_log` in it. Table absent → loud warning, **exit 0** (a bookkeeping
+  row must never block a disaster-recovery step). Table present, insert lands →
+  success. Table present, insert fails → **non-zero**, because once the table
+  exists the panel reports its newest row as the age of the last backup, and a
+  dump that silently failed to record itself makes the page claim a staler
+  safety net than the operator has. A probe that cannot answer is treated as
+  the third case: the database answered a full `pg_dump` through that channel
+  seconds earlier.
+
+- **The age is the whole signal, and the page says so.** Nothing verifies that
+  the file still exists, that it restores, or that its contents are the
+  database — the panel cannot see the filesystem it is reporting on. Staleness
+  warns at **> 8 days**, a day clear of a weekly cadence so a Sunday schedule
+  does not page every Saturday.
+
+- **Errors live in a `deque(maxlen=100)` on the root logger and nowhere else.**
+  Container logs rotate with the container, so the errors from before the last
+  deploy — usually the ones worth reading — are gone. `src/services/error_log.py`
+  attaches at ERROR in the lifespan *before* the sandbox-mode branch returns, so
+  a process that dies in a startup guard still has the record. Only four
+  strings per entry are kept, never the `LogRecord`: a record holds `exc_info`,
+  which holds a traceback, which holds every frame's locals, and a hundred of
+  those is a bounded buffer of unbounded object graphs. `emit` cannot raise —
+  it runs inside every `logger.error(...)` in the process, including the ones
+  in exception handlers.
+
+- **The observation window is rendered next to the count, always.** "No errors"
+  on its own reads as a claim about the server; what it means is "this process
+  has not failed since it started", and a container restarted two minutes ago
+  has an empty buffer for reasons unrelated to health. Same reason the copy
+  points at `make logs` for anything older or fuller.
+
+- **Errors and backup age are admin-only; the pass history is scoped.** The run
+  list follows the performance page's rule (an admin sees every pass, a regular
+  user only their own, and deliberately none of the ownerless single-user or
+  global ones). The other two sections have **no owner to scope by** — the ring
+  buffer holds whatever the process logged, other tenants' paths and identifiers
+  included, and a backup covers the whole database — so they are gated on
+  `is_admin` rather than filtered, and a non-admin gets a page of their own run
+  history with a line saying why.
 
 ## Flash messages
 

--- a/docs/architecture/control-panel.md
+++ b/docs/architecture/control-panel.md
@@ -156,6 +156,15 @@
   differs between the repo default and the real host's `Makefile.local`, and a
   host path does not belong in a shared table.
 
+- **Writer, reader and migration all name `public.backups_log`, qualified.** An
+  unqualified reference resolves through `search_path`, so a role or database
+  pointing elsewhere would have the three addressing different tables — and the
+  failure is silent in the worst direction: backups recorded into a table the
+  panel never reads, so the page warns that none have been taken while one is
+  taken daily. `op.create_table` still takes no schema (matching 019/020), so
+  migration 021 asserts afterwards that what it created is the object the other
+  two address, and asserts it again before `downgrade()` drops anything.
+
 - **The recording guard has three branches and they do not agree, deliberately.**
   `make deploy` runs `db-backup` *before* `db-migrate` — the backup is the only
   way back from a bad migration, so that ordering is not negotiable — which
@@ -175,22 +184,47 @@
   warns at **> 8 days**, a day clear of a weekly cadence so a Sunday schedule
   does not page every Saturday.
 
-- **Errors live in a `deque(maxlen=100)` on the root logger and nowhere else.**
-  Container logs rotate with the container, so the errors from before the last
-  deploy — usually the ones worth reading — are gone. `src/services/error_log.py`
-  attaches at ERROR in the lifespan *before* the sandbox-mode branch returns, so
-  a process that dies in a startup guard still has the record. Only four
-  strings per entry are kept, never the `LogRecord`: a record holds `exc_info`,
-  which holds a traceback, which holds every frame's locals, and a hundred of
-  those is a bounded buffer of unbounded object graphs. `emit` cannot raise —
-  it runs inside every `logger.error(...)` in the process, including the ones
-  in exception handlers.
+- **Errors live in a `deque(maxlen=100)`, in memory, for the life of the
+  process.** Container logs rotate with the container, so the errors from before
+  the last deploy — usually the ones worth reading — are gone.
+  `src/services/error_log.py` attaches at ERROR in the lifespan *before* the
+  sandbox-mode branch returns, so a process that dies in a startup guard still
+  has the record. Only four strings per entry are kept, never the `LogRecord`:
+  a record holds `exc_info`, which holds a traceback, which holds every frame's
+  locals, and a hundred of those is a bounded buffer of unbounded object graphs.
+  `emit` cannot raise — it runs inside every `logger.error(...)` in the process,
+  including the ones in exception handlers.
+
+- **The root logger alone would miss every 500, so `uvicorn.error` is attached
+  explicitly.** uvicorn applies its own `dictConfig` at startup and it stops the
+  ascent before the root — 0.52 sets `propagate: false` on the `uvicorn` logger,
+  the *parent* of `uvicorn.error`, which is precisely where an unhandled
+  exception in the ASGI app is logged. (Which logger in that chain carries the
+  flag has moved between releases, so the test asserts the behaviour — a
+  root-only probe handler sees nothing — rather than the config key.) Attaching
+  only to the root captures the errors the application chose to log and none of
+  the ones it did not, which is the opposite of what a page headed "recent
+  errors" is for. The **same handler instance** goes on both, and `emit` stamps
+  each record so one that reaches the handler twice, on a release whose chain
+  does reach the root, is stored once. Any other logger that breaks propagation
+  has to be added to `CAPTURED_LOGGERS` or its errors will not appear.
 
 - **The observation window is rendered next to the count, always.** "No errors"
   on its own reads as a claim about the server; what it means is "this process
   has not failed since it started", and a container restarted two minutes ago
   has an empty buffer for reasons unrelated to health. Same reason the copy
   points at `make logs` for anything older or fuller.
+
+- **The dashboard strip has a failure boundary; the dashboard does not depend
+  on it.** Its reads are the only ones on `/admin/` that touch `indexer_runs`
+  and `backups_log`, so a fault confined to those two tables would take the
+  whole dashboard down for every user while every other query on the page
+  succeeds — on the page an operator opens *because* something is wrong. So
+  `_health_strip_or_degraded` rolls the failed transaction back (without it the
+  render's own queries raise `InFailedSQLTransaction` instead of the real
+  error), logs at ERROR so the ring buffer catches it, and renders a "health
+  summary unavailable" strip. Saying so beats rendering "ok" from a query that
+  never returned.
 
 - **Errors and backup age are admin-only; the pass history is scoped.** The run
   list follows the performance page's rule (an admin sees every pass, a regular

--- a/docs/architecture/control-panel.md
+++ b/docs/architecture/control-panel.md
@@ -156,14 +156,20 @@
   differs between the repo default and the real host's `Makefile.local`, and a
   host path does not belong in a shared table.
 
-- **Writer, reader and migration all name `public.backups_log`, qualified.** An
-  unqualified reference resolves through `search_path`, so a role or database
+- **Writer, reader and migration all resolve `public.backups_log`.** An
+  unqualified reference goes through `search_path`, so a role or database
   pointing elsewhere would have the three addressing different tables — and the
   failure is silent in the worst direction: backups recorded into a table the
   panel never reads, so the page warns that none have been taken while one is
-  taken daily. `op.create_table` still takes no schema (matching 019/020), so
-  migration 021 asserts afterwards that what it created is the object the other
-  two address, and asserts it again before `downgrade()` drops anything.
+  taken daily. The writer's INSERT and the panel's SELECT name it explicitly.
+  Migration 021 instead **pins the path** — `SET LOCAL search_path TO public` at
+  the top of `upgrade()` and `downgrade()`, `RESET` at the end because alembic
+  runs every pending revision in one transaction. Pinning and not
+  `schema="public"` on each `op.*` call: a schema-qualified table does not match
+  an ORM model that declares no schema, and `alembic check` would then report
+  drift forever. Its catalog lookups still resolve the qualified name, and it
+  asserts after creating (and before dropping) that the object really is
+  `public.backups_log`, so a pin that failed to take effect fails closed.
 
 - **The recording guard has three branches and they do not agree, deliberately.**
   `make deploy` runs `db-backup` *before* `db-migrate` — the backup is the only

--- a/openspec/changes/panel-ops-health/checks/literal_sweep.py
+++ b/openspec/changes/panel-ops-health/checks/literal_sweep.py
@@ -1,0 +1,71 @@
+"""Literal-sweep scan for the templates this change touches (task 3.x).
+
+`health.html` is new and `base.html` and `dashboard.html` both gained markup
+here, so the panel-theming requirement they already satisfy — "no color literal
+outside a custom-property definition" — has to be re-proved rather than assumed.
+
+    python3 openspec/changes/panel-ops-health/checks/literal_sweep.py
+
+The scanner itself is `panel-light-mode`'s, reused rather than reimplemented: a
+second copy of the parser is a second set of blind spots. It is imported from
+the archive with **one** correction, which is why this wrapper exists at all —
+`colorscan.TEMPLATE_DIR` is derived as `parents[4]` of its own path, and
+archiving the change moved it one directory deeper, so it now resolves to
+`openspec/src/control_panel/templates`, which does not exist. A scan of a
+directory that does not exist reports zero declarations and exits 0, which is a
+gate that passes by finding nothing (issue #170). So the directory is repointed
+here and the declaration count is asserted non-zero: a sweep that scanned
+nothing must fail, not pass.
+
+`health.html` is not in `colorscan.PANEL_TEMPLATES` either — that list is the
+set of templates that existed when the sweep was written — so it is named
+explicitly below, exactly as #161's and #162's wrappers name theirs.
+"""
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[4]
+ARCHIVED = REPO / "openspec/changes/archive/2026-08-29-panel-light-mode/checks"
+sys.path.insert(0, str(ARCHIVED))
+
+import colorscan  # noqa: E402
+
+# The correction. See the module docstring — and issue #170, which tracks
+# fixing it at the source.
+colorscan.TEMPLATE_DIR = REPO / "src" / "control_panel" / "templates"
+
+#: The templates this change adds or edits, scanned alongside the shared token
+#: partial, which is where their tokens are defined.
+TOUCHED = ["_theme.html", "base.html", "dashboard.html", "health.html"]
+
+
+def main() -> int:
+    missing = [t for t in TOUCHED if not (colorscan.TEMPLATE_DIR / t).exists()]
+    entries = colorscan.scan_all(templates=TOUCHED)
+    hits = [e for e in entries if e.literals and not e.prop.startswith("--")]
+
+    print(f"template dir                : {colorscan.TEMPLATE_DIR}")
+    print(f"templates scanned           : {', '.join(TOUCHED)}")
+    print(f"in-scope color declarations : {len(entries)}")
+    print(f"literals outside tokens     : {len(hits)}")
+    for e in hits:
+        print(f"  {e.template}:{e.line}  [{e.kind}] {e.context}  "
+              f"{e.prop}: {e.value}   -> {e.literals}")
+
+    if missing:
+        # `scan_all` skips a template that does not exist, so a renamed or
+        # mistyped page would otherwise be reported as clean.
+        print(f"FAIL: these templates were not found and so were never scanned: {missing}")
+        return 1
+    if not entries:
+        print(
+            "FAIL: the sweep found no color declarations at all, which means it "
+            "scanned the wrong directory rather than that the templates are "
+            "clean."
+        )
+        return 1
+    return 1 if hits else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/openspec/changes/panel-ops-health/specs/panel-ops-health/spec.md
+++ b/openspec/changes/panel-ops-health/specs/panel-ops-health/spec.md
@@ -1,7 +1,7 @@
 ## ADDED Requirements
 
 ### Requirement: Health page
-The panel SHALL provide a health page showing indexer run history (most recent 50 runs with start, duration, trigger, counts, and error), the most recent application errors (up to 100, ERROR level and above, since process start, with the observation window stated), and the age of the most recent recorded backup.
+The panel SHALL provide a health page showing indexer run history (most recent 50 runs with start, duration, trigger, counts, and error), the most recent application errors (up to 100, ERROR level and above, since process start, with the observation window stated), and the age of the most recent recorded backup. The run history SHALL be scoped as the performance page scopes it; the error and backup sections SHALL be shown to administrators only, because neither has an owner to scope by — the error buffer holds whatever the process logged and a backup covers the whole database.
 
 #### Scenario: Populated page
 - **WHEN** runs, errors, and a backup record exist
@@ -10,6 +10,10 @@ The panel SHALL provide a health page showing indexer run history (most recent 5
 #### Scenario: Empty states
 - **WHEN** a fresh install has no runs, no errors, and no backup rows
 - **THEN** the page renders explicit empty states and no section errors
+
+#### Scenario: Non-admin viewer
+- **WHEN** a non-admin opens the health page
+- **THEN** they see only their own run history, the error and backup sections are absent with copy saying they are administrators-only, and no `backups_log` query is issued for that request
 
 ### Requirement: Backup recency record
 A successful `make db-backup` SHALL insert a `backups_log` row (timestamp, filename, size) through the same channel as the dump when the table exists; when the table does not yet exist (any pre-021 database, including the deploy that ships migration 021, whose backup step precedes its migrate step) the target SHALL skip the insert with a loud warning and still succeed. Once the table exists, a failed insert SHALL fail the target loudly. The panel SHALL warn when the most recent row is older than 8 days.

--- a/openspec/changes/panel-ops-health/tasks.md
+++ b/openspec/changes/panel-ops-health/tasks.md
@@ -1,18 +1,18 @@
 ## 1. Schema
 
-- [ ] 1.1 `backups_log` model + migration 021; test-schema green; alembic check clean
+- [x] 1.1 `backups_log` model + migration 021; test-schema green; alembic check clean
 
 ## 2. Recording
 
-- [ ] 2.1 Makefile db-backup inserts the row after a successful dump, guarded by a to_regclass existence check (absent → loud warning, target still succeeds; present → insert failure fails the target); DEPLOYMENT.md updated incl. the bootstrap-deploy note
-- [ ] 2.2 Ring buffer ERROR handler (maxlen 100) attached in main.py lifespan
+- [x] 2.1 Makefile db-backup inserts the row after a successful dump, guarded by a to_regclass existence check (absent → loud warning, target still succeeds; present → insert failure fails the target); DEPLOYMENT.md updated incl. the bootstrap-deploy note
+- [x] 2.2 Ring buffer ERROR handler (maxlen 100) attached in main.py lifespan
 
 ## 3. Panel
 
-- [ ] 3.1 Health page: run history (≤50), error list with observation window, backup age + 8-day warning; empty states for all three
-- [ ] 3.2 Dashboard health strip linking to the page; theme token partial throughout
+- [x] 3.1 Health page: run history (≤50), error list with observation window, backup age + 8-day warning; empty states for all three
+- [x] 3.2 Dashboard health strip linking to the page; theme token partial throughout
 
 ## 4. Docs and verification
 
-- [ ] 4.1 docs/architecture/control-panel.md health section
+- [x] 4.1 docs/architecture/control-panel.md health section
 - [ ] 4.2 End-to-end: trigger a pass, force one logged error, run db-backup, verify page + strip against live server

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -70,6 +70,18 @@ from src.services.search_analytics import (
     top_queries,
     zero_result_queries,
 )
+from src.services.error_log import (
+    ERROR_BUFFER_SIZE,
+    error_count,
+    is_full as error_buffer_full,
+    observing_since,
+    recent_errors,
+)
+from src.services.ops_health import (
+    HEALTH_RUNS_LIMIT,
+    STALE_AFTER_DAYS,
+    latest_backup,
+)
 from src.services.usage_stats import (
     RECENT_RUNS_LIMIT,
     WINDOW_LABELS,
@@ -462,6 +474,11 @@ async def dashboard(
     last_run_at = _indexer.last_index_run_at
     last_run_ok = _indexer.last_index_run_ok
 
+    # The persisted counterpart to the heartbeat above: last recorded pass,
+    # backup age, errors since process start. Survives a restart, which the
+    # heartbeat does not, and links to the full history on /admin/health.
+    health = await _health_strip(session, user)
+
     return templates.TemplateResponse(request, "dashboard.html", _panel_context(request, user, {
         "active": "dashboard",
         "stats": {
@@ -481,6 +498,7 @@ async def dashboard(
         "index_interval": settings.index_interval_seconds,
         "graph": graph,
         "graph_backfill_running": link_backfill_in_progress,
+        "health": health,
     }))
 
 
@@ -1409,6 +1427,141 @@ async def performance_page(
             "has_data": any(t["executed"] or t["refusals"] for t in tools),
         }),
     )
+
+
+# --- Health ---------------------------------------------------------------
+#
+# Three sections, three sources, and two of them are **admin-only**:
+#
+#   * The pass history is scoped exactly as `/admin/performance` scopes it — an
+#     admin sees every pass, a regular user only their own, and deliberately
+#     none of the ownerless single-user/global passes, which are not theirs to
+#     read (`recent_indexer_runs`' docstring has the reasoning).
+#   * The error list and the backup age are **operator concerns about the
+#     server**, not about a tenant's data, and neither has any notion of an
+#     owner to scope by. The ring buffer holds whatever the process logged,
+#     including the OAuth internals of other tenants and any path, query or
+#     identifier a failure happened to carry; the backup covers the whole
+#     database. Showing either to a non-admin would leak across tenants with no
+#     filter available to prevent it, so both are gated on `is_admin` and a
+#     regular user sees a health page consisting of their own run history.
+#
+# The dashboard strip below follows the same split.
+
+
+def _error_view(entries: list[dict]) -> list[dict]:
+    """Ring-buffer entries as template rows: ISO timestamp, logger, message."""
+    return [
+        {
+            "timestamp": entry["timestamp"].isoformat(),
+            "logger": entry["logger"],
+            "level": entry["level"],
+            "message": entry["message"],
+        }
+        for entry in entries
+    ]
+
+
+def _error_window() -> dict:
+    """The count and the window it was observed over — no records.
+
+    The window is not decoration. A container restarted five minutes ago has an
+    empty buffer, and "no errors" without "since 14:32" reads as "this server
+    has been healthy" when it means "this process has not been running long
+    enough to have failed yet".
+    """
+    since = observing_since()
+    return {
+        "error_count": error_count(),
+        "errors_capped": error_buffer_full(),
+        "error_buffer_size": ERROR_BUFFER_SIZE,
+        "observing_since_iso": since.isoformat() if since else None,
+        "observing_since_rel": _humanize_delta(since) if since else None,
+    }
+
+
+def _error_section() -> dict:
+    """`_error_window()` plus the records themselves, for the page."""
+    return {**_error_window(), "errors": _error_view(recent_errors())}
+
+
+async def _backup_view(session: AsyncSession) -> dict | None:
+    """`latest_backup` with a humanized age, or None when nothing is recorded."""
+    backup = await latest_backup(session)
+    if backup is None:
+        return None
+    return {**backup, "age_rel": _humanize_delta(backup["created_at"])}
+
+
+@router.get("/health", response_class=HTMLResponse)
+async def health_page(
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    user=Depends(require_user_panel),
+):
+    """Indexer pass history, recent application errors, and backup age.
+
+    Read-only throughout. Every section has an explicit empty state and none of
+    them is an error condition: a fresh install has no passes, no errors and no
+    recorded backup, and that page has to render cleanly — it is the first
+    thing an operator looks at when they are not sure the server is working.
+    """
+    uid = _scope_user_id(user)
+    is_admin = _is_admin(user)
+
+    runs = await recent_indexer_runs(session, uid, limit=HEALTH_RUNS_LIMIT)
+
+    backup = await _backup_view(session) if is_admin else None
+    errors = _error_section() if is_admin else None
+
+    return templates.TemplateResponse(
+        request,
+        "health.html",
+        _panel_context(request, user, {
+            "active": "health",
+            "runs": runs,
+            "runs_limit": HEALTH_RUNS_LIMIT,
+            # The two operator-only sections. False renders the note that says
+            # so, rather than silently showing a page missing two thirds of
+            # what its heading promises.
+            "show_ops": is_admin,
+            "backup": backup,
+            "stale_after_days": STALE_AFTER_DAYS,
+            **(errors or {}),
+        }),
+    )
+
+
+async def _health_strip(session: AsyncSession, user) -> dict:
+    """The dashboard's compact health summary.
+
+    Reuses the health page's own reads rather than approximating them: the last
+    pass comes from `indexer_runs` (the persisted record, not the in-process
+    heartbeat the dashboard already shows above it — a restarted container has
+    no heartbeat and still has a pass history), the backup age from
+    `backups_log`, the error count from the ring buffer.
+
+    Same admin split as the page. A non-admin gets the pass outcome and nothing
+    else, and the strip renders without the two cells rather than with empty
+    ones.
+    """
+    uid = _scope_user_id(user)
+    is_admin = _is_admin(user)
+
+    runs = await recent_indexer_runs(session, uid, limit=1)
+    last_run = runs[0] if runs else None
+
+    strip: dict[str, Any] = {
+        "show_ops": is_admin,
+        "last_run": last_run,
+        "stale_after_days": STALE_AFTER_DAYS,
+    }
+    if is_admin:
+        strip["backup"] = await _backup_view(session)
+        # The count and the window, not the hundred records — the strip links
+        # to the page, which is where they are read.
+        strip.update(_error_window())
+    return strip
 
 
 # --- Search analytics -----------------------------------------------------

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -477,7 +477,7 @@ async def dashboard(
     # The persisted counterpart to the heartbeat above: last recorded pass,
     # backup age, errors since process start. Survives a restart, which the
     # heartbeat does not, and links to the full history on /admin/health.
-    health = await _health_strip(session, user)
+    health = await _health_strip_or_degraded(session, user)
 
     return templates.TemplateResponse(request, "dashboard.html", _panel_context(request, user, {
         "active": "dashboard",
@@ -1562,6 +1562,40 @@ async def _health_strip(session: AsyncSession, user) -> dict:
         # to the page, which is where they are read.
         strip.update(_error_window())
     return strip
+
+
+async def _health_strip_or_degraded(session: AsyncSession, user) -> dict:
+    """`_health_strip`, with a failure boundary around it.
+
+    **The dashboard is the page an operator opens when something is wrong, and
+    the strip is the newest thing on it.** Its reads are the only ones on this
+    handler that touch `indexer_runs` and `backups_log`, so a fault confined to
+    those two tables — a `NOT VALID` FK left by a hand repair, a permission
+    revoked, a 021 that has not run on a database the container was pointed at —
+    would take `/admin/` down for every user while every other query on the page
+    succeeds. Losing three cells is the right trade against losing the page.
+
+    The rollback is not optional: a failed statement poisons the session's
+    transaction, and everything after it on this request would raise
+    `InFailedSQLTransaction` instead of the original error. It runs first, so
+    the render that follows has a usable session.
+
+    The failure is logged at ERROR, which means the ring buffer catches it and
+    the health page shows an operator *why* their strip is missing.
+    """
+    try:
+        return await _health_strip(session, user)
+    except Exception:  # noqa: BLE001 - the strip must never take the page down
+        try:
+            await session.rollback()
+        except Exception:  # noqa: BLE001 - best effort; the render is what matters
+            logger.exception("could not roll back after a failed health strip read")
+        logger.error(
+            "Dashboard health strip unavailable: its reads failed. The rest of "
+            "the dashboard is unaffected; see /admin/health.",
+            exc_info=True,
+        )
+        return {"unavailable": True, "show_ops": _is_admin(user)}
 
 
 # --- Search analytics -----------------------------------------------------

--- a/src/control_panel/templates/base.html
+++ b/src/control_panel/templates/base.html
@@ -859,6 +859,12 @@
                 </svg>
                 Search
             </a>
+            <a href="/admin/health" class="nav-item {% if active == 'health' %}active{% endif %}">
+                <svg class="nav-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                    <polyline points="1.5,8.5 4.5,8.5 6,5 8.5,11.5 10.5,8.5 14.5,8.5"/>
+                </svg>
+                Health
+            </a>
 
             <div class="nav-section">Access</div>
             <a href="/admin/keys" class="nav-item {% if active == 'keys' %}active{% endif %}">

--- a/src/control_panel/templates/dashboard.html
+++ b/src/control_panel/templates/dashboard.html
@@ -43,6 +43,21 @@
     <div class="card anim-1" style="margin-bottom:20px;">
         <div class="card-body" style="padding-top:14px;padding-bottom:14px;display:flex;align-items:center;gap:26px;flex-wrap:wrap;">
 
+            {% if health.unavailable %}
+            {#
+              The strip's own reads failed and the rest of the dashboard did
+              not. Saying so beats both alternatives: rendering "ok"/"none
+              recorded" would be a claim built on a query that never returned,
+              and 500ing the page would lose the whole dashboard over three
+              cells. The failure is logged at ERROR, so the health page has it.
+            #}
+            <div style="font-size:13px;color:var(--text-3);">
+                Health summary unavailable — its queries failed. The rest of this
+                page is unaffected; the error is logged.
+            </div>
+            <a href="/admin/health" style="margin-left:auto;font-size:12px;color:var(--primary-text);text-decoration:none;">Health &rarr;</a>
+            {% else %}
+
             <div style="display:flex;align-items:center;gap:8px;font-size:13px;">
                 <span style="font-size:12px;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:var(--text-2);">Last pass</span>
                 {% if health.last_run and health.last_run.error %}
@@ -80,6 +95,7 @@
             {% endif %}
 
             <a href="/admin/health" style="margin-left:auto;font-size:12px;color:var(--primary-text);text-decoration:none;">Health &rarr;</a>
+            {% endif %}
         </div>
     </div>
 

--- a/src/control_panel/templates/dashboard.html
+++ b/src/control_panel/templates/dashboard.html
@@ -29,6 +29,60 @@
 
 <div class="page-body">
 
+    {#
+      Health strip. The line above the fold answers "is anything wrong" from the
+      three sources /admin/health reads: the last *recorded* pass (persisted, so
+      unlike the heartbeat in the page header it survives a restart), the age of
+      the last recorded backup, and the errors this process has logged. Every
+      cell links to the page; a failed pass links straight to its row.
+
+      The backup and error cells are administrators-only, for the reason the
+      health page states: neither has an owner to scope by, and the error buffer
+      holds whatever the process logged.
+    #}
+    <div class="card anim-1" style="margin-bottom:20px;">
+        <div class="card-body" style="padding-top:14px;padding-bottom:14px;display:flex;align-items:center;gap:26px;flex-wrap:wrap;">
+
+            <div style="display:flex;align-items:center;gap:8px;font-size:13px;">
+                <span style="font-size:12px;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:var(--text-2);">Last pass</span>
+                {% if health.last_run and health.last_run.error %}
+                    <a href="/admin/health#run-{{ health.last_run.id }}" class="badge badge-red" style="text-decoration:none;">failed</a>
+                {% elif health.last_run %}
+                    <span class="badge badge-green">ok</span>
+                {% else %}
+                    <span style="color:var(--text-3);">none recorded</span>
+                {% endif %}
+            </div>
+
+            {% if health.show_ops %}
+            <div style="display:flex;align-items:center;gap:8px;font-size:13px;">
+                <span style="font-size:12px;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:var(--text-2);">Backup</span>
+                {% if health.backup and health.backup.stale %}
+                    <span class="badge badge-yellow" title="Older than {{ health.stale_after_days }} days.">{{ health.backup.age_rel }}</span>
+                {% elif health.backup %}
+                    <span style="color:var(--text);">{{ health.backup.age_rel }}</span>
+                {% else %}
+                    <span style="color:var(--text-3);">none recorded</span>
+                {% endif %}
+            </div>
+
+            <div style="display:flex;align-items:center;gap:8px;font-size:13px;">
+                <span style="font-size:12px;font-weight:600;letter-spacing:0.08em;text-transform:uppercase;color:var(--text-2);">Errors</span>
+                {% if health.error_count %}
+                    <span class="badge badge-red">{{ health.error_count }}</span>
+                {% else %}
+                    <span style="color:var(--text-3);">0</span>
+                {% endif %}
+                {# The window, not just the number: "0 errors" without "since
+                   the process started" reads as a claim about the server. #}
+                <span style="font-size:12px;color:var(--text-3);">since process start{% if health.observing_since_rel %} ({{ health.observing_since_rel }}){% endif %}</span>
+            </div>
+            {% endif %}
+
+            <a href="/admin/health" style="margin-left:auto;font-size:12px;color:var(--primary-text);text-decoration:none;">Health &rarr;</a>
+        </div>
+    </div>
+
     <!-- Stat row -->
     <div class="stats-grid">
 

--- a/src/control_panel/templates/health.html
+++ b/src/control_panel/templates/health.html
@@ -1,0 +1,247 @@
+{% extends "base.html" %}
+{% block title %}Health — Obsidian MCP{% endblock %}
+{% block content %}
+
+{#
+  Every color on this page comes from a token defined in `_theme.html`; there
+  are no literals here. See docs/architecture/control-panel.md — "one token
+  source, dark canonical". The light-mode change's `checks/literal_sweep.py`,
+  re-run through this change's wrapper, is what enforces it.
+
+  Section order is alarms first, detail second: the backup age and the error
+  list are the two things that answer "is anything wrong", and the pass history
+  is what you read once one of them says yes. Every section has an explicit
+  empty state — a fresh install has no passes, no errors and no recorded backup,
+  and that page has to render cleanly, because it is the first thing an
+  operator opens when they are not sure the server is working.
+#}
+
+<div class="page-top">
+    <div>
+        <h1 class="page-title">Health</h1>
+        <div style="font-size:13px;color:var(--text-3);margin-top:8px;">
+            Index passes, recent errors, and backup recency.
+        </div>
+    </div>
+</div>
+
+<div class="page-body">
+
+    {% if show_ops %}
+
+    <!-- Backups -->
+    <div class="card anim-1" style="margin-bottom:20px;">
+        <div class="card-header">
+            <span class="card-title">Last backup</span>
+            {% if backup and backup.stale %}
+            <span class="badge badge-yellow">stale</span>
+            {% endif %}
+        </div>
+        <div class="card-body">
+            {% if backup %}
+            <div class="kv">
+                <span class="kv-k">Taken</span>
+                <span class="kv-v">
+                    <time datetime="{{ backup.created_at_iso }}" data-localize>{{ backup.created_at_iso }}</time>
+                    <span style="color:var(--text-3);">· {{ backup.age_rel }}</span>
+                </span>
+            </div>
+            <div class="kv">
+                <span class="kv-k">File</span>
+                <span class="kv-v mono" style="font-size:12px;">{{ backup.filename }}<span style="color:var(--text-3);"> · {{ backup.size_human }}</span></span>
+            </div>
+            {% if backup.stale %}
+            <p style="color:var(--warning);font-size:13px;line-height:1.6;margin:14px 0 0;">
+                The last recorded backup is more than {{ stale_after_days }} days
+                old. A deploy runs migrations against the live database and the
+                backup is the only way back from a bad one — take one with
+                <span class="mono">make db-backup</span> before the next deploy.
+            </p>
+            {% endif %}
+            {#
+              Age is the entire signal, and saying so is the point: the panel
+              cannot see the backups directory (that is why this is a database
+              row at all), so it cannot claim the file still exists or that it
+              restores. A page that implied otherwise would be worse than one
+              that showed nothing.
+            #}
+            <p style="color:var(--text-3);font-size:12px;line-height:1.6;margin:14px 0 0;">
+                Recorded by <span class="mono">make db-backup</span> when the dump
+                completed. This is the age of that record — the panel cannot see
+                the backups directory, so it does not verify that the file is
+                still there or that it restores.
+            </p>
+            {% else %}
+            <p style="color:var(--text-2);font-size:14px;line-height:1.6;margin:0;">
+                No backup recorded yet.
+            </p>
+            <p style="color:var(--text-3);font-size:12px;line-height:1.6;margin:10px 0 0;">
+                Backups are recorded by <span class="mono">make db-backup</span>.
+                A deploy takes its backup <em>before</em> it migrates, so the
+                deploy that first shipped this table wrote its dump without
+                recording it — that one warns and succeeds, and the next backup
+                is the first that appears here. A dump taken by hand with
+                <span class="mono">pg_dump</span> never appears here.
+            </p>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Recent errors -->
+    <div class="card anim-2" style="margin-bottom:20px;">
+        <div class="card-header">
+            <span class="card-title">Recent errors</span>
+            <span class="mono" style="font-size:11px;color:var(--text-3);">
+                {% if errors_capped %}newest {{ error_buffer_size }}{% else %}{{ error_count }} since start{% endif %}
+            </span>
+        </div>
+        <div class="card-body">
+            {#
+              The observation window, always, and above the list rather than
+              under it. "No errors" on its own reads as "this server has been
+              healthy"; what it actually means is "this *process* has not failed
+              since it started", and a container restarted two minutes ago has an
+              empty buffer for reasons that have nothing to do with health.
+            #}
+            <p style="color:var(--text-3);font-size:12px;line-height:1.6;margin:0 0 12px;">
+                {% if observing_since_iso %}
+                Observing since process start,
+                <time datetime="{{ observing_since_iso }}" data-localize>{{ observing_since_iso }}</time>
+                ({{ observing_since_rel }}).
+                {% else %}
+                Observation window unknown — the buffer was never attached, so
+                this process has recorded nothing.
+                {% endif %}
+                Kept in memory only: a restart clears them, and
+                <span class="mono">make logs</span> has the full text and the
+                tracebacks.
+                {% if errors_capped %}
+                The buffer holds the newest {{ error_buffer_size }}; older errors
+                from this process have been evicted.
+                {% endif %}
+            </p>
+
+            {% if errors %}
+            <div class="table-scroll">
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Time</th>
+                        <th>Logger</th>
+                        <th>Message</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for e in errors %}
+                    <tr>
+                        <td class="mono" style="font-size:11px;color:var(--text-2);white-space:nowrap;">
+                            <time datetime="{{ e.timestamp }}" data-localize>{{ e.timestamp }}</time>
+                        </td>
+                        <td class="mono" style="font-size:11px;color:var(--text-3);">
+                            {% if e.level != 'ERROR' %}<span class="badge badge-red" style="margin-right:6px;">{{ e.level }}</span>{% endif %}{{ e.logger }}
+                        </td>
+                        {# First line only. A hundred full tracebacks is a page
+                           nobody can read; this is a pointer to `make logs`. #}
+                        <td style="font-size:12px;color:var(--error);word-break:break-word;">{{ e.message }}</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            </div>
+            {% else %}
+            <p style="color:var(--text-2);font-size:14px;line-height:1.6;margin:0;">
+                No errors logged since this process started.
+            </p>
+            {% endif %}
+        </div>
+    </div>
+
+    {% else %}
+    {#
+      A non-admin sees their own pass history and nothing else. The error buffer
+      holds whatever the process logged — other tenants' paths, queries and
+      identifiers included — and the backup covers the whole database; neither
+      has an owner to scope by, so both are admin-only rather than filtered.
+    #}
+    <div class="card anim-1" style="margin-bottom:20px;">
+        <div class="card-body">
+            <p style="color:var(--text-2);font-size:14px;line-height:1.6;margin:0;">
+                Application errors and backup recency are server-wide and are
+                shown to administrators only. Below are the index passes over
+                your own vault.
+            </p>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Pass history -->
+    <div class="card anim-3">
+        <div class="card-header">
+            <span class="card-title">Index passes</span>
+            <span class="mono" style="font-size:11px;color:var(--text-3);">newest {{ runs_limit }}</span>
+        </div>
+        <div class="table-scroll">
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Started</th>
+                    <th style="text-align:right;">Duration</th>
+                    <th>Trigger</th>
+                    <th>Owner</th>
+                    <th style="text-align:right;" title="Notes the scan walked.">Scanned</th>
+                    <th style="text-align:right;" title="Notes the scan wrote or rewrote.">Indexed</th>
+                    <th style="text-align:right;" title="Notes this pass embedded and certified.">Embedded</th>
+                    <th>Result</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for r in runs %}
+                {# The row is an anchor target: the dashboard's health strip
+                   links a failed pass straight to its row here. #}
+                <tr id="run-{{ r.id }}">
+                    <td class="mono" style="font-size:11px;color:var(--text-2);">
+                        <time datetime="{{ r.started_at }}" data-localize>{{ r.started_at }}</time>
+                    </td>
+                    <td class="mono" style="text-align:right;font-size:12px;color:var(--text-2);">{% if r.duration %}{{ r.duration }}{% else %}<span style="color:var(--text-3);">—</span>{% endif %}</td>
+                    <td style="font-size:12px;"><span class="badge badge-gray">{{ r.trigger }}</span></td>
+                    <td style="font-size:12px;line-height:1.3;">
+                        {% if r.owner %}
+                            <span style="color:var(--primary-text);">{{ r.owner }}</span>
+                        {% elif r.owner_missing %}
+                            {# A non-NULL user_id that joined to nothing. The FK
+                               forbids it, so say so rather than quietly
+                               rendering it as an ownerless pass. #}
+                            <span class="mono" style="font-size:11px;color:var(--error);">user #{{ r.user_id }} (missing)</span>
+                        {% else %}
+                            {# ON DELETE SET NULL: when the user goes, the row's
+                               claim about whose vault it indexed stops being
+                               true. Single-user and global passes land here too,
+                               and both are honestly "no owner". #}
+                            <span class="mono" style="font-size:11px;color:var(--text-3);" title="A single-user or global pass, or a pass whose user has since been deleted.">no owner</span>
+                        {% endif %}
+                    </td>
+                    <td class="mono" style="text-align:right;font-size:12px;color:var(--text-2);">{{ r.notes_scanned }}</td>
+                    <td class="mono" style="text-align:right;font-size:12px;color:var(--text-2);">{{ r.notes_indexed }}</td>
+                    <td class="mono" style="text-align:right;font-size:12px;color:var(--text-2);">{{ r.notes_embedded }}</td>
+                    <td style="font-size:12px;">
+                        {% if r.error %}
+                            <div><span class="badge badge-red">failed</span></div>
+                            <div class="mono" style="font-size:10px;color:var(--text-3);white-space:pre-wrap;word-break:break-word;max-width:420px;">{{ r.error }}</div>
+                        {% else %}
+                            <span class="badge badge-green">ok</span>
+                        {% endif %}
+                    </td>
+                </tr>
+                {% endfor %}
+                {% if not runs %}
+                <tr>
+                    <td colspan="8" style="text-align:center;padding:32px;color:var(--text-3);">No index or embed pass has been recorded yet. The first pass after a deploy writes the first row.</td>
+                </tr>
+                {% endif %}
+            </tbody>
+        </table>
+        </div>
+    </div>
+
+</div>
+{% endblock %}

--- a/src/main.py
+++ b/src/main.py
@@ -24,7 +24,7 @@ from src.limiter import limiter
 from src.mcp_server.auth import APIKeyMiddleware
 from src.mcp_server.server import mcp
 from src.oauth.routes import router as oauth_router
-from src.services import vault
+from src.services import error_log, vault
 from src.services.indexer import run_indexer_loop
 from src.services import vault_fs
 from src.transfer.routes import router as transfer_router
@@ -254,6 +254,12 @@ def _on_indexer_done(task: asyncio.Task) -> None:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # First, before any guard can fail: the panel's health page reads this
+    # buffer, and the records worth reading most are the ones a startup guard
+    # writes on its way to `sys.exit(1)`. Attached to the **root** logger at
+    # ERROR, so it sees every module's errors without any of them opting in;
+    # process-lifetime only, no schema — see `src/services/error_log.py`.
+    error_log.attach()
     if settings.mcp_sandbox_mode:
         logging.getLogger(__name__).warning(
             "MCP_SANDBOX_MODE active — skipping DB check and indexer. "

--- a/src/models/db.py
+++ b/src/models/db.py
@@ -843,3 +843,81 @@ class QuotaCounter(Base):
     )
 
     __table_args__ = ({"comment": _QUOTA_COUNTERS_TABLE_MARKER},)
+
+
+# Migration 021's ownership marker for `backups_log`, mirrored here for the
+# reason 019's and 020's are: `alembic check` compares a table comment, so a
+# marker that drifted from the migration keying on it is a dirty check rather
+# than a `downgrade()` that has quietly stopped recognising its own work. Keep
+# byte identical to `TABLE_MARKER` in `alembic/versions/021_backups_log.py`.
+_BACKUPS_LOG_TABLE_MARKER = "one row per recorded database backup (021_backups_log)"
+
+# The floor `ck_backups_log_size_bytes` enforces, mirrored into migration 021
+# as a literal. A recorded backup of zero bytes is not a backup, and the health
+# page would render it as one — `make db-backup` already refuses an empty dump
+# before it records anything, and this is that refusal made true of the
+# database rather than of one shell script.
+BACKUP_MIN_SIZE_BYTES = 1
+
+
+class BackupLog(Base):
+    """One row per successful `make db-backup` (migration 021).
+
+    **The container cannot see the backups directory, and must not be able
+    to.** Dumps are written host-side into `$(DATA_DIR)/backups` by a Makefile
+    target; mounting that path into the container would put a host-specific
+    volume into a public repo's compose file and hand the application write
+    access to its own backups. So the *record* travels through the database
+    instead: `db-backup` inserts a row through the same `docker exec … psql`
+    channel it already uses for `pg_dump`, and the panel reads backup freshness
+    without ever touching the filesystem it is reporting on.
+
+    That makes this table a claim about something the application cannot
+    verify. It is deliberately an **age** signal and nothing more: nobody here
+    checks that the file still exists, that it restores, or that its contents
+    are the database. "The last backup this server knows about was taken N days
+    ago" is the whole promise, and the page's copy says so.
+
+    `filename` is the **basename** of the dump, not its path. The directory is
+    a deployment-local constant that differs between the repo default and the
+    real host (`Makefile.local`), and writing it into a shared table would put
+    a host path in the one place the repo is careful to keep them out of.
+
+    Bootstrap: `make deploy` takes its backup *before* it migrates, so the
+    deploy that ships 021 dumps against a database with no `backups_log` in it.
+    The target warns and succeeds there (the backup is the migration's safety
+    net and must not be blocked by the bookkeeping); the first recorded backup
+    is the next one. A fresh install therefore renders "no backup recorded
+    yet", which is a state, not an error.
+    """
+
+    __tablename__ = "backups_log"
+
+    # 021's ownership marker, reachable from the class so a caller checking
+    # model/migration agreement names the table it is checking. `ClassVar` is
+    # what keeps the declarative mapper from reading it as a column.
+    _TABLE_MARKER: ClassVar[str] = _BACKUPS_LOG_TABLE_MARKER
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    created_at: Mapped[datetime.datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    # Free text rather than a bounded varchar: the writer supplies whatever
+    # `basename` produced, and truncating an operator's only handle on which
+    # file this row names would be worse than storing a long one.
+    filename: Mapped[str] = mapped_column(Text, nullable=False)
+    # `BigInteger`: a dump of this database gzips to megabytes today and an
+    # `integer` stops being able to hold it at 2 GiB, which is a size a vault
+    # of a few hundred thousand notes reaches without anything going wrong.
+    size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
+
+    __table_args__ = (
+        CheckConstraint(
+            f"size_bytes >= {BACKUP_MIN_SIZE_BYTES}",
+            name="ck_backups_log_size_bytes",
+        ),
+        # The page reads exactly one row — the newest — and the dashboard strip
+        # reads the same one on every render.
+        Index("ix_backups_log_created_at", "created_at"),
+        {"comment": _BACKUPS_LOG_TABLE_MARKER},
+    )

--- a/src/services/error_log.py
+++ b/src/services/error_log.py
@@ -21,6 +21,24 @@ So the errors are kept in memory instead, and that is the whole design:
   HTML page is a page nobody can read and a response nobody should send. The
   first line is what identifies the error; `make logs` has the rest.
 
+## The root logger is not enough
+
+uvicorn applies its own `dictConfig` at startup, and that config sets
+`"propagate": false` on the **`uvicorn`** logger — the parent of `uvicorn.error`,
+which is exactly where an unhandled exception in the ASGI app is logged
+("Exception in ASGI application"). A record logged there therefore ascends to
+`uvicorn`, is handled, and **stops**: it never reaches a root handler. (Which
+logger in that chain carries the flag has moved between uvicorn releases —
+0.52's config puts it on `uvicorn` and leaves `uvicorn.error` alone — so what
+matters is the observed behaviour, not the key.)
+
+Attaching to the root alone would therefore capture every error the application
+chose to log and **not one of the 500s it did not**, which is the opposite of
+what a page headed "recent errors" is for. So `attach()` puts the same handler
+instance on `uvicorn.error` as well, and `emit` marks each record so one that
+reaches this handler twice — which is what happens on any release where the
+chain does propagate to the root — is stored once.
+
 ## Why it cannot raise
 
 This is a `logging.Handler` on the **root** logger, so it runs inside every
@@ -52,6 +70,29 @@ ERROR_BUFFER_SIZE = 100
 #: `CRITICAL` too — the startup guards in `src/main.py` log at that level, and
 #: those are precisely the records an operator comes looking for.
 CAPTURE_LEVEL = logging.ERROR
+
+#: Loggers the handler is attached to. The root logger is not enough, and the
+#: exception it misses is the most important one on the page.
+#:
+#: uvicorn installs its own `dictConfig` at startup, and that config stops the
+#: ascent before the root: 0.52 sets `"propagate": false` on the `uvicorn`
+#: logger, the parent of `uvicorn.error`. Every unhandled exception in an ASGI
+#: application is logged on `uvicorn.error` — "Exception in ASGI application" —
+#: so those records are handled by uvicorn and never reach a root handler at
+#: all. A page headed "recent errors" that cannot show a 500 is worse than no
+#: page.
+#:
+#: Attaching the **same handler instance** to both is what makes the
+#: double-capture guard in `emit` sufficient: on a release whose chain does
+#: propagate to the root, `callHandlers` walks `uvicorn.error` and then the
+#: root, reaches this handler twice for one record, and the second visit is
+#: dropped.
+CAPTURED_LOGGERS: tuple[str, ...] = ("uvicorn.error",)
+
+#: Set on a record the moment this handler stores it, so a second visit by the
+#: same handler (propagation plus a direct attachment) does not store it twice.
+#: `LogRecord`s are per-emit objects, so the flag cannot outlive the record.
+_SEEN_ATTR = "_omcp_error_ring_seen"
 
 # The buffer and the moment observation began. `_lock` guards both: logging
 # calls can arrive from the event loop and from any thread a library spawns,
@@ -94,6 +135,11 @@ class RingBufferHandler(logging.Handler):
 
     def emit(self, record: logging.LogRecord) -> None:
         try:
+            # One record, one entry, however many loggers in the chain carry
+            # this handler. See `_SEEN_ATTR`.
+            if getattr(record, _SEEN_ATTR, False):
+                return
+            setattr(record, _SEEN_ATTR, True)
             entry = {
                 "timestamp": datetime.datetime.fromtimestamp(
                     record.created, tz=datetime.timezone.utc
@@ -108,38 +154,55 @@ class RingBufferHandler(logging.Handler):
             _buffer.append(entry)
 
 
+def _targets(root: logging.Logger | None) -> list[logging.Logger]:
+    """The root logger (or the one given) plus every logger in
+    `CAPTURED_LOGGERS`. One handler instance across all of them."""
+    base = root if root is not None else logging.getLogger()
+    return [base, *(logging.getLogger(name) for name in CAPTURED_LOGGERS)]
+
+
 def attach(root: logging.Logger | None = None) -> logging.Handler:
-    """Install the handler on the root logger. Idempotent.
+    """Install the handler on the root logger **and on `uvicorn.error`**.
+
+    Idempotent, and idempotent per logger: calling it twice (a re-entered
+    lifespan, as in tests) reuses the existing handler and never adds a second
+    copy to a logger that already has it.
 
     Called from the lifespan, before the sandbox-mode branch returns, so a
     process that skips every startup guard still records what it fails at.
-    Calling it twice (a re-entered lifespan, as in tests) reuses the existing
-    handler rather than double-recording every error.
+
+    Why `uvicorn.error` is named explicitly rather than covered by the root:
+    uvicorn's own `dictConfig` stops the ascent before the root (0.52 sets
+    `propagate: false` on `uvicorn`, its parent), and `uvicorn.error` is where
+    every unhandled ASGI exception is logged. Without this the page would show
+    the errors the application chose to log and none of the 500s it did not.
     """
     global _handler, _observing_since
 
-    target = root if root is not None else logging.getLogger()
     with _lock:
-        if _handler is not None and _handler in target.handlers:
-            return _handler
         if _handler is None:
             _handler = RingBufferHandler(level=CAPTURE_LEVEL)
         if _observing_since is None:
             _observing_since = datetime.datetime.now(datetime.timezone.utc)
         handler = _handler
-    target.addHandler(handler)
+
+    for target in _targets(root):
+        if handler not in target.handlers:
+            target.addHandler(handler)
     return handler
 
 
 def detach(root: logging.Logger | None = None) -> None:
-    """Remove the handler. The buffer's contents are left alone — a shutdown
-    that logs an error on its way out should still be readable if anything
-    renders afterwards."""
-    global _handler
-    target = root if root is not None else logging.getLogger()
+    """Remove the handler from every logger `attach` put it on.
+
+    The buffer's contents are left alone — a shutdown that logs an error on its
+    way out should still be readable if anything renders afterwards.
+    """
     with _lock:
         handler = _handler
-    if handler is not None:
+    if handler is None:
+        return
+    for target in _targets(root):
         target.removeHandler(handler)
 
 

--- a/src/services/error_log.py
+++ b/src/services/error_log.py
@@ -1,0 +1,194 @@
+"""An in-process ring buffer of the most recent ERROR-and-above log records.
+
+The panel's health page needs to answer "what has gone wrong lately" without an
+operator opening an SSH session. Everything this server logs goes to stdout and
+therefore to the container log, which **rotates with the container**: the errors
+from before the last `make deploy` are gone, and the ones an operator most wants
+are usually the ones that preceded a restart.
+
+So the errors are kept in memory instead, and that is the whole design:
+
+* **Process lifetime only.** No table, no migration, nothing to prune. Persisting
+  them is observability scope creep — the honest boundary is "since this process
+  started", and the page says exactly that rather than implying a history it does
+  not have. `make logs` remains the tool for anything older or fuller.
+* **A bounded `deque`.** `maxlen=100`; the 101st error evicts the 1st. An
+  unbounded list is a memory leak with a log line as its trigger, which is the
+  one shape of leak a server can be *made* to have by whatever is already going
+  wrong.
+* **The first line of the message, not the traceback.** The page is a pointer,
+  not a log viewer: a hundred multi-thousand-line tracebacks rendered into one
+  HTML page is a page nobody can read and a response nobody should send. The
+  first line is what identifies the error; `make logs` has the rest.
+
+## Why it cannot raise
+
+This is a `logging.Handler` on the **root** logger, so it runs inside every
+`logger.error(...)` in the process, including the ones in exception handlers.
+A handler that raises there turns an error into a second error at a point where
+almost nothing is prepared for one. `emit` therefore catches everything and
+falls back to the un-formatted `msg`; a record it cannot render at all is
+dropped rather than escalated.
+
+## Multi-worker
+
+Single-process uvicorn today, so the buffer is the whole server's. Under
+multiple workers each process would keep its own and the page would show one
+worker's errors — noted here and on the page's copy rather than solved, because
+the fix (shipping records somewhere shared) is the persistence this module
+deliberately does not do.
+"""
+from __future__ import annotations
+
+import collections
+import datetime
+import logging
+import threading
+
+#: How many records the buffer holds. The 101st error evicts the 1st.
+ERROR_BUFFER_SIZE = 100
+
+#: The level at and above which a record is captured. `logging.ERROR` catches
+#: `CRITICAL` too — the startup guards in `src/main.py` log at that level, and
+#: those are precisely the records an operator comes looking for.
+CAPTURE_LEVEL = logging.ERROR
+
+# The buffer and the moment observation began. `_lock` guards both: logging
+# calls can arrive from the event loop and from any thread a library spawns,
+# and `deque.append` is atomic while "append, then read the whole thing for a
+# render" is not.
+_lock = threading.Lock()
+_buffer: collections.deque = collections.deque(maxlen=ERROR_BUFFER_SIZE)
+_observing_since: datetime.datetime | None = None
+_handler: logging.Handler | None = None
+
+
+def _first_line(record: logging.LogRecord) -> str:
+    """The record's message, first line only, never raising.
+
+    `record.getMessage()` interpolates `msg % args` and raises on a format
+    mismatch — a real thing that happens in the exception paths that produce
+    these records in the first place. The fallback is the raw `msg`, which is
+    still the identifying half of the line.
+    """
+    try:
+        text = record.getMessage()
+    except Exception:  # noqa: BLE001 - a logging handler may not raise
+        try:
+            text = str(record.msg)
+        except Exception:  # noqa: BLE001
+            return "<unrenderable log record>"
+    line = text.splitlines()[0] if text.splitlines() else ""
+    return line.strip()
+
+
+class RingBufferHandler(logging.Handler):
+    """Append ERROR+ records to the module-level ring buffer.
+
+    Deliberately stores a small dict rather than the `LogRecord`: a record
+    holds `exc_info`, which holds a traceback, which holds every frame's locals
+    — up to a hundred of them, alive for the life of the process. Keeping four
+    strings instead is the difference between a bounded buffer and a bounded
+    number of unbounded object graphs.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            entry = {
+                "timestamp": datetime.datetime.fromtimestamp(
+                    record.created, tz=datetime.timezone.utc
+                ),
+                "logger": record.name,
+                "level": record.levelname,
+                "message": _first_line(record),
+            }
+        except Exception:  # noqa: BLE001 - never raise out of logging
+            return
+        with _lock:
+            _buffer.append(entry)
+
+
+def attach(root: logging.Logger | None = None) -> logging.Handler:
+    """Install the handler on the root logger. Idempotent.
+
+    Called from the lifespan, before the sandbox-mode branch returns, so a
+    process that skips every startup guard still records what it fails at.
+    Calling it twice (a re-entered lifespan, as in tests) reuses the existing
+    handler rather than double-recording every error.
+    """
+    global _handler, _observing_since
+
+    target = root if root is not None else logging.getLogger()
+    with _lock:
+        if _handler is not None and _handler in target.handlers:
+            return _handler
+        if _handler is None:
+            _handler = RingBufferHandler(level=CAPTURE_LEVEL)
+        if _observing_since is None:
+            _observing_since = datetime.datetime.now(datetime.timezone.utc)
+        handler = _handler
+    target.addHandler(handler)
+    return handler
+
+
+def detach(root: logging.Logger | None = None) -> None:
+    """Remove the handler. The buffer's contents are left alone — a shutdown
+    that logs an error on its way out should still be readable if anything
+    renders afterwards."""
+    global _handler
+    target = root if root is not None else logging.getLogger()
+    with _lock:
+        handler = _handler
+    if handler is not None:
+        target.removeHandler(handler)
+
+
+def reset() -> None:
+    """Forget everything, including the observation window. Tests only —
+    nothing in the server clears this, because "since process start" is only
+    true if it is never cleared."""
+    global _observing_since
+    with _lock:
+        _buffer.clear()
+        _observing_since = None
+
+
+def observing_since() -> datetime.datetime | None:
+    """When the handler was attached, i.e. what "since" means on the page.
+
+    None before the lifespan has run at all (a bare test client, an import-time
+    render), which the page states as an unknown window rather than implying it
+    has been watching since the epoch.
+    """
+    with _lock:
+        return _observing_since
+
+
+def error_count() -> int:
+    """How many records the buffer currently holds.
+
+    At the cap this is 100 and not "100 or more": the buffer cannot say how many
+    it evicted, and the dashboard strip's copy says "most recent" rather than a
+    total it cannot know.
+    """
+    with _lock:
+        return len(_buffer)
+
+
+def is_full() -> bool:
+    """True once eviction has begun, so a reader can say "at least"."""
+    with _lock:
+        return len(_buffer) >= ERROR_BUFFER_SIZE
+
+
+def recent_errors(limit: int = ERROR_BUFFER_SIZE) -> list[dict]:
+    """The buffered records, **newest first**, at most `limit` of them.
+
+    Copies are returned: the entries are plain dicts and a caller that mutated
+    one would be editing the buffer.
+    """
+    limit = max(0, min(int(limit), ERROR_BUFFER_SIZE))
+    with _lock:
+        entries = list(_buffer)
+    entries.reverse()
+    return [dict(entry) for entry in entries[:limit]]

--- a/src/services/ops_health.py
+++ b/src/services/ops_health.py
@@ -1,0 +1,127 @@
+"""Read-only backing for the panel's health page (#163).
+
+Three questions, three sources, and only one of them is here:
+
+* **Pass history** — `indexer_runs`, read through
+  `src.services.usage_stats.recent_indexer_runs`, which the performance page
+  already uses. The health page asks the same function for a longer window
+  rather than growing a second query with its own scoping rule.
+* **Recent errors** — `src.services.error_log`, an in-process ring buffer. No
+  schema, process lifetime only.
+* **Backup recency** — this module. `backups_log` (migration 021) is written
+  host-side by `make db-backup`, because the container cannot see the backups
+  directory and giving it a mount was the alternative rejected.
+
+## The table may legitimately not exist
+
+`make deploy` backs up **before** it migrates, and a database can sit at any
+revision below 021 for other reasons (a downgrade, a restore from an older
+dump). Reading a table that is not there is a 500 on the whole page, so the
+read probes `to_regclass` first and returns None — which the page renders as
+"no backup recorded yet", the same state a fresh install is in. Failure posture
+throughout: an absent record is a state, never an error.
+
+## What "stale" means, and what it does not
+
+`STALE_AFTER_DAYS = 8`. The threshold is deliberately a day clear of a weekly
+cadence: a backup taken every Sunday is at most 7 days old on a good week, and a
+7-day threshold would page an operator every Saturday evening for a schedule
+that is working. Eight days means one missed run, not one late one.
+
+The signal is **age and nothing else**. Nobody here checks that the file still
+exists, that it restores, or that its contents are the database — the panel
+cannot see the filesystem it is reporting on, which is the whole reason this
+table exists. "The last backup this server knows about was taken N days ago" is
+the entire promise, and the page's copy says so rather than implying a verified
+backup.
+"""
+from __future__ import annotations
+
+import datetime
+
+from sqlalchemy import text
+
+#: How many passes the health page's run history shows. The performance page
+#: shows 20 as a summary; this is the fuller view the #160 change deferred here,
+#: and the table itself keeps 500 rows.
+HEALTH_RUNS_LIMIT = 50
+
+#: Older than this and the newest recorded backup is called stale. See the
+#: module docstring for why it is 8 and not 7.
+STALE_AFTER_DAYS = 8
+
+
+async def latest_backup(session) -> dict | None:
+    """The newest `backups_log` row as a display dict, or None.
+
+    None covers both "no row" and "no table": a fresh install and a pre-021
+    database are the same state as far as this page is concerned — nothing has
+    been recorded — and distinguishing them on an operator's screen would be
+    distinguishing two things they would act on identically.
+    """
+    present = (
+        await session.execute(text("SELECT to_regclass('public.backups_log')"))
+    ).scalar()
+    if present is None:
+        return None
+
+    row = (
+        await session.execute(
+            text(
+                "SELECT created_at, filename, size_bytes FROM backups_log "
+                "ORDER BY created_at DESC, id DESC LIMIT 1"
+            )
+        )
+    ).first()
+    if row is None:
+        return None
+
+    created_at = row.created_at
+    if created_at is not None and created_at.tzinfo is None:
+        # The column is `timestamptz`, so this should not arise; a naive value
+        # would otherwise make the subtraction below raise and take the page
+        # down over a timezone.
+        created_at = created_at.replace(tzinfo=datetime.timezone.utc)
+
+    age = _age(created_at)
+    return {
+        "created_at": created_at,
+        "created_at_iso": created_at.isoformat() if created_at else None,
+        "filename": row.filename,
+        "size_bytes": int(row.size_bytes) if row.size_bytes is not None else None,
+        "size_human": human_size(row.size_bytes),
+        "age": age,
+        "age_days": None if age is None else age.days,
+        "stale": is_stale(created_at),
+    }
+
+
+def _age(created_at: datetime.datetime | None) -> datetime.timedelta | None:
+    if created_at is None:
+        return None
+    return datetime.datetime.now(datetime.timezone.utc) - created_at
+
+
+def is_stale(created_at: datetime.datetime | None) -> bool:
+    """True when the newest recorded backup is older than the threshold.
+
+    A missing record is **not** stale — it is unknown, and the page says so
+    with its own copy. Reporting "stale" for a fresh install would be a warning
+    about a backup nobody has failed to take yet.
+    """
+    age = _age(created_at)
+    if age is None:
+        return False
+    return age > datetime.timedelta(days=STALE_AFTER_DAYS)
+
+
+def human_size(size_bytes) -> str | None:
+    """A dump size for display. Base-1024, one decimal above KiB."""
+    if size_bytes is None:
+        return None
+    value = float(size_bytes)
+    for unit in ("B", "KiB", "MiB", "GiB", "TiB"):
+        if value < 1024 or unit == "TiB":
+            return f"{int(value)} {unit}" if unit == "B" else f"{value:.1f} {unit}"
+        value /= 1024
+    return None  # pragma: no cover - the loop always returns

--- a/src/services/ops_health.py
+++ b/src/services/ops_health.py
@@ -65,10 +65,17 @@ async def latest_backup(session) -> dict | None:
     if present is None:
         return None
 
+    # `public.backups_log`, qualified, and the probe above asks about the same
+    # qualified name. `docker/record-backup.sh` writes to the qualified name for
+    # the same reason: an unqualified reference resolves through `search_path`,
+    # so a role or database whose `search_path` points elsewhere would have the
+    # writer and this reader addressing two different tables — the page would
+    # report a backup age from a table nothing writes, which is the one number
+    # on this page that must not be quietly wrong.
     row = (
         await session.execute(
             text(
-                "SELECT created_at, filename, size_bytes FROM backups_log "
+                "SELECT created_at, filename, size_bytes FROM public.backups_log "
                 "ORDER BY created_at DESC, id DESC LIMIT 1"
             )
         )

--- a/tests/integration/test_issue_163_ops_health_pg.py
+++ b/tests/integration/test_issue_163_ops_health_pg.py
@@ -1,0 +1,297 @@
+"""`backups_log` and the `db-backup` recording guard, against real PostgreSQL.
+
+Two things a fake cannot answer.
+
+**The guard.** `docker/record-backup.sh` has three branches with three
+different exit dispositions, and getting one of them wrong is not visible until
+the day it matters: a target that fails when `backups_log` is absent aborts the
+very deploy that creates the table, and one that succeeds when the insert failed
+leaves the panel reporting a staler safety net than the operator has. So the
+script is executed **verbatim** here — the real `psql`, the real SQL, the real
+exit codes — with only `docker exec <container>` shimmed away, because the
+throwaway Postgres these tests already run against is reachable directly.
+
+**The read.** `latest_backup` probes `to_regclass` and then orders by
+`created_at DESC`; both halves are SQL and are asserted against a database that
+has actually been migrated by 021, not against a fake that agrees with them.
+
+Skipped unless `PGVECTOR_TEST_ADMIN_URL` is set — see `_harness.py`.
+"""
+import asyncio
+import datetime
+import os
+import stat
+import subprocess
+from urllib.parse import unquote, urlsplit
+
+import asyncpg
+import pytest
+
+import _harness
+
+pytestmark = _harness.requires_pgvector
+
+DIM = 64
+
+REPO = _harness.ROOT
+SCRIPT = os.path.join(REPO, "docker", "record-backup.sh")
+
+# What the absent-table branch must print. The wording is part of the contract:
+# an operator reading a deploy log has to be able to tell "this backup is not
+# recorded" from "this backup failed".
+ABSENT_WARNING = "backup taken but not recorded; table arrives with migration 021"
+
+
+@pytest.fixture
+def db(request):
+    """A throwaway database at `head`, or at the revision the marker names."""
+    revision = getattr(request, "param", "head")
+    generator = _harness.throwaway_database(
+        f"ops_health_{revision.replace('-', '_')}", DIM, revision=revision
+    )
+    url = next(generator)
+    try:
+        yield url
+    finally:
+        generator.close()
+
+
+# --------------------------------------------------------------------------
+# plumbing
+# --------------------------------------------------------------------------
+
+
+def _pg_env(url: str) -> dict:
+    """`PG*` variables psql can connect with, from a SQLAlchemy URL."""
+    parts = urlsplit(_harness.asyncpg_dsn(url))
+    return {
+        "PGHOST": parts.hostname or "localhost",
+        "PGPORT": str(parts.port or 5432),
+        "PGUSER": unquote(parts.username or "postgres"),
+        "PGPASSWORD": unquote(parts.password or ""),
+    }
+
+
+def _dbname(url: str) -> str:
+    return unquote(urlsplit(url).path).lstrip("/")
+
+
+def _docker_shim(tmp_path):
+    """A `docker` on PATH that runs `docker exec <name> <cmd…>` as `<cmd…>`.
+
+    The point is to leave the script's own invocation untouched — the real
+    `psql`, the real flags, the real `:'var'` interpolation and `ON_ERROR_STOP`
+    semantics — while pointing it at the Postgres this test already has. A
+    shim that reimplemented the query would be testing itself.
+    """
+    bindir = tmp_path / "bin"
+    bindir.mkdir(exist_ok=True)
+    shim = bindir / "docker"
+    shim.write_text(
+        "#!/bin/bash\n"
+        'if [ "$1" != "exec" ]; then\n'
+        '  echo "shim: expected \'docker exec\', got: $*" >&2; exit 99\n'
+        "fi\n"
+        "shift\n"
+        "# drop docker exec's own flags (-i, -t, …), then the container name\n"
+        'while [ $# -gt 0 ] && [ "${1:0:1}" = "-" ]; do shift; done\n'
+        "shift\n"
+        'exec "$@"\n'
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return bindir
+
+
+def run_record(url, tmp_path, *, contents=b"fake dump bytes", db_name=None):
+    """Run `docker/record-backup.sh` against `url`'s database."""
+    dump = tmp_path / "backup_20260829_031500.sql.gz"
+    dump.write_bytes(contents)
+    bindir = _docker_shim(tmp_path)
+    env = {
+        **os.environ,
+        **_pg_env(url),
+        "PATH": f"{bindir}:{os.environ['PATH']}",
+        "DB_CONTAINER": "pretend-postgres",
+        "DB_NAME": db_name or _dbname(url),
+    }
+    result = subprocess.run(
+        ["bash", SCRIPT, str(dump)],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return result, dump
+
+
+async def _fetch(url, statement, *args):
+    conn = await asyncpg.connect(_harness.asyncpg_dsn(url))
+    try:
+        return await conn.fetch(statement, *args)
+    finally:
+        await conn.close()
+
+
+def fetch(url, statement, *args):
+    return asyncio.run(_fetch(url, statement, *args))
+
+
+async def _execute(url, statement, *args):
+    conn = await asyncpg.connect(_harness.asyncpg_dsn(url))
+    try:
+        return await conn.execute(statement, *args)
+    finally:
+        await conn.close()
+
+
+def sql(url, statement, *args):
+    return asyncio.run(_execute(url, statement, *args))
+
+
+# --------------------------------------------------------------------------
+# 1. The recording guard's three branches
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("db", ["020"], indirect=True)
+def test_a_pre_021_database_warns_loudly_and_still_succeeds(db, tmp_path):
+    """The bootstrap deploy, exactly: `make deploy` backs up **before** it
+    migrates, so the dump that ships 021 runs against a database with no
+    `backups_log`. Failing here would abort the deploy that creates the table —
+    a bookkeeping row blocking a disaster-recovery step."""
+    result, dump = run_record(db, tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert ABSENT_WARNING in result.stdout
+    assert dump.exists(), "the dump itself is untouched by the recording step"
+
+
+def test_a_successful_record_lands_the_row_the_page_reads(db, tmp_path):
+    contents = b"x" * 4242
+    result, dump = run_record(db, tmp_path, contents=contents)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    rows = fetch(db, "SELECT filename, size_bytes, created_at FROM backups_log")
+    assert len(rows) == 1
+    # The **basename**, never the path: the backups directory is a
+    # deployment-local constant and a host path does not belong in a shared
+    # table.
+    assert rows[0]["filename"] == dump.name
+    assert "/" not in rows[0]["filename"]
+    assert rows[0]["size_bytes"] == len(contents)
+    assert rows[0]["created_at"] is not None
+
+
+def test_a_failing_insert_fails_the_target_loudly(db, tmp_path):
+    """Once the table exists the disposition inverts. The panel reports the
+    newest row as the age of the last backup, so a dump that silently failed to
+    record itself makes the page claim a staler safety net than there is."""
+    sql(
+        db,
+        "CREATE FUNCTION _refuse_backup_row() RETURNS trigger AS $$ "
+        "BEGIN RAISE EXCEPTION 'no room at the inn'; END $$ LANGUAGE plpgsql",
+    )
+    sql(
+        db,
+        "CREATE TRIGGER _refuse_backup_row BEFORE INSERT ON backups_log "
+        "FOR EACH ROW EXECUTE FUNCTION _refuse_backup_row()",
+    )
+
+    result, _dump = run_record(db, tmp_path)
+
+    assert result.returncode != 0, "a failed record must fail the backup target"
+    combined = result.stdout + result.stderr
+    assert "Backup RECORDING FAILED" in combined
+    assert "no room at the inn" in combined, "the database's own reason is surfaced"
+    assert ABSENT_WARNING not in combined, (
+        "a failed insert must never be reported as the benign absent-table case"
+    )
+    assert fetch(db, "SELECT count(*) AS n FROM backups_log")[0]["n"] == 0
+
+
+def test_a_probe_that_cannot_answer_fails_rather_than_warning(db, tmp_path):
+    """Neither branch: the database answered a full `pg_dump` through this exact
+    channel seconds earlier, so a `psql` that cannot run one catalog lookup is a
+    fault. Guessing "the table is probably absent" would convert every such
+    fault into the benign warning."""
+    result, _dump = run_record(db, tmp_path, db_name="no_such_database_here")
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "could not ask the database" in combined
+    assert ABSENT_WARNING not in combined
+
+
+def test_a_zero_byte_dump_cannot_be_recorded_as_a_backup(db, tmp_path):
+    """`db-backup` refuses an empty dump before it ever gets here; the CHECK is
+    that refusal made true of the database rather than of one shell script."""
+    result, _dump = run_record(db, tmp_path, contents=b"")
+
+    assert result.returncode != 0
+    assert "ck_backups_log_size_bytes" in result.stdout + result.stderr
+    assert fetch(db, "SELECT count(*) AS n FROM backups_log")[0]["n"] == 0
+
+
+# --------------------------------------------------------------------------
+# 2. The read the page performs
+# --------------------------------------------------------------------------
+
+
+def _latest(url):
+    """`ops_health.latest_backup` over a real session."""
+    import sys
+
+    if str(REPO) not in sys.path:
+        sys.path.insert(0, str(REPO))
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from src.services.ops_health import latest_backup
+
+    async def _go():
+        engine = create_async_engine(url)
+        try:
+            async with async_sessionmaker(engine, expire_on_commit=False)() as session:
+                return await latest_backup(session)
+        finally:
+            await engine.dispose()
+
+    return asyncio.run(_go())
+
+
+@pytest.mark.parametrize("db", ["020"], indirect=True)
+def test_the_read_survives_a_database_without_the_table(db):
+    """The same pre-021 database the guard warns on. A page that 500s here is a
+    page nobody can use to find out why their deploy went wrong."""
+    assert _latest(db) is None
+
+
+def test_the_read_returns_the_newest_row_with_its_age(db):
+    old = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=40)
+    recent = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=2)
+    sql(
+        db,
+        "INSERT INTO backups_log (created_at, filename, size_bytes) "
+        "VALUES ($1, 'older.sql.gz', 10), ($2, 'newer.sql.gz', 20)",
+        old,
+        recent,
+    )
+    backup = _latest(db)
+    assert backup["filename"] == "newer.sql.gz"
+    assert backup["age_days"] == 2
+    assert backup["stale"] is False
+
+
+def test_a_backup_older_than_the_threshold_reads_as_stale(db):
+    sql(
+        db,
+        "INSERT INTO backups_log (created_at, filename, size_bytes) VALUES "
+        "($1, 'ancient.sql.gz', 10)",
+        datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=40),
+    )
+    backup = _latest(db)
+    assert backup["stale"] is True
+    assert backup["age_days"] == 40
+
+
+def test_an_empty_table_reads_as_nothing_recorded(db):
+    assert _latest(db) is None

--- a/tests/integration/test_issue_163_ops_health_pg.py
+++ b/tests/integration/test_issue_163_ops_health_pg.py
@@ -76,6 +76,29 @@ def _dbname(url: str) -> str:
     return unquote(urlsplit(url).path).lstrip("/")
 
 
+def _noisy_docker_shim(tmp_path):
+    """As `_docker_shim`, but the "server" also writes a warning to stderr.
+
+    Exactly what a healthy PostgreSQL does after a libc upgrade — the
+    collation-version mismatch notice is emitted on connection. The value on
+    stdout is still a perfectly good `t`.
+    """
+    bindir = tmp_path / "noisy-bin"
+    bindir.mkdir(exist_ok=True)
+    shim = bindir / "docker"
+    shim.write_text(
+        "#!/bin/bash\n"
+        'echo "WARNING: database \\"x\\" has a collation version mismatch" >&2\n'
+        'if [ "$1" != "exec" ]; then exit 99; fi\n'
+        "shift\n"
+        'while [ $# -gt 0 ] && [ "${1:0:1}" = "-" ]; do shift; done\n'
+        "shift\n"
+        'exec "$@"\n'
+    )
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return bindir
+
+
 def _docker_shim(tmp_path):
     """A `docker` on PATH that runs `docker exec <name> <cmd…>` as `<cmd…>`.
 
@@ -102,11 +125,11 @@ def _docker_shim(tmp_path):
     return bindir
 
 
-def run_record(url, tmp_path, *, contents=b"fake dump bytes", db_name=None):
+def run_record(url, tmp_path, *, contents=b"fake dump bytes", db_name=None, noisy=False):
     """Run `docker/record-backup.sh` against `url`'s database."""
     dump = tmp_path / "backup_20260829_031500.sql.gz"
     dump.write_bytes(contents)
-    bindir = _docker_shim(tmp_path)
+    bindir = _noisy_docker_shim(tmp_path) if noisy else _docker_shim(tmp_path)
     env = {
         **os.environ,
         **_pg_env(url),
@@ -207,6 +230,85 @@ def test_a_failing_insert_fails_the_target_loudly(db, tmp_path):
         "a failed insert must never be reported as the benign absent-table case"
     )
     assert fetch(db, "SELECT count(*) AS n FROM backups_log")[0]["n"] == 0
+
+
+def test_a_server_warning_on_stderr_does_not_look_like_a_missing_table(db, tmp_path):
+    """The BLOCKER this guard was rewritten for. A healthy server writes
+    warnings to stderr — a collation-version mismatch after a libc upgrade is
+    emitted on connection. Folded into stdout the probe's value becomes
+    `WARNING: …\\nt`, which is not the string `t`, and the absent-table branch
+    then exits 0 without recording anything. Forever, on a table that exists."""
+    result, dump = run_record(db, tmp_path, noisy=True)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert ABSENT_WARNING not in result.stdout, (
+        "a warning on stderr must not be read as 'the table is absent'"
+    )
+    rows = fetch(db, "SELECT filename FROM backups_log")
+    assert [r["filename"] for r in rows] == [dump.name], (
+        "the row must land despite the noise on stderr"
+    )
+
+
+def test_an_unrecognised_probe_answer_fails_rather_than_being_guessed_at(db, tmp_path):
+    """Neither `t` nor `f` on a successful exit means the value being read is
+    not the value that was asked for. Classifying that as 'absent' is how a
+    healthy database silently stops recording backups while the target keeps
+    exiting 0, so it fails instead."""
+    bindir = tmp_path / "liar-bin"
+    bindir.mkdir()
+    shim = bindir / "docker"
+    shim.write_text("#!/bin/bash\necho 'surprise banner'\nexit 0\n")
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    dump = tmp_path / "backup_20260829_031500.sql.gz"
+    dump.write_bytes(b"bytes")
+    result = subprocess.run(
+        ["bash", SCRIPT, str(dump)],
+        env={
+            **os.environ,
+            **_pg_env(db),
+            "PATH": f"{bindir}:{os.environ['PATH']}",
+            "DB_CONTAINER": "pretend-postgres",
+            "DB_NAME": _dbname(db),
+        },
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "neither 't' nor 'f'" in combined
+    assert ABSENT_WARNING not in combined
+    assert fetch(db, "SELECT count(*) AS n FROM backups_log")[0]["n"] == 0
+
+
+def test_the_row_lands_in_public_even_when_search_path_points_elsewhere(db, tmp_path):
+    """An unqualified INSERT resolves through `search_path`. With a decoy table
+    of the same name earlier on the path, an unqualified writer records into it
+    while the panel — which reads `public.backups_log` — never sees the row, and
+    the target reports success either way."""
+    sql(db, "CREATE SCHEMA decoy")
+    sql(
+        db,
+        "CREATE TABLE decoy.backups_log (id serial PRIMARY KEY, "
+        " created_at timestamptz NOT NULL DEFAULT now(), filename text NOT NULL, "
+        " size_bytes bigint NOT NULL)",
+    )
+    sql(db, f'ALTER DATABASE "{_dbname(db)}" SET search_path TO decoy, public')
+
+    result, dump = run_record(db, tmp_path)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert fetch(db, "SELECT count(*) AS n FROM decoy.backups_log")[0]["n"] == 0, (
+        "the decoy must stay empty"
+    )
+    rows = fetch(db, "SELECT filename FROM public.backups_log")
+    assert [r["filename"] for r in rows] == [dump.name]
+
+    # And the panel's own read finds it, for the same reason.
+    assert _latest(db)["filename"] == dump.name
 
 
 def test_a_probe_that_cannot_answer_fails_rather_than_warning(db, tmp_path):

--- a/tests/integration/test_schema_check.py
+++ b/tests/integration/test_schema_check.py
@@ -60,7 +60,7 @@ DIM = 64  # irrelevant here; keeps the migration cheap.
 # The current head. Every case that migrates forward asserts it, so adding a
 # revision without teaching this module about it fails loudly rather than
 # leaving the new migration unexercised.
-HEAD_REVISION = "020"
+HEAD_REVISION = "021"
 
 CONSTRAINT = "ck_oauth_clients_auth_method_secret"
 MARKER = "created by 013_schema_reconciliation"
@@ -3514,3 +3514,277 @@ def test_downgrade_020_refuses_a_counter_table_it_did_not_create():
         assert "020's comment marker" in result.stdout + result.stderr
         # And the column it would have dropped next is still there.
         assert daily_limit_comment(url) == QUOTA_COLUMN_MARKER
+
+
+# --------------------------------------------------------------------------
+# migration 021 — the backup record (#163)
+# --------------------------------------------------------------------------
+#
+# One table, and what makes it load-bearing is not its shape but what the panel
+# says about its newest row: "your last database backup was taken N days ago".
+# That is a claim about disaster recovery, so the ways it can be quietly wrong
+# are the cases below.
+#
+#   * `created_at` must be NOT NULL. A nullable one sorts to nowhere under
+#     `ORDER BY created_at DESC`, so a NULL row can hide every later backup and
+#     the page reports the one before it — or none. `alembic check` sees the
+#     nullability, which is why the interesting cases here are the two it does
+#     not see.
+#   * `ck_backups_log_size_bytes` must be the real predicate and `convalidated`.
+#     A same-named `CHECK (true)` is issue #53 exactly, and the value it lets
+#     through — a zero-byte dump — is precisely the failure `db-backup`'s
+#     empty-dump guard exists for, rendered on the page as a backup.
+#   * `ix_backups_log_created_at` must be on `created_at`. An index of that name
+#     recreated on `filename` keeps the name an existence check looks for while
+#     the newest-first read the page and the dashboard strip both perform has
+#     nothing to lean on, and autogenerate reports no drift at all.
+
+BACKUPS_TABLE_MARKER = "one row per recorded database backup (021_backups_log)"
+BACKUPS_CHECK_NAME = "ck_backups_log_size_bytes"
+BACKUPS_INDEX = "ix_backups_log_created_at"
+
+
+def backups_log_comment(url):
+    return fetchval(
+        url,
+        "SELECT obj_description(c.oid, 'pg_class') FROM pg_class c "
+        "WHERE c.relname = 'backups_log' AND c.relkind = 'r'",
+    )
+
+
+def backups_size_check(url):
+    """`(constraintdef, convalidated)` for 021's CHECK, or None."""
+    rows = fetch(
+        url,
+        "SELECT pg_get_constraintdef(oid) AS def, convalidated "
+        "FROM pg_constraint "
+        "WHERE conrelid = 'backups_log'::regclass AND contype = 'c' "
+        "  AND conname = $1",
+        BACKUPS_CHECK_NAME,
+    )
+    if not rows:
+        return None
+    return " ".join(rows[0]["def"].split()), rows[0]["convalidated"]
+
+
+def backups_index_columns(url, name=BACKUPS_INDEX):
+    return fetchval(
+        url,
+        "SELECT array_agg(a.attname ORDER BY k.ord) "
+        "FROM pg_index i JOIN pg_class ic ON ic.oid = i.indexrelid "
+        "     CROSS JOIN unnest(string_to_array(i.indkey::text, ' ')) "
+        "                WITH ORDINALITY AS k(attnum, ord) "
+        "     JOIN pg_attribute a ON a.attrelid = i.indrelid "
+        "                        AND a.attnum = k.attnum::smallint "
+        "WHERE i.indrelid = 'backups_log'::regclass AND ic.relname = $1 "
+        "GROUP BY ic.relname",
+        name,
+    )
+
+
+def insert_backup(url, filename="backup_20260829_120000.sql.gz", size=4096, when=None):
+    """One `backups_log` row, the way `docker/record-backup.sh` writes it."""
+    if when is None:
+        return fetchval(
+            url,
+            "INSERT INTO backups_log (filename, size_bytes) VALUES ($1, $2) "
+            "RETURNING id",
+            filename,
+            size,
+        )
+    return fetchval(
+        url,
+        "INSERT INTO backups_log (created_at, filename, size_bytes) "
+        "VALUES ($1, $2, $3) RETURNING id",
+        when,
+        filename,
+        size,
+    )
+
+
+def refuse_021(url, *, must_mention):
+    """Stamp back to 020, re-run 021, require it to refuse, return the message.
+
+    The same stamp-back path `make test-schema` exercises for idempotence, so a
+    verifier that waved a mutation through here would wave it through on a real
+    database somebody had altered by hand.
+    """
+    _harness.run_alembic(url, "stamp", "020", dimensions=DIM)
+    result = _harness.run_alembic(url, "upgrade", "head", dimensions=DIM, check=False)
+    assert result.returncode != 0, "021 should have refused"
+    combined = result.stdout + result.stderr
+    for phrase in must_mention:
+        assert phrase in combined, f"refusal did not mention {phrase!r}:\n{combined}"
+    return combined
+
+
+def test_021_creates_the_table_it_promises():
+    with throwaway_db("schema_backups_fresh") as url:
+        assert alembic_version(url) == HEAD_REVISION
+
+        assert backups_log_comment(url) == BACKUPS_TABLE_MARKER
+
+        # NOT NULL on `created_at` is what makes the newest-first read mean
+        # anything; the size column is bigint because a dump passes 2 GiB
+        # without anything having gone wrong.
+        assert column_shape(url, "backups_log", "created_at")[0] is True
+        assert column_shape(url, "backups_log", "filename") == (True, "text", None)
+        assert column_shape(url, "backups_log", "size_bytes")[:2] == (True, "bigint")
+
+        rendered, validated = backups_size_check(url)
+        assert validated is True
+        assert "size_bytes" in rendered
+
+        assert backups_index_columns(url) == ["created_at"]
+
+        check = _harness.run_alembic(url, "check", dimensions=DIM, check=False)
+        assert check.returncode == 0, (
+            f"alembic check reported drift\n{check.stdout}\n{check.stderr}"
+        )
+
+
+def test_the_size_check_rejects_a_zero_byte_backup():
+    """The catalog says the constraint is there; this proves it enforces.
+
+    `pg_dump` can write nothing and exit 0 when it is pointed at the wrong
+    thing — that is why `db-backup` has an empty-dump guard at all. A row of
+    size 0 is that failure recorded as a backup and rendered on the page as
+    one.
+    """
+    with throwaway_db("schema_backups_domain") as url:
+        insert_backup(url, size=1)
+        for illegal in (0, -1):
+            with pytest.raises(asyncpg.CheckViolationError):
+                insert_backup(url, filename=f"bad-{illegal}.sql.gz", size=illegal)
+
+
+def test_the_newest_row_is_what_the_page_reads():
+    """The read the health page and the dashboard strip both perform, run
+    against the real ordering rather than argued about."""
+    with throwaway_db("schema_backups_newest") as url:
+        old = datetime.datetime(2026, 1, 1, tzinfo=datetime.timezone.utc)
+        new = datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc)
+        insert_backup(url, filename="older.sql.gz", when=old)
+        insert_backup(url, filename="newer.sql.gz", when=new)
+        assert fetchval(
+            url,
+            "SELECT filename FROM backups_log ORDER BY created_at DESC, id DESC "
+            "LIMIT 1",
+        ) == "newer.sql.gz"
+
+
+def test_rerunning_021_adopts_its_own_table_and_keeps_the_rows():
+    """The idempotence path the gate itself performs: 021 genuinely re-executes
+    against a database already carrying its table, and no backup record is
+    lost."""
+    with throwaway_db("schema_backups_rerun") as url:
+        insert_backup(url, filename="kept.sql.gz", size=99)
+        _harness.run_alembic(url, "stamp", "020", dimensions=DIM)
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+
+        assert alembic_version(url) == HEAD_REVISION
+        assert fetchval(url, "SELECT filename FROM backups_log") == "kept.sql.gz"
+        assert backups_log_comment(url) == BACKUPS_TABLE_MARKER
+
+
+def test_021_refuses_an_unmarked_table_of_its_name():
+    """`IF NOT EXISTS` would adopt this — nullable `created_at`, no CHECK, no
+    index — and the panel would report its rows as backup history."""
+    with throwaway_db("schema_backups_unmarked", revision="020") as url:
+        sql(
+            url,
+            "CREATE TABLE backups_log (id serial PRIMARY KEY, "
+            " created_at timestamptz, filename text, size_bytes bigint)",
+        )
+        result = _harness.run_alembic(
+            url, "upgrade", "head", dimensions=DIM, check=False
+        )
+        assert result.returncode != 0
+        assert "021's comment marker" in result.stdout + result.stderr
+
+
+def test_021_refuses_a_nullable_created_at():
+    """A NULL `created_at` sorts to nowhere under `ORDER BY created_at DESC`,
+    so one such row can hide every backup taken after it."""
+    with throwaway_db("schema_backups_nullable") as url:
+        sql(url, "ALTER TABLE backups_log ALTER COLUMN created_at DROP NOT NULL")
+        refuse_021(url, must_mention=["its columns are", "created_at"])
+
+
+def test_021_refuses_an_impostor_check_of_its_name():
+    """A same-named `CHECK (true)` satisfies a lookup by name and enforces
+    nothing (issue #53). The predicate is compared, not the name."""
+    with throwaway_db("schema_backups_impostor_check") as url:
+        sql(url, f"ALTER TABLE backups_log DROP CONSTRAINT {BACKUPS_CHECK_NAME}")
+        sql(
+            url,
+            f"ALTER TABLE backups_log ADD CONSTRAINT {BACKUPS_CHECK_NAME} CHECK (true)",
+        )
+        refuse_021(url, must_mention=["its CHECK is"])
+        # A zero-byte backup really is admitted while the impostor stands —
+        # which is the whole reason the predicate is compared, not the name.
+        insert_backup(url, filename="empty.sql.gz", size=0)
+
+
+def test_021_refuses_a_not_valid_check():
+    """`NOT VALID` enforces new rows having never checked the existing ones, so
+    the table may already record a zero-byte backup."""
+    with throwaway_db("schema_backups_notvalid_check") as url:
+        sql(url, f"ALTER TABLE backups_log DROP CONSTRAINT {BACKUPS_CHECK_NAME}")
+        sql(
+            url,
+            f"ALTER TABLE backups_log ADD CONSTRAINT {BACKUPS_CHECK_NAME} "
+            "CHECK (size_bytes >= 1) NOT VALID",
+        )
+        refuse_021(url, must_mention=["NOT VALID"])
+
+
+def test_021_refuses_a_missing_check():
+    with throwaway_db("schema_backups_no_check") as url:
+        sql(url, f"ALTER TABLE backups_log DROP CONSTRAINT {BACKUPS_CHECK_NAME}")
+        refuse_021(url, must_mention=["no size CHECK"])
+
+
+def test_021_refuses_an_index_of_its_name_on_another_column():
+    """Names are not definitions: an index of the right name on `filename`
+    leaves the newest-first read with nothing to lean on, and autogenerate
+    reports no drift at all."""
+    with throwaway_db("schema_backups_index") as url:
+        sql(url, f"DROP INDEX {BACKUPS_INDEX}")
+        sql(url, f"CREATE INDEX {BACKUPS_INDEX} ON backups_log (filename)")
+        refuse_021(url, must_mention=[BACKUPS_INDEX, "filename"])
+
+
+def test_021_refuses_a_missing_index():
+    with throwaway_db("schema_backups_no_index") as url:
+        sql(url, f"DROP INDEX {BACKUPS_INDEX}")
+        refuse_021(url, must_mention=[f"missing index {BACKUPS_INDEX}"])
+
+
+def test_downgrade_021_removes_the_table_and_upgrade_rebuilds_it():
+    with throwaway_db("schema_backups_downgrade") as url:
+        _harness.run_alembic(url, "downgrade", "020", dimensions=DIM)
+        assert alembic_version(url) == "020"
+        assert fetchval(url, "SELECT to_regclass('backups_log')") is None
+
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+        assert alembic_version(url) == HEAD_REVISION
+        assert backups_log_comment(url) == BACKUPS_TABLE_MARKER
+        assert backups_index_columns(url) == ["created_at"]
+        check = _harness.run_alembic(url, "check", dimensions=DIM, check=False)
+        assert check.returncode == 0, (
+            f"alembic check reported drift\n{check.stdout}\n{check.stderr}"
+        )
+
+
+def test_downgrade_021_refuses_a_table_it_did_not_create():
+    """013's rule on the way back down: undo *this* migration, not delete a
+    table somebody else put there under this name."""
+    with throwaway_db("schema_backups_downgrade_foreign") as url:
+        sql(url, "COMMENT ON TABLE backups_log IS 'somebody else made this'")
+        result = _harness.run_alembic(
+            url, "downgrade", "020", dimensions=DIM, check=False
+        )
+        assert result.returncode != 0
+        assert "021's comment marker" in result.stdout + result.stderr
+        assert fetchval(url, "SELECT to_regclass('backups_log')") is not None

--- a/tests/integration/test_schema_check.py
+++ b/tests/integration/test_schema_check.py
@@ -3548,7 +3548,8 @@ def backups_log_comment(url):
     return fetchval(
         url,
         "SELECT obj_description(c.oid, 'pg_class') FROM pg_class c "
-        "WHERE c.relname = 'backups_log' AND c.relkind = 'r'",
+        "WHERE c.relname = 'backups_log' AND c.relkind = 'r' "
+        "  AND c.relnamespace = 'public'::regnamespace",
     )
 
 
@@ -3558,7 +3559,7 @@ def backups_size_check(url):
         url,
         "SELECT pg_get_constraintdef(oid) AS def, convalidated "
         "FROM pg_constraint "
-        "WHERE conrelid = 'backups_log'::regclass AND contype = 'c' "
+        "WHERE conrelid = 'public.backups_log'::regclass AND contype = 'c' "
         "  AND conname = $1",
         BACKUPS_CHECK_NAME,
     )
@@ -3589,7 +3590,7 @@ def backups_index_columns(url, name=BACKUPS_INDEX):
         "                WITH ORDINALITY AS k(attnum, ord) "
         "     JOIN pg_attribute a ON a.attrelid = i.indrelid "
         "                        AND a.attnum = k.attnum::smallint "
-        "WHERE i.indrelid = 'backups_log'::regclass AND ic.relname = $1 "
+        "WHERE i.indrelid = 'public.backups_log'::regclass AND ic.relname = $1 "
         "GROUP BY ic.relname",
         name,
     )
@@ -3826,6 +3827,61 @@ def test_021_refuses_an_id_that_no_longer_draws_from_its_sequence():
     with throwaway_db("schema_backups_id_default") as url:
         sql(url, "ALTER TABLE backups_log ALTER COLUMN id DROP DEFAULT")
         refuse_021(url, must_mention=["id"])
+
+
+def test_021_creates_in_public_under_a_redirected_search_path():
+    """The migration itself run with `search_path` pointing somewhere else.
+
+    Unqualified DDL resolves through `search_path`, so without the pin
+    `op.create_table` would put the table in `decoy` — where
+    `docker/record-backup.sh` (which INSERTs into `public.backups_log`) and the
+    panel (which SELECTs from it) would never find it. The failure is silent in
+    the worst direction: the target records backups into a table the page never
+    reads, so the page warns that none have been taken while one is taken daily.
+
+    The pin is `SET LOCAL search_path TO public`, which is transaction-scoped —
+    and `alembic/env.py` runs every pending revision inside one transaction, the
+    same property 013 through 020 rely on for `lock_timeout`. This case is what
+    proves that holds in this environment rather than asserting it.
+    """
+    with throwaway_db("schema_backups_path", revision="020") as url:
+        dbname = fetchval(url, "SELECT current_database()")
+        sql(url, "CREATE SCHEMA decoy")
+        sql(url, f'ALTER DATABASE "{dbname}" SET search_path TO decoy, public')
+        # A *new* connection is what alembic will open, so confirm the redirect
+        # is actually in force for one before believing the rest of this case.
+        assert fetchval(url, "SHOW search_path") == "decoy, public"
+
+        _harness.run_alembic(url, "upgrade", "head", dimensions=DIM)
+
+        assert alembic_version(url) == HEAD_REVISION
+        assert fetchval(url, "SELECT to_regclass('public.backups_log')") is not None
+        assert fetchval(url, "SELECT to_regclass('decoy.backups_log')") is None, (
+            "the table must land where the writer and the panel look, not first "
+            "on the search path"
+        )
+        # The index and the comment are separate unqualified statements, so
+        # they are checked separately rather than assumed to have followed.
+        assert backups_log_comment(url) == BACKUPS_TABLE_MARKER
+        assert backups_index_columns(url) == ["created_at"]
+        assert backups_pk(url) == ["id"]
+        assert fetchval(
+            url,
+            "SELECT count(*) FROM pg_class c "
+            "WHERE c.relnamespace = 'decoy'::regnamespace",
+        ) == 0, "nothing at all was created in the decoy schema"
+
+        # The pin is `SET LOCAL`, so it must not have outlived the transaction.
+        assert fetchval(url, "SHOW search_path") == "decoy, public"
+
+        check = _harness.run_alembic(url, "check", dimensions=DIM, check=False)
+        assert check.returncode == 0, (
+            f"alembic check reported drift\n{check.stdout}\n{check.stderr}"
+        )
+
+        # And the downgrade drops from public, not from wherever the path points.
+        _harness.run_alembic(url, "downgrade", "020", dimensions=DIM)
+        assert fetchval(url, "SELECT to_regclass('public.backups_log')") is None
 
 
 def test_downgrade_021_removes_the_table_and_upgrade_rebuilds_it():

--- a/tests/integration/test_schema_check.py
+++ b/tests/integration/test_schema_check.py
@@ -3567,6 +3567,19 @@ def backups_size_check(url):
     return " ".join(rows[0]["def"].split()), rows[0]["convalidated"]
 
 
+def backups_pk(url):
+    """The PK's columns in order, or None when there is no primary key."""
+    return fetchval(
+        url,
+        "SELECT (SELECT array_agg(a.attname ORDER BY k.ord) "
+        "          FROM unnest(c.conkey) WITH ORDINALITY AS k(attnum, ord) "
+        "          JOIN pg_attribute a ON a.attrelid = c.conrelid "
+        "                             AND a.attnum = k.attnum) "
+        "FROM pg_constraint c "
+        "WHERE c.conrelid = 'public.backups_log'::regclass AND c.contype = 'p'",
+    )
+
+
 def backups_index_columns(url, name=BACKUPS_INDEX):
     return fetchval(
         url,
@@ -3636,6 +3649,15 @@ def test_021_creates_the_table_it_promises():
         assert "size_bytes" in rendered
 
         assert backups_index_columns(url) == ["created_at"]
+
+        # The primary key and both server defaults — the three things
+        # `alembic check` compares not at all (it does not look at primary
+        # keys, and `compare_server_default` is off by default), so they are
+        # asserted here or nowhere.
+        assert backups_pk(url) == ["id"]
+        assert column_shape(url, "backups_log", "created_at")[2] == "now()"
+        id_default = column_shape(url, "backups_log", "id")[2]
+        assert id_default is not None and id_default.startswith("nextval(")
 
         check = _harness.run_alembic(url, "check", dimensions=DIM, check=False)
         assert check.returncode == 0, (
@@ -3759,6 +3781,51 @@ def test_021_refuses_a_missing_index():
     with throwaway_db("schema_backups_no_index") as url:
         sql(url, f"DROP INDEX {BACKUPS_INDEX}")
         refuse_021(url, must_mention=[f"missing index {BACKUPS_INDEX}"])
+
+
+def test_021_refuses_a_tampered_created_at_default():
+    """The quietest mutation this table has. Every column, type, nullability,
+    constraint and index stays exactly as 021 made it — `alembic check` does
+    not compare server defaults at all — and every backup recorded afterwards
+    reads as permanently fresh, so the staleness warning the whole feature
+    exists to raise can never fire again."""
+    with throwaway_db("schema_backups_default") as url:
+        sql(
+            url,
+            "ALTER TABLE backups_log ALTER COLUMN created_at "
+            "SET DEFAULT now() + interval '100 years'",
+        )
+        # `alembic check` is genuinely happy with this, which is the point.
+        check = _harness.run_alembic(url, "check", dimensions=DIM, check=False)
+        assert check.returncode == 0, (
+            "if autogenerate ever starts seeing this, say so here rather than "
+            "leaving the migration's own comparison unexplained"
+        )
+        combined = refuse_021(url, must_mention=["created_at default", "now()"])
+        assert "staleness" in combined
+
+        # And it really would have made a fresh backup read as a future one.
+        insert_backup(url, filename="future.sql.gz")
+        assert fetchval(
+            url, "SELECT created_at > now() + interval '50 years' FROM backups_log"
+        ) is True
+
+
+def test_021_refuses_a_missing_primary_key():
+    """Autogenerate does not compare primary keys, so a table whose PK has been
+    dropped reports as being in perfect agreement with the model — while `id`
+    is no longer unique and the newest-row read has lost its tie-break."""
+    with throwaway_db("schema_backups_no_pk") as url:
+        sql(url, "ALTER TABLE backups_log DROP CONSTRAINT backups_log_pkey")
+        assert backups_pk(url) is None
+        combined = refuse_021(url, must_mention=["no primary key"])
+        assert "tie-break" in combined
+
+
+def test_021_refuses_an_id_that_no_longer_draws_from_its_sequence():
+    with throwaway_db("schema_backups_id_default") as url:
+        sql(url, "ALTER TABLE backups_log ALTER COLUMN id DROP DEFAULT")
+        refuse_021(url, must_mention=["id"])
 
 
 def test_downgrade_021_removes_the_table_and_upgrade_rebuilds_it():

--- a/tests/test_issue_163_ops_health.py
+++ b/tests/test_issue_163_ops_health.py
@@ -509,6 +509,26 @@ def test_the_writer_and_the_reader_name_the_same_qualified_table():
     assert '{"table": TABLE}' not in migration, (
         "every catalog lookup resolves the qualified name"
     )
+    # The DDL itself is unqualified on purpose — a schema-qualified table does
+    # not match a model that declares none, and `alembic check` would report
+    # drift forever after. What makes it land in public is the pin.
+    assert "SET LOCAL search_path TO public" in migration
+    assert migration.count("RESET search_path") >= 2, (
+        "both upgrade() and downgrade() must reset it: alembic runs every "
+        "pending revision in one transaction, so SET LOCAL would leak"
+    )
+    # No `op.*` call may carry a `schema=` keyword. Checked on the parse tree,
+    # not the text: the docstring above explains at length why it must not,
+    # and a substring search would match that explanation.
+    import ast
+
+    schema_kwargs = [
+        node
+        for node in ast.walk(ast.parse(migration))
+        if isinstance(node, ast.Call)
+        and any(kw.arg == "schema" for kw in node.keywords)
+    ]
+    assert schema_kwargs == []
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_issue_163_ops_health.py
+++ b/tests/test_issue_163_ops_health.py
@@ -1,0 +1,678 @@
+"""The health page, the error ring buffer, and backup recency (#163).
+
+Hermetic: no database, no container. What a real PostgreSQL has to answer —
+does the `backups_log` row round-trip, does the Makefile guard take the branch
+it claims — is `tests/integration/test_issue_163_ops_health_pg.py` and
+`tests/integration/test_schema_check.py`. What is pinned here is what breaks
+silently:
+
+* **The buffer is bounded and cannot raise.** It sits on the root logger, so it
+  runs inside every `logger.error(...)` in the process — including the ones in
+  exception handlers, where a second exception is the last thing anybody wants.
+* **The observation window renders beside the count, always.** "No errors"
+  without "since 14:32" is a claim about the server; what it means is "this
+  process has not failed yet", and a container restarted two minutes ago has an
+  empty buffer for reasons unrelated to health.
+* **Every section has an explicit empty state.** A fresh install has no passes,
+  no errors and no recorded backup, and that is the page an operator opens when
+  they are not sure the server works at all.
+* **Errors and backup age are admin-only.** Neither has an owner to scope by,
+  so the alternative to gating them is a non-admin reading other tenants' paths
+  out of a traceback.
+* **The migration's markers and its size floor are mirrored in the model.** A
+  drifted marker is a dirty `alembic check` and a `downgrade()` that has quietly
+  stopped recognising its own work.
+"""
+import asyncio
+import datetime
+import logging
+import os
+import re
+import tempfile
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+from src.control_panel import routes  # noqa: E402
+from src.services import error_log, ops_health  # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEMPLATES_DIR = os.path.join(HERE, "..", "src", "control_panel", "templates")
+
+
+@pytest.fixture(autouse=True)
+def _clean_buffer():
+    """Every case starts with an empty buffer and no attached handler."""
+    root = logging.getLogger()
+    error_log.detach(root)
+    error_log.reset()
+    yield
+    error_log.detach(root)
+    error_log.reset()
+
+
+# --------------------------------------------------------------------------
+# 1. The ring buffer
+# --------------------------------------------------------------------------
+
+
+def test_it_captures_errors_and_ignores_everything_below():
+    error_log.attach()
+    log = logging.getLogger("src.services.thing")
+    log.warning("a warning nobody needs on the page")
+    log.info("an info line")
+    log.error("the embed pass died")
+    log.critical("the dim guard refused to start")
+
+    entries = error_log.recent_errors()
+    assert [e["message"] for e in entries] == [
+        "the dim guard refused to start",
+        "the embed pass died",
+    ], "newest first, and nothing below ERROR"
+    assert entries[0]["level"] == "CRITICAL"
+    assert entries[1]["logger"] == "src.services.thing"
+    assert entries[0]["timestamp"].tzinfo is not None
+
+
+def test_only_the_first_line_of_a_traceback_shaped_message_is_kept():
+    """The page is a pointer, not a log viewer. A hundred multi-thousand-line
+    tracebacks rendered into one HTML page is a page nobody can read."""
+    error_log.attach()
+    logging.getLogger("src.mcp_server.tools").error(
+        "OperationalError: connection reset\n"
+        '  File "/app/src/x.py", line 12, in run\n'
+        "    await session.execute(stmt)"
+    )
+    entry = error_log.recent_errors()[0]
+    assert entry["message"] == "OperationalError: connection reset"
+    assert "File " not in entry["message"]
+
+
+def test_the_buffer_is_capped_and_evicts_the_oldest():
+    error_log.attach()
+    log = logging.getLogger("flood")
+    for i in range(error_log.ERROR_BUFFER_SIZE + 25):
+        log.error("error %d", i)
+
+    entries = error_log.recent_errors()
+    assert len(entries) == error_log.ERROR_BUFFER_SIZE == 100
+    assert error_log.error_count() == 100
+    assert error_log.is_full() is True
+    # Newest first, and the first 25 are gone rather than the last 25.
+    assert entries[0]["message"] == "error 124"
+    assert entries[-1]["message"] == "error 25"
+
+
+def test_a_record_whose_format_arguments_are_wrong_does_not_raise():
+    """This handler runs inside every `logger.error(...)` in the process,
+    including the ones in exception handlers. Raising there turns one error
+    into two at the point least able to cope.
+
+    The record is handed to the handler directly rather than logged: a
+    `%d` fed a string makes *pytest's own* capture handler raise first, which
+    would be a test of pytest rather than of this module.
+    """
+    handler = error_log.attach()
+    record = logging.LogRecord(
+        name="bad", level=logging.ERROR, pathname=__file__, lineno=1,
+        msg="%d items and %s", args=("not-an-int",), exc_info=None,
+    )
+    handler.emit(record)  # must not raise
+    entry = error_log.recent_errors()[0]
+    assert "%d items and %s" in entry["message"], (
+        "the fallback is the raw msg, which is still the identifying half"
+    )
+
+
+def test_attaching_twice_does_not_double_record():
+    root = logging.getLogger()
+    first = error_log.attach(root)
+    second = error_log.attach(root)
+    assert first is second
+    assert root.handlers.count(first) == 1
+    logging.getLogger("once").error("only once")
+    assert len(error_log.recent_errors()) == 1
+
+
+def test_the_observation_window_starts_at_attach_and_is_unknown_before():
+    assert error_log.observing_since() is None, (
+        "before the lifespan has attached anything, the page must say the "
+        "window is unknown rather than imply it has been watching"
+    )
+    before = datetime.datetime.now(datetime.timezone.utc)
+    error_log.attach()
+    since = error_log.observing_since()
+    assert since is not None and since >= before
+
+
+def test_entries_are_copies_so_a_reader_cannot_edit_the_buffer():
+    error_log.attach()
+    logging.getLogger("x").error("original")
+    error_log.recent_errors()[0]["message"] = "tampered"
+    assert error_log.recent_errors()[0]["message"] == "original"
+
+
+def test_the_lifespan_attaches_the_handler_before_the_sandbox_branch():
+    """A process that dies in a startup guard is exactly the one whose errors
+    an operator comes looking for, so the buffer must be live before any guard
+    can call `sys.exit`."""
+    import inspect
+
+    from src import main
+
+    source = inspect.getsource(main.lifespan)
+    attach_at = source.index("error_log.attach()")
+    sandbox_at = source.index("settings.mcp_sandbox_mode")
+    assert attach_at < sandbox_at
+
+
+# --------------------------------------------------------------------------
+# 2. Backup recency
+# --------------------------------------------------------------------------
+
+
+class _Row:
+    def __init__(self, **kw):
+        self.__dict__.update(kw)
+
+
+class _Result:
+    def __init__(self, scalar=None, first=None, rows=None):
+        self._scalar = scalar
+        self._first = first
+        self._rows = rows or []
+
+    def scalar(self):
+        return self._scalar
+
+    def first(self):
+        return self._first
+
+    def fetchall(self):
+        return self._rows
+
+
+class _BackupSession:
+    """Answers the two statements `latest_backup` issues, in order."""
+
+    def __init__(self, table_present=True, row=None, runs=None):
+        self.table_present = table_present
+        self.row = row
+        self.runs = runs or []
+        self.statements: list[str] = []
+
+    async def execute(self, statement, params=None):
+        text = str(statement)
+        self.statements.append(text)
+        if "to_regclass" in text:
+            return _Result(scalar="backups_log" if self.table_present else None)
+        if "FROM backups_log" in text:
+            return _Result(first=self.row)
+        if "indexer_runs" in text:
+            return _Result(rows=self.runs)
+        return _Result(scalar=0)
+
+
+def _backup_row(age_days=1.0, size=4096, filename="backup_20260829_020000.sql.gz"):
+    return _Row(
+        created_at=datetime.datetime.now(datetime.timezone.utc)
+        - datetime.timedelta(days=age_days),
+        filename=filename,
+        size_bytes=size,
+    )
+
+
+def test_a_pre_021_database_reads_as_no_backup_rather_than_a_500():
+    """`make deploy` backs up **before** it migrates, and a database can sit
+    below 021 for other reasons too. Reading a table that is not there would
+    take the whole page down."""
+    session = _BackupSession(table_present=False)
+    assert asyncio.run(ops_health.latest_backup(session)) is None
+    assert any("to_regclass" in s for s in session.statements), (
+        "the read must probe before it selects"
+    )
+    assert not any("FROM backups_log" in s for s in session.statements)
+
+
+def test_an_empty_table_reads_as_no_backup_too():
+    session = _BackupSession(table_present=True, row=None)
+    assert asyncio.run(ops_health.latest_backup(session)) is None
+
+
+def test_a_recorded_backup_carries_its_age_and_size():
+    session = _BackupSession(row=_backup_row(age_days=2, size=5 * 1024 * 1024))
+    backup = asyncio.run(ops_health.latest_backup(session))
+    assert backup["filename"] == "backup_20260829_020000.sql.gz"
+    assert backup["size_human"] == "5.0 MiB"
+    assert backup["age_days"] == 2
+    assert backup["stale"] is False
+
+
+@pytest.mark.parametrize(
+    "age_days,stale",
+    # Not exactly 8.0: the age is measured against `now()` at read time, so a
+    # row seeded exactly 8 days ago is a few microseconds over by the time the
+    # comparison runs. The threshold is strictly-greater, and 7.9/8.1 pin it
+    # without pinning a race.
+    [(0.0, False), (7.0, False), (7.9, False), (8.1, True), (30.0, True)],
+)
+def test_staleness_turns_over_at_eight_days(age_days, stale):
+    """Eight and not seven: a backup taken every Sunday is at most 7 days old
+    on a good week, and a 7-day threshold pages an operator every Saturday for
+    a schedule that is working."""
+    session = _BackupSession(row=_backup_row(age_days=age_days))
+    assert asyncio.run(ops_health.latest_backup(session))["stale"] is stale
+
+
+def test_a_missing_record_is_not_stale():
+    """Unknown is not overdue. Warning "stale" on a fresh install is a warning
+    about a backup nobody has failed to take yet."""
+    assert ops_health.is_stale(None) is False
+
+
+def test_human_size_is_base_1024():
+    assert ops_health.human_size(512) == "512 B"
+    assert ops_health.human_size(2048) == "2.0 KiB"
+    assert ops_health.human_size(3 * 1024**3) == "3.0 GiB"
+    assert ops_health.human_size(None) is None
+
+
+# --------------------------------------------------------------------------
+# 3. The model and the migration describe the same table
+# --------------------------------------------------------------------------
+
+
+def test_the_markers_and_the_size_floor_are_mirrored_byte_for_byte():
+    """A drifted marker is a dirty `alembic check` (the model declares the
+    table comment) *and* a `downgrade()` that has stopped recognising its own
+    work."""
+    import importlib.util
+
+    from src.models.db import BACKUP_MIN_SIZE_BYTES, BackupLog
+
+    path = os.path.join(HERE, "..", "alembic", "versions", "021_backups_log.py")
+    spec = importlib.util.spec_from_file_location("_m021", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert BackupLog._TABLE_MARKER == module.MARKER
+    assert BackupLog.__table_args__[-1]["comment"] == module.MARKER
+    assert BACKUP_MIN_SIZE_BYTES == module.MIN_SIZE_BYTES
+    assert module.TABLE == BackupLog.__tablename__
+    assert [c[0] for c in module.EXPECTED_COLUMNS] == [
+        c.name for c in BackupLog.__table__.columns
+    ]
+
+
+# --------------------------------------------------------------------------
+# 3b. The Makefile wiring the guard depends on
+# --------------------------------------------------------------------------
+#
+# What the guard *does* is exercised against real PostgreSQL in
+# `tests/integration/test_issue_163_ops_health_pg.py`. What is pinned here is
+# the wiring around it, because the reason the guard exists is an ordering fact
+# about `make deploy` that a future edit could silently reverse.
+
+
+def _makefile() -> str:
+    with open(os.path.join(HERE, "..", "Makefile")) as fh:
+        return fh.read()
+
+
+def test_deploy_still_backs_up_before_it_migrates():
+    """The whole reason the absent-table branch exists. If this ever inverts,
+    the bootstrap warning becomes dead code and the guard's disposition should
+    be revisited — not left as a comment describing an ordering that changed."""
+    make = _makefile()
+    body = make[make.index("\ndeploy:") : make.index("\nup:")]
+    # Commands only: the recipe's comments name both steps, in the other order.
+    deploy = "\n".join(
+        line for line in body.splitlines() if not line.strip().startswith("#")
+    )
+    assert deploy.index("db-backup") < deploy.index("alembic upgrade head")
+
+
+def test_db_backup_records_the_dump_and_its_status_is_the_targets():
+    """The recording call is the recipe's **last** command, so its exit status
+    is the target's: once the table exists, a backup that cannot record itself
+    fails the backup."""
+    make = _makefile()
+    recipe = make[make.index("\ndb-backup:") : make.index("\ndb-restore:")]
+    assert "docker/record-backup.sh" in recipe
+    # Passed the file that was actually written, and the container the dump
+    # itself used — the same channel, not a second one.
+    assert "$$BACKUP_FILE.gz" in recipe.split("record-backup.sh")[1].split("\n")[0]
+    assert "DB_CONTAINER=$(DB_CONTAINER)" in recipe
+    body = [line.strip() for line in recipe.strip().splitlines() if line.strip()]
+    assert "record-backup.sh" in body[-1], (
+        "the recording must be the last command in the recipe, or its failure "
+        "cannot fail the target"
+    )
+
+
+def test_the_recording_script_goes_through_docker_exec_psql():
+    """Same channel as `pg_dump`. A host-side script has no other handle on the
+    database, and inventing one (a direct connection, a mounted socket) is how
+    a public repo acquires a host-specific path."""
+    with open(os.path.join(HERE, "..", "docker", "record-backup.sh")) as fh:
+        script = fh.read()
+    assert 'docker exec -i "$DB_CONTAINER" psql' in script
+    assert "to_regclass('public.backups_log')" in script
+    assert "ON_ERROR_STOP=1" in script
+    # The filename and size travel as psql variables, not as interpolated
+    # shell text — and the SQL arrives on stdin, because psql does not
+    # interpolate `:'var'` into a `-c` command (it reaches the server as typed
+    # and is a syntax error there).
+    assert ":'filename'" in script and ":'size_bytes'" in script
+    assert "-c \"INSERT" not in script
+
+
+# --------------------------------------------------------------------------
+# 4. The page
+# --------------------------------------------------------------------------
+
+
+def _env():
+    from jinja2 import ChainableUndefined, ChoiceLoader, DictLoader, Environment, FileSystemLoader
+
+    return Environment(
+        loader=ChoiceLoader([
+            DictLoader({
+                "base.html":
+                    "{% block title %}{% endblock %}{% block content %}{% endblock %}"
+            }),
+            FileSystemLoader(TEMPLATES_DIR),
+        ]),
+        undefined=ChainableUndefined,
+        autoescape=True,
+    )
+
+
+def _run(**kw):
+    return dict({
+        "id": 7, "started_at": "2026-08-29T10:00:00+00:00", "duration": "12.4s",
+        "trigger": "scheduled", "user_id": None, "owner": None,
+        "owner_missing": False, "notes_scanned": 100, "notes_indexed": 3,
+        "notes_embedded": 3, "error": None,
+    }, **kw)
+
+
+def _render_health(**overrides):
+    ctx = dict(
+        active="health",
+        runs=[_run()],
+        runs_limit=ops_health.HEALTH_RUNS_LIMIT,
+        show_ops=True,
+        backup={
+            "created_at_iso": "2026-08-29T02:00:00+00:00",
+            "filename": "backup_20260829_020000.sql.gz",
+            "size_human": "5.0 MiB",
+            "age_rel": "9 hours ago",
+            "stale": False,
+        },
+        stale_after_days=ops_health.STALE_AFTER_DAYS,
+        errors=[{
+            "timestamp": "2026-08-29T09:59:00+00:00",
+            "logger": "src.services.indexer",
+            "level": "ERROR",
+            "message": "embed pass failed: connection reset",
+        }],
+        error_count=1,
+        errors_capped=False,
+        error_buffer_size=error_log.ERROR_BUFFER_SIZE,
+        observing_since_iso="2026-08-29T08:00:00+00:00",
+        observing_since_rel="2 hours ago",
+    )
+    ctx.update(overrides)
+    return _env().get_template("health.html").render(**ctx)
+
+
+def test_the_populated_page_renders_all_three_sections():
+    html = _render_health()
+    assert "backup_20260829_020000.sql.gz" in html
+    assert "5.0 MiB" in html
+    assert "embed pass failed: connection reset" in html
+    assert "src.services.indexer" in html
+    assert "Index passes" in html
+    assert 'id="run-7"' in html, "the strip links a failed pass to its row"
+
+
+def test_the_error_section_states_the_window_it_observed():
+    html = _render_health()
+    assert "Observing since process start" in html
+    assert "2026-08-29T08:00:00+00:00" in html
+    assert "2 hours ago" in html
+
+
+def test_a_fresh_install_renders_three_explicit_empty_states():
+    """No passes, no errors, no backup rows: the page an operator opens when
+    they are not sure the server works at all."""
+    html = _render_health(
+        runs=[], errors=[], error_count=0, backup=None,
+        observing_since_iso="2026-08-29T08:00:00+00:00",
+    )
+    assert "No backup recorded yet" in html
+    assert "No errors logged since this process started" in html
+    assert "No index or embed pass has been recorded yet" in html
+    # And it still says when it started observing — "no errors" alone is a
+    # claim about the server rather than about this process.
+    assert "Observing since process start" in html
+
+
+def test_an_unknown_observation_window_says_so():
+    html = _render_health(observing_since_iso=None, observing_since_rel=None,
+                          errors=[], error_count=0)
+    assert "Observation window unknown" in html
+
+
+def test_a_stale_backup_warns_and_names_the_threshold():
+    html = _render_health(backup={
+        "created_at_iso": "2026-08-01T02:00:00+00:00",
+        "filename": "backup_20260801_020000.sql.gz",
+        "size_human": "4.9 MiB",
+        "age_rel": "28 days ago",
+        "stale": True,
+    })
+    assert "stale" in html
+    assert f"more than {ops_health.STALE_AFTER_DAYS} days" in html
+    assert "make db-backup" in html
+
+
+def test_the_page_never_claims_the_backup_was_verified():
+    """Age is the whole signal: the panel cannot see the filesystem it reports
+    on, which is the reason the record is a database row at all."""
+    html = _render_health()
+    assert "does not verify" in html
+
+
+def test_a_capped_buffer_says_older_errors_were_evicted():
+    html = _render_health(errors_capped=True, error_count=100)
+    assert "have been evicted" in html
+
+
+def test_a_non_admin_sees_only_their_passes_and_is_told_why():
+    html = _render_health(show_ops=False, backup=None, errors=[])
+    assert "shown to administrators only" in html
+    assert "Last backup" not in html
+    assert "Recent errors" not in html
+    assert "Index passes" in html
+
+
+def test_the_page_is_reachable_and_in_the_nav():
+    paths = {r.path for r in routes.router.routes}
+    assert "/admin/health" in paths
+
+    with open(os.path.join(TEMPLATES_DIR, "base.html")) as fh:
+        base = fh.read()
+    assert 'href="/admin/health"' in base
+    assert "active == 'health'" in base
+
+
+# --------------------------------------------------------------------------
+# 5. The dashboard strip
+# --------------------------------------------------------------------------
+
+
+def _render_strip(**health):
+    ctx = dict(
+        is_admin=True, username="max", multi_user_mode=False, csrf_token="csrf",
+        stats={"notes_indexed": 1, "notes_with_embeddings": 1,
+               "embedding_pct": 100, "active_keys": 1, "requests_today": 0},
+        recent_usage=[], reindexed_24h=0, last_indexed_iso=None,
+        last_indexed_rel="never", last_run_iso=None, last_run_rel="never",
+        last_run_ok=True, index_interval=300, graph={},
+        graph_backfill_running=False,
+        health=dict({
+            "show_ops": True, "last_run": None, "backup": None,
+            "error_count": 0, "errors_capped": False,
+            "observing_since_iso": "2026-08-29T08:00:00+00:00",
+            "observing_since_rel": "2 hours ago",
+            "stale_after_days": ops_health.STALE_AFTER_DAYS,
+        }, **health),
+    )
+    return _env().get_template("dashboard.html").render(**ctx)
+
+
+def test_the_strip_links_a_failed_pass_to_its_row_on_the_health_page():
+    html = _render_strip(last_run=_run(id=42, error="OSError: no space left"))
+    assert '/admin/health#run-42' in html
+    assert "failed" in html
+
+
+def test_the_strip_shows_ok_for_a_clean_pass_and_links_to_the_page():
+    html = _render_strip(last_run=_run(id=42))
+    assert "#run-42" not in html
+    assert 'href="/admin/health"' in html
+
+
+def test_the_strip_says_none_recorded_rather_than_ok_when_there_is_no_pass():
+    """A fresh install has no pass row. "ok" would be a claim about a pass that
+    never ran."""
+    html = _render_strip(last_run=None)
+    strip = html[: html.index("Stat row")]
+    assert "none recorded" in strip
+    assert "ok" not in re.sub(r"<[^>]+>", " ", strip)
+
+
+def test_the_strip_states_the_error_window_beside_the_count():
+    html = _render_strip(error_count=0)
+    assert "since process start" in html
+    assert "2 hours ago" in html
+
+
+def test_a_stale_backup_is_flagged_on_the_strip():
+    html = _render_strip(backup={"age_rel": "28 days ago", "stale": True})
+    strip = html[: html.index("Stat row")]
+    assert "28 days ago" in strip
+    assert "badge-yellow" in strip
+
+
+def test_a_non_admin_strip_carries_the_pass_and_neither_operator_cell():
+    html = _render_strip(show_ops=False, last_run=_run(id=42))
+    strip = html[: html.index("Stat row")]
+    assert "Last pass" in strip
+    assert "Backup" not in strip
+    assert "Errors" not in strip
+
+
+# --------------------------------------------------------------------------
+# 6. The route's admin split
+# --------------------------------------------------------------------------
+
+
+class _Request:
+    def __init__(self):
+        self.session = {}
+        self.scope = {}
+        self.query_params = {}
+
+
+class _User:
+    def __init__(self, is_admin):
+        self.id = 3
+        self.username = "user"
+        self.is_admin = is_admin
+        self.is_active = True
+
+
+def _health_context(monkeypatch, is_admin, table_present=True):
+    captured = {}
+
+    def _fake_response(request, name, context):
+        captured["name"] = name
+        captured["context"] = context
+        return None
+
+    monkeypatch.setattr(routes.templates, "TemplateResponse", _fake_response)
+    monkeypatch.setattr(routes, "generate_csrf_token", lambda _r: "csrf")
+    session = _BackupSession(table_present=table_present, row=None)
+    asyncio.run(
+        routes.health_page(
+            request=_Request(), session=session, user=_User(is_admin)
+        )
+    )
+    return captured, session
+
+
+def test_the_route_withholds_errors_and_backups_from_a_non_admin(monkeypatch):
+    """Neither section has an owner to scope by: the ring buffer holds whatever
+    the process logged — other tenants' paths and identifiers included — and a
+    backup covers the whole database. Gating is the only available answer."""
+    error_log.attach()
+    logging.getLogger("secretive").error("/vault/someone-else/private.md failed")
+
+    captured, session = _health_context(monkeypatch, is_admin=False)
+    ctx = captured["context"]
+    assert ctx["show_ops"] is False
+    assert ctx["backup"] is None
+    assert "errors" not in ctx
+    assert not any("backups_log" in s for s in session.statements), (
+        "a non-admin request must not even ask"
+    )
+
+
+def test_the_route_gives_an_admin_both_sections(monkeypatch):
+    error_log.attach()
+    logging.getLogger("loud").error("something broke")
+
+    captured, session = _health_context(monkeypatch, is_admin=True)
+    ctx = captured["context"]
+    assert captured["name"] == "health.html"
+    assert ctx["show_ops"] is True
+    assert ctx["error_count"] == 1
+    assert ctx["errors"][0]["message"] == "something broke"
+    assert ctx["observing_since_iso"] is not None
+    assert ctx["runs_limit"] == ops_health.HEALTH_RUNS_LIMIT == 50
+    assert any("to_regclass" in s for s in session.statements)
+
+
+def test_the_run_history_asks_for_fifty_not_twenty(monkeypatch):
+    """The performance page's 20 is a summary; #160 deferred the fuller view
+    here."""
+    seen = {}
+
+    async def _fake_runs(session, user_id, limit=None):
+        seen["limit"] = limit
+        seen["user_id"] = user_id
+        return []
+
+    monkeypatch.setattr(routes, "recent_indexer_runs", _fake_runs)
+    _health_context(monkeypatch, is_admin=True)
+    assert seen["limit"] == 50
+    assert seen["user_id"] is None, "an admin sees every pass"
+
+
+def test_a_non_admins_run_history_is_scoped_to_them(monkeypatch):
+    seen = {}
+
+    async def _fake_runs(session, user_id, limit=None):
+        seen["user_id"] = user_id
+        return []
+
+    monkeypatch.setattr(routes, "recent_indexer_runs", _fake_runs)
+    _health_context(monkeypatch, is_admin=False)
+    assert seen["user_id"] == 3

--- a/tests/test_issue_163_ops_health.py
+++ b/tests/test_issue_163_ops_health.py
@@ -156,6 +156,92 @@ def test_entries_are_copies_so_a_reader_cannot_edit_the_buffer():
     assert error_log.recent_errors()[0]["message"] == "original"
 
 
+class _Probe(logging.Handler):
+    """Counts what reaches it. Used only to prove where propagation stops."""
+
+    def __init__(self):
+        super().__init__(level=logging.ERROR)
+        self.records = []
+
+    def emit(self, record):
+        self.records.append(record)
+
+
+def test_an_unhandled_asgi_500_reaches_the_buffer_under_uvicorns_config():
+    """`uvicorn.error` is where "Exception in ASGI application" is logged, and
+    uvicorn's own `dictConfig` stops that record before the root logger. So the
+    test asserts the *behaviour* — a root-only handler sees nothing, ours sees
+    it exactly once — rather than which logger in the chain happens to carry
+    `propagate: false` in this release."""
+    import copy
+    import logging.config
+
+    from uvicorn.config import LOGGING_CONFIG
+
+    names = ("uvicorn", "uvicorn.error", "uvicorn.access")
+    saved = {
+        name: (
+            logging.getLogger(name).level,
+            logging.getLogger(name).propagate,
+            list(logging.getLogger(name).handlers),
+        )
+        for name in names
+    }
+    root = logging.getLogger()
+    saved_root = (root.level, list(root.handlers))
+    probe = _Probe()
+    try:
+        logging.config.dictConfig(copy.deepcopy(LOGGING_CONFIG))
+        root.addHandler(probe)
+        error_log.attach()
+        logging.getLogger("uvicorn.error").error("Exception in ASGI application")
+
+        assert probe.records == [], (
+            "a root-only handler must NOT see this record — that is the whole "
+            "reason uvicorn.error is attached directly"
+        )
+        entries = error_log.recent_errors()
+        assert len(entries) == 1, "captured exactly once, not zero and not twice"
+        assert entries[0]["logger"] == "uvicorn.error"
+        assert entries[0]["message"] == "Exception in ASGI application"
+    finally:
+        error_log.detach()
+        root.removeHandler(probe)
+        for name, (level, propagate, handlers) in saved.items():
+            logger = logging.getLogger(name)
+            logger.handlers[:] = handlers
+            logger.propagate = propagate
+            logger.setLevel(level)
+        root.handlers[:] = saved_root[1]
+        root.setLevel(saved_root[0])
+
+
+def test_a_propagating_uvicorn_error_is_still_recorded_only_once():
+    """The same handler instance sits on `uvicorn.error` and on the root, so
+    `callHandlers` reaches it twice for one record if propagation is ever on.
+    The per-record flag is what makes that one entry."""
+    uvicorn_error = logging.getLogger("uvicorn.error")
+    saved = uvicorn_error.propagate
+    try:
+        uvicorn_error.propagate = True
+        error_log.attach()
+        uvicorn_error.error("one record, two handler visits")
+        assert len(error_log.recent_errors()) == 1
+    finally:
+        uvicorn_error.propagate = saved
+
+
+def test_detach_removes_the_handler_from_every_logger_attach_used():
+    error_log.attach()
+    error_log.detach()
+    handlers = logging.getLogger("uvicorn.error").handlers
+    assert not any(isinstance(h, error_log.RingBufferHandler) for h in handlers)
+    assert not any(
+        isinstance(h, error_log.RingBufferHandler)
+        for h in logging.getLogger().handlers
+    )
+
+
 def test_the_lifespan_attaches_the_handler_before_the_sandbox_branch():
     """A process that dies in a startup guard is exactly the one whose errors
     an operator comes looking for, so the buffer must be live before any guard
@@ -195,6 +281,16 @@ class _Result:
     def fetchall(self):
         return self._rows
 
+    def scalars(self):
+        outer = self
+
+        class _S:
+            def all(self):
+                value = outer._scalar
+                return value if isinstance(value, list) else []
+
+        return _S()
+
 
 class _BackupSession:
     """Answers the two statements `latest_backup` issues, in order."""
@@ -210,7 +306,7 @@ class _BackupSession:
         self.statements.append(text)
         if "to_regclass" in text:
             return _Result(scalar="backups_log" if self.table_present else None)
-        if "FROM backups_log" in text:
+        if "backups_log" in text:
             return _Result(first=self.row)
         if "indexer_runs" in text:
             return _Result(rows=self.runs)
@@ -235,7 +331,7 @@ def test_a_pre_021_database_reads_as_no_backup_rather_than_a_500():
     assert any("to_regclass" in s for s in session.statements), (
         "the read must probe before it selects"
     )
-    assert not any("FROM backups_log" in s for s in session.statements)
+    assert not any("FROM public.backups_log" in s for s in session.statements)
 
 
 def test_an_empty_table_reads_as_no_backup_too():
@@ -342,11 +438,14 @@ def test_db_backup_records_the_dump_and_its_status_is_the_targets():
     fails the backup."""
     make = _makefile()
     recipe = make[make.index("\ndb-backup:") : make.index("\ndb-restore:")]
-    assert "docker/record-backup.sh" in recipe
+    invocations = [
+        line for line in recipe.splitlines() if "bash docker/record-backup.sh" in line
+    ]
+    assert len(invocations) == 1, invocations
     # Passed the file that was actually written, and the container the dump
     # itself used — the same channel, not a second one.
-    assert "$$BACKUP_FILE.gz" in recipe.split("record-backup.sh")[1].split("\n")[0]
-    assert "DB_CONTAINER=$(DB_CONTAINER)" in recipe
+    assert "$$BACKUP_FILE.gz" in invocations[0]
+    assert "DB_CONTAINER=$(DB_CONTAINER)" in invocations[0]
     body = [line.strip() for line in recipe.strip().splitlines() if line.strip()]
     assert "record-backup.sh" in body[-1], (
         "the recording must be the last command in the recipe, or its failure "
@@ -369,6 +468,47 @@ def test_the_recording_script_goes_through_docker_exec_psql():
     # and is a syntax error there).
     assert ":'filename'" in script and ":'size_bytes'" in script
     assert "-c \"INSERT" not in script
+
+
+def test_the_probe_never_folds_stderr_into_the_value_it_classifies():
+    """A healthy server writes warnings to stderr — a collation-version
+    mismatch after a libc upgrade is emitted on connection. Folded into stdout,
+    the probe's value becomes `WARNING: …\\nt`, which is not `t`, and the
+    absent-table branch then exits 0 without recording anything, forever, on a
+    table that exists."""
+    with open(os.path.join(HERE, "..", "docker", "record-backup.sh")) as fh:
+        script = fh.read()
+    # Comments may discuss `2>&1`; no *command* may use it.
+    commands = [
+        line for line in script.splitlines() if not line.lstrip().startswith("#")
+    ]
+    assert not any("2>&1" in line for line in commands), (
+        "stderr must be captured separately from the value being classified"
+    )
+    assert '2>"$STDERR_FILE"' in script
+
+
+def test_the_writer_and_the_reader_name_the_same_qualified_table():
+    """An unqualified reference resolves through `search_path`, so a role
+    pointing elsewhere would have the writer recording into a table the panel
+    never reads — the page then warns that no backup has been taken while one
+    is taken daily."""
+    with open(os.path.join(HERE, "..", "docker", "record-backup.sh")) as fh:
+        script = fh.read()
+    assert "INSERT INTO public.backups_log" in script
+
+    with open(os.path.join(HERE, "..", "src", "services", "ops_health.py")) as fh:
+        reader = fh.read()
+    assert "FROM public.backups_log" in reader
+
+    with open(
+        os.path.join(HERE, "..", "alembic", "versions", "021_backups_log.py")
+    ) as fh:
+        migration = fh.read()
+    assert 'QUALIFIED = "public.backups_log"' in migration
+    assert '{"table": TABLE}' not in migration, (
+        "every catalog lookup resolves the qualified name"
+    )
 
 
 # --------------------------------------------------------------------------
@@ -577,6 +717,106 @@ def test_a_non_admin_strip_carries_the_pass_and_neither_operator_cell():
     assert "Last pass" in strip
     assert "Backup" not in strip
     assert "Errors" not in strip
+
+
+def test_a_degraded_strip_says_so_rather_than_claiming_a_state():
+    html = _render_strip(unavailable=True)
+    strip = html[: html.index("Stat row")]
+    assert "Health summary unavailable" in strip
+    # Never "ok" or "none recorded" — those are claims built on a query that
+    # never returned.
+    assert "none recorded" not in strip
+    assert 'href="/admin/health"' in strip
+
+
+# --------------------------------------------------------------------------
+# 5b. The dashboard does not depend on the strip
+# --------------------------------------------------------------------------
+
+
+class _ExplodingStripSession:
+    """Answers the dashboard's own queries and raises on the strip's.
+
+    The realistic fault: `indexer_runs` unreadable — a `NOT VALID` FK left by a
+    hand repair, a revoked permission, a 021 that has not run on the database
+    the container was pointed at — while every other table on the page is fine.
+    """
+
+    def __init__(self):
+        self.rolled_back = False
+        self.n = 0
+
+    async def execute(self, stmt, *_a, **_k):
+        self.n += 1
+        text = str(stmt).lower()
+        if "indexer_runs" in text or "backups_log" in text or "to_regclass" in text:
+            raise RuntimeError("relation \"indexer_runs\" does not exist")
+        if "max(" in text:
+            return _Result(scalar=None)
+        if "select" in text and "usage_logs" in text and "count" not in text:
+            return _Result(scalar=[])
+        return _Result(scalar=0)
+
+    async def rollback(self):
+        self.rolled_back = True
+
+
+class _Scalars:
+    def __init__(self, value):
+        self._value = value
+
+    def all(self):
+        return self._value if isinstance(self._value, list) else []
+
+
+def _dashboard_context(monkeypatch, session):
+    captured = {}
+
+    def _fake_response(request, name, context):
+        captured["context"] = context
+        return "rendered"
+
+    monkeypatch.setattr(routes.templates, "TemplateResponse", _fake_response)
+    monkeypatch.setattr(routes, "generate_csrf_token", lambda _r: "csrf")
+
+    async def _graph(*_a, **_k):
+        return {}
+
+    monkeypatch.setattr(routes, "_graph_stats", _graph)
+    response = asyncio.run(
+        routes.dashboard(request=_Request(), session=session, user=_User(True))
+    )
+    return captured["context"], response
+
+
+def test_a_failing_strip_query_does_not_take_the_dashboard_down(monkeypatch):
+    """The dashboard is the page an operator opens *because* something is
+    wrong. Losing three cells beats losing the page."""
+    session = _ExplodingStripSession()
+    ctx, response = _dashboard_context(monkeypatch, session)
+
+    assert response == "rendered", "the page still renders"
+    assert ctx["health"] == {"unavailable": True, "show_ops": True}
+    # And the dashboard's own data is untouched.
+    assert "stats" in ctx and "graph" in ctx
+
+
+def test_the_failed_strip_transaction_is_rolled_back(monkeypatch):
+    """Without it every statement after the failure raises
+    `InFailedSQLTransaction` instead of the real error — including the ones the
+    render itself would issue."""
+    session = _ExplodingStripSession()
+    _dashboard_context(monkeypatch, session)
+    assert session.rolled_back is True
+
+
+def test_the_strip_failure_is_logged_at_error_so_the_page_shows_it(monkeypatch):
+    error_log.attach()
+    session = _ExplodingStripSession()
+    _dashboard_context(monkeypatch, session)
+
+    messages = [e["message"] for e in error_log.recent_errors()]
+    assert any("health strip unavailable" in m.lower() for m in messages), messages
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_issue_78_panel_labels.py
+++ b/tests/test_issue_78_panel_labels.py
@@ -287,6 +287,12 @@ class _DashboardSession:
         text = str(stmt).lower()
         if "max(" in text:
             return _Scalar(self._last_indexed)
+        # The dashboard's health strip (#163) probes for `backups_log` before
+        # reading it, because a pre-021 database legitimately has no such
+        # table. NULL is what `to_regclass` returns then, and it is the right
+        # answer for a fake that has no tables at all.
+        if "to_regclass" in text:
+            return _Scalar(None)
         if "select" in text and "usage_logs" in text and "count" not in text:
             return _Scalar([])
         return _Scalar(0)
@@ -390,6 +396,10 @@ def _render_dashboard(**overrides) -> str:
         "index_interval": 300,
         "graph": {},
         "graph_backfill_running": False,
+        # The health strip (#163). Empty is the fresh-install state — no
+        # recorded pass, no backup, nothing observed — which every cell of the
+        # strip has to render without a value.
+        "health": {"show_ops": True, "last_run": None, "stale_after_days": 8},
     }
     context.update(overrides)
     templates = Jinja2Templates(directory=TEMPLATES_DIR)


### PR DESCRIPTION
Final wave-2 change: the panel answers "is the system healthy, when did the last backup run, what failed recently" without SSH.

- `/admin/health`: indexer run history (≤50, owner-labeled), in-process error ring buffer (ERROR+, ≤100, observation window stated, also capturing uvicorn.error so unhandled ASGI 500s land in it), latest-backup age with >8-day staleness warning; explicit empty states; errors/backup sections admin-gated (spec scenario added)
- Migration **021** `backups_log`; `make db-backup` records each successful dump through the same psql channel, guarded three ways: table absent (pre-021 bootstrap) → loud warning + success; present → insert failure fails the target; probe answer unparseable → fails (stderr captured separately after review caught benign server warnings misclassifying a healthy table as absent — a silent forever-off switch)
- Migration DDL pinned via `SET LOCAL search_path TO public` (decoy-schema migration test; alembic check stays clean) with identity assertions as belt-and-braces; 021's verifier checks PK, defaults, sequence ownership (tampered-default stamp-back refused)
- Dashboard health strip behind a failure boundary — a broken optional widget renders degraded copy instead of 500ing `/admin/`

Gates: spec 5 Codex rounds; implementation openspec-verifier (0 blocking) + adversarial Codex (1 BLOCKER + 3 MAJOR caught, 3 rounds to PASS). 2791 hermetic + 12 ops-PG + 135 schema-gate tests, 0 failures.

Post-merge: deploy runs 021 — its own backup step will print the documented "backup taken but not recorded" bootstrap warning; the first recorded backup is the next `make db-backup`, run as part of live verification.

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SakkpngBNXLiTpbRu6CPxw