### PR TITLE
ops: protect DB backups and .env, drop the /app/backups mount (#181, #186, #187)

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -481,6 +481,15 @@ deployment; on a compose-file deployment the equivalents are plain
   take by hand with `pg_dump` will not appear there, and the page will keep
   warning after 8 days as though none had been taken.
 
+  Dumps hold every tenant's note text and every credential hash, so
+  `make db-backup` writes them under `umask 077` into a `0700` directory,
+  verifies each one with `gzip -t`, and then prunes dumps older than
+  `BACKUP_RETAIN_DAYS` (default 30) while always keeping the newest
+  `BACKUP_RETAIN_MIN` (default 7). Override either on the command line or in
+  `Makefile.local`. The backups directory is **never** mounted into the
+  container — `make deploy` and `make status` fail if a mount at
+  `/app/backups` exists — and `.env` should be `0600` (`make init` sets it).
+
   **On the deploy that first ships this** (migration 021): `make deploy`
   takes its backup *before* it migrates — deliberately, because the backup
   is the only way back from a bad migration — so that one dump runs against

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ DATA_DIR ?= ./data
 # `obsidian-mcp-postgres`; a shared host instance is usually just `postgres`.
 # Override in Makefile.local to match the deployment.
 DB_CONTAINER ?= postgres
+# The application container, as named in docker-compose.yml.
+CONTAINER ?= obsidian-mcp
 COMPOSE_FILE := $(DEPLOY_DIR)/docker-compose.yml
 ENV_FILE := $(DEPLOY_DIR)/.env
 COMPOSE := docker compose --project-directory $(DEPLOY_DIR) -f $(COMPOSE_FILE)
@@ -30,7 +32,7 @@ SCHEMA_TEST_CONTAINER ?= obsidian-mcp-schema-test
 SCHEMA_TEST_PORT ?= 55438
 SCHEMA_TEST_IMAGE ?= pgvector/pgvector:pg16
 
-.PHONY: help init build build-cached push image deploy up down restart logs shell db-init db-migrate db-check db-backup db-restore status clean reindex reset-embeddings rebuild-tsvectors audit trivy test-schema
+.PHONY: help init build build-cached push image deploy up down restart logs shell db-init db-migrate db-check db-backup db-restore status check-no-backups-mount clean reindex reset-embeddings rebuild-tsvectors audit trivy test-schema
 
 help:
 	@echo "$(GREEN)Obsidian MCP Server$(NC)"
@@ -75,7 +77,11 @@ init:
 	@echo "$(GREEN)Setting up Obsidian MCP...$(NC)"
 	@sudo mkdir -p $(DATA_DIR)/backups
 	@sudo chown -R $(shell id -u):$(shell id -g) $(DATA_DIR)
-	@sudo chmod -R 775 $(DATA_DIR)
+	# Owner-only: `.env` carries the DB password and SECRET_KEY, and the dumps
+	# under backups/ carry every tenant's note text. Nothing but the deploying
+	# user (and root) needs to read either, so no group/world bits (#187).
+	@sudo chmod 750 $(DATA_DIR)
+	@sudo chmod 700 $(DATA_DIR)/backups
 	@if [ ! -f "$(ENV_FILE)" ]; then \
 		echo "$(GREEN)Creating $(ENV_FILE) from template...$(NC)"; \
 		cp .env.example $(ENV_FILE); \
@@ -83,6 +89,7 @@ init:
 		SECRET=$$(openssl rand -hex 32); \
 		sed -i "s/CHANGE_ME/$$DB_PASS/" $(ENV_FILE); \
 		sed -i "s/SECRET_KEY=.*/SECRET_KEY=$$SECRET/" $(ENV_FILE); \
+		chmod 600 $(ENV_FILE); \
 		echo "$(GREEN)$(ENV_FILE) created with random secrets$(NC)"; \
 	else \
 		echo "$(YELLOW)$(ENV_FILE) already exists$(NC)"; \
@@ -132,6 +139,7 @@ deploy: image
 	# against the old schema (and matching README's documented deploy behavior).
 	$(COMPOSE) run --rm obsidian-mcp alembic upgrade head
 	$(COMPOSE) up -d --force-recreate
+	@$(MAKE) check-no-backups-mount
 	@docker image prune -f
 	@docker builder prune -f --filter until=168h
 	@HOST=$$(grep -E '^MCP_HOSTNAME=' $(ENV_FILE) 2>/dev/null | cut -d= -f2); \
@@ -225,9 +233,19 @@ test-schema:
 # so on the deploy that ships 021 the table does not exist yet and the target
 # must warn and still succeed. Its exit status is the target's: once the table
 # exists, a backup that fails to record itself fails the backup.
+# Dumps are created under `umask 077` so they are never readable by another
+# local account (they hold every tenant's note text and every credential
+# hash), and the directory is kept 0700. After a dump is verified (`gzip -t`)
+# and recorded, dumps older than BACKUP_RETAIN_DAYS are pruned — but never
+# below BACKUP_RETAIN_MIN most-recent files, and never the one just taken, so
+# a long gap between deploys cannot leave the directory empty (#181).
+BACKUP_RETAIN_DAYS ?= 30
+BACKUP_RETAIN_MIN ?= 7
+
 db-backup:
 	@mkdir -p $(DATA_DIR)/backups
-	@TIMESTAMP=$$(date +%Y%m%d_%H%M%S); \
+	@chmod 700 $(DATA_DIR)/backups
+	@umask 077; TIMESTAMP=$$(date +%Y%m%d_%H%M%S); \
 	BACKUP_FILE="$(DATA_DIR)/backups/backup_$$TIMESTAMP.sql"; \
 	: "the database named here is mirrored as DB_NAME's default in docker/record-backup.sh; keep the two in step"; \
 	if ! docker exec $(DB_CONTAINER) pg_dump -U postgres obsidian_mcp > $$BACKUP_FILE; then \
@@ -246,8 +264,21 @@ db-backup:
 		echo "$(RED)Backup FAILED: could not gzip $$BACKUP_FILE$(NC)"; \
 		exit 1; \
 	fi; \
+	if ! gzip -t $$BACKUP_FILE.gz; then \
+		rm -f $$BACKUP_FILE.gz; \
+		echo "$(RED)Backup FAILED: $$BACKUP_FILE.gz did not verify$(NC)"; \
+		exit 1; \
+	fi; \
+	chmod 600 $$BACKUP_FILE.gz; \
 	echo "$(GREEN)Backup: $$BACKUP_FILE.gz$(NC)"; \
-	DB_CONTAINER=$(DB_CONTAINER) bash docker/record-backup.sh $$BACKUP_FILE.gz
+	DB_CONTAINER=$(DB_CONTAINER) bash docker/record-backup.sh $$BACKUP_FILE.gz || exit 1; \
+	PRUNED=0; \
+	for OLD in $$(ls -1t $(DATA_DIR)/backups/backup_*.sql.gz 2>/dev/null | tail -n +$$(( $(BACKUP_RETAIN_MIN) + 1 ))); do \
+		if [ "$$OLD" != "$$BACKUP_FILE.gz" ] && [ -n "$$(find "$$OLD" -mtime +$(BACKUP_RETAIN_DAYS) 2>/dev/null)" ]; then \
+			rm -f "$$OLD"; PRUNED=$$((PRUNED + 1)); \
+		fi; \
+	done; \
+	if [ $$PRUNED -gt 0 ]; then echo "$(YELLOW)Pruned $$PRUNED backup(s) older than $(BACKUP_RETAIN_DAYS) days (kept at least $(BACKUP_RETAIN_MIN))$(NC)"; fi
 
 db-restore:
 	@if [ -z "$(FILE)" ]; then echo "$(RED)Usage: make db-restore FILE=<path>$(NC)"; exit 1; fi
@@ -301,9 +332,20 @@ rebuild-tsvectors:
 	$(COMPOSE) run --rm obsidian-mcp python -m scripts.rebuild_tsvectors
 	@echo "$(GREEN)Done. Keyword search now reflects FTS_CONFIGS (embeddings untouched, no API calls).$(NC)"
 
+# Invariant: the application container must not be able to see the backups
+# directory (docs/architecture/control-panel.md, "Backup recency"). The mount
+# once crept back into the compose file (#186); this refuses a deploy that
+# reintroduces it under any host path.
+check-no-backups-mount:
+	@if docker inspect $(CONTAINER) --format '{{range .Mounts}}{{.Destination}}{{"\n"}}{{end}}' 2>/dev/null | grep -qx '/app/backups'; then \
+		echo "$(RED)INVARIANT VIOLATED: $(CONTAINER) has a mount at /app/backups — the container must not see the backups directory (#186).$(NC)"; \
+		exit 1; \
+	fi
+
 status:
 	@echo "$(GREEN)Obsidian MCP Status:$(NC)"
 	@$(COMPOSE) ps
+	@$(MAKE) check-no-backups-mount
 	@echo ""
 	@echo "$(GREEN)Health:$(NC)"
 	@HOST=$$(grep -E '^MCP_HOSTNAME=' $(ENV_FILE) 2>/dev/null | cut -d= -f2); \

--- a/Makefile
+++ b/Makefile
@@ -271,14 +271,15 @@ db-backup:
 	fi; \
 	chmod 600 $$BACKUP_FILE.gz; \
 	echo "$(GREEN)Backup: $$BACKUP_FILE.gz$(NC)"; \
-	DB_CONTAINER=$(DB_CONTAINER) bash docker/record-backup.sh $$BACKUP_FILE.gz || exit 1; \
+	: "prune BEFORE recording: the new dump is already verified above, and the recording must stay the recipe's last command so its exit status is the target's"; \
 	PRUNED=0; \
 	for OLD in $$(ls -1t $(DATA_DIR)/backups/backup_*.sql.gz 2>/dev/null | tail -n +$$(( $(BACKUP_RETAIN_MIN) + 1 ))); do \
 		if [ "$$OLD" != "$$BACKUP_FILE.gz" ] && [ -n "$$(find "$$OLD" -mtime +$(BACKUP_RETAIN_DAYS) 2>/dev/null)" ]; then \
 			rm -f "$$OLD"; PRUNED=$$((PRUNED + 1)); \
 		fi; \
 	done; \
-	if [ $$PRUNED -gt 0 ]; then echo "$(YELLOW)Pruned $$PRUNED backup(s) older than $(BACKUP_RETAIN_DAYS) days (kept at least $(BACKUP_RETAIN_MIN))$(NC)"; fi
+	if [ $$PRUNED -gt 0 ]; then echo "$(YELLOW)Pruned $$PRUNED backup(s) older than $(BACKUP_RETAIN_DAYS) days (kept at least $(BACKUP_RETAIN_MIN))$(NC)"; fi; \
+	DB_CONTAINER=$(DB_CONTAINER) bash docker/record-backup.sh $$BACKUP_FILE.gz
 
 db-restore:
 	@if [ -z "$(FILE)" ]; then echo "$(RED)Usage: make db-restore FILE=<path>$(NC)"; exit 1; fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,11 @@
 # To adapt to your environment, set in `.env`:
 #   MCP_HOSTNAME       -- public hostname Traefik routes to
 #   VAULT_HOST_PATH    -- host path to your Obsidian vault
-#   BACKUPS_HOST_PATH  -- host path for database backups (optional)
+#
+# Backups are written host-side by `make db-backup` into $(DATA_DIR)/backups
+# and are deliberately NOT mounted into the container (see
+# docs/architecture/control-panel.md, "Backup recency"); `make deploy`
+# refuses a container that has a mount at /app/backups.
 #
 # The Traefik labels assume an external `t2_proxy` network and a
 # `chain-oauth@file` middleware; adjust the network/middleware names
@@ -44,7 +48,6 @@ services:
     volumes:
       # Max (admin) — bootstraps to vault_path=/obsidian after the flag flip.
       - ${VAULT_HOST_PATH:-./vault}:/obsidian
-      - ${BACKUPS_HOST_PATH:-./backups}:/app/backups
       - /etc/timezone:/etc/timezone:ro
       - /etc/localtime:/etc/localtime:ro
 

--- a/docs/architecture/schema-and-migrations.md
+++ b/docs/architecture/schema-and-migrations.md
@@ -99,3 +99,38 @@ directly — one family per `(client_id, user_id)`, never a family spanning two
 users, never a user's rows split across two families — plus stamp-back
 idempotence (which must not re-stamp existing `grant_id`s) and the downgrade.
 
+## Backups are protected data, not just a rollback tool
+
+A `pg_dump` of this database is the complete text of every tenant's notes
+(`note_embeddings.chunk_text`), every search query ever logged, and every
+password, API-key, OAuth and transfer-token hash. Before 2026-09-04 the
+dumps were written with the caller's umask (0664) into a 0775 directory, were
+never pruned (95 files, 7.4 GB, back to March), and the directory was
+bind-mounted read-write into the application container in direct
+contradiction of the "container cannot see backups" invariant that
+`control-panel.md` documents for `backups_log` (ASVS assessment findings
+#181, #186, #187). The rules now:
+
+- **`make db-backup` runs under `umask 077`, `chmod 600`s the dump, keeps the
+  directory `0700`, and verifies the archive (`gzip -t`) before recording
+  it.** A dump that does not verify is deleted and the target fails, so
+  `make deploy` refuses to migrate.
+- **Retention is bounded:** dumps older than `BACKUP_RETAIN_DAYS` (30) are
+  pruned after the new one is verified and recorded, never below
+  `BACKUP_RETAIN_MIN` (7) most-recent files and never the one just taken.
+  Retention is the operator's, not the container's: nothing in `src/`
+  touches the directory.
+- **The directory is never mounted into the container.** `docker-compose.yml`
+  carries no `/app/backups` volume, and `make deploy` / `make status` run
+  `check-no-backups-mount`, which fails if `docker inspect` shows one. This
+  is the enforcement of the invariant `control-panel.md` states; do not add
+  the mount back "for convenience" — `docker/record-backup.sh` exists
+  precisely so the container never needs it.
+- **`.env` is `0600`.** It carries `DATABASE_URL` (with the password) and
+  `SECRET_KEY`; `make init` sets the mode, and a second local account on the
+  host is the reason this matters.
+
+Encryption at rest for the dumps is not implemented; if it is added, keep a
+restore-tested copy with separately managed keys before switching it on, or
+the backup stops being a backup.
+

--- a/src/config.py
+++ b/src/config.py
@@ -108,7 +108,8 @@ class _FieldFilteredSource(PydanticBaseSettingsSource):
 
     Used for the **dotenv source only**. The repo-root `.env` is shared with
     `docker-compose.yml` and legitimately carries compose-only keys
-    (`VAULT_HOST_PATH`, `BACKUPS_HOST_PATH`) that are not settings; with
+    (`VAULT_HOST_PATH`, and the retired `BACKUPS_HOST_PATH` still present in
+    older `.env` files) that are not settings; with
     pydantic-settings' `extra="forbid"` they make `Settings()` — and therefore
     a single-file `pytest` run from a checkout — fail at import.
 
@@ -330,8 +331,8 @@ class Settings(BaseSettings):
         """Default source order, with the dotenv source filtered to known fields.
 
         The repo-root `.env` doubles as the compose env file and carries
-        compose-only keys (`VAULT_HOST_PATH`, `BACKUPS_HOST_PATH`) that are not
-        `Settings` fields. Under `extra="forbid"` those abort `Settings()` at
+        compose-only keys (`VAULT_HOST_PATH`, or a retired `BACKUPS_HOST_PATH` in
+        an older `.env`) that are not `Settings` fields. Under `extra="forbid"` those abort `Settings()` at
         import time. Dropping them from the dotenv source only keeps every other
         surface strict.
         """


### PR DESCRIPTION
Closes the three host/deployment findings from the 2026-09-04 ASVS assessment.

- `make db-backup` now writes under `umask 077`, `chmod 600`s the dump, keeps the directory `0700`, verifies with `gzip -t` before recording, and prunes dumps older than `BACKUP_RETAIN_DAYS` (30) while never dropping below `BACKUP_RETAIN_MIN` (7) most-recent files or the one just taken.
- `make init` sets `750` on the data dir, `700` on backups and `600` on `.env` instead of a recursive `775`.
- `docker-compose.yml` drops the read-write `/app/backups` mount that contradicted the documented "container cannot see backups" invariant. Nothing in `src/` used it.
- New `make check-no-backups-mount` fails `make deploy` and `make status` if the container ever has a mount at `/app/backups` again.
- `DEPLOYMENT.md` and `docs/architecture/schema-and-migrations.md` record the protection and retention rules.

Already applied on the host: `.env` 0600, backups dir 0700, existing dumps 0600, compose copy synced, container recreated without the mount (`check-no-backups-mount` passes, `/health` ok). `make rebuild-tsvectors` was also run for #207 (3,939 notes).

Closes #181
Closes #186
Closes #187
Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWbxW7QFtncUwizXdNyNCZ