### PR TITLE
fix(tools): rewrite splices link text from the unmasked content (#211)

### DIFF
--- a/docs/architecture/vault-tools.md
+++ b/docs/architecture/vault-tools.md
@@ -624,6 +624,26 @@ speed-up. The fallback is unreachable through the scanners and is tested by
 calling the splice directly; the equality itself is tested against the retired
 implementation as an oracle over a randomized corpus.
 
+**The recognizers read the masked copy; every byte written back is sliced from
+the unmasked note (#211).** The two scans run over `apply_fence_mask(content,
+…)` because a link inside a fence or inside backticks is text *about* a link
+and must not be rewritten — that is the whole reason the mask exists. But the
+replacement text is spliced into `content`, and it used to be assembled from
+pieces read off the mask: the wikilink `rest` (`#anchor|alias`) and the
+markdown link's text and anchor. Inline code inside any of those is a run of
+spaces in the mask, so ``See [the `foo` option](Old.md)`` was published as
+`See [the       option](New.md)` — a silent destructive write on an ordinary
+note, on the path whose entire job is to leave everything except the target
+alone. The fix is the same property the masker already promises everywhere
+else: masking is a **same-length** substitution, so a span found in the masked
+copy indexes the identical region of `content`, and the rewriter re-slices
+`rest`, `text` and `anchor` out of `content` at that span
+(`MdLinkMatch.text_start` / `anchor_start` exist for exactly this). What the
+recognizers *see* is unchanged, so which links are rewritten is unchanged; only
+where the written bytes come from changed. Anything later added to the
+replacement — a new alias form, a title, a display component — takes its bytes
+from `content` too, never from `masked`.
+
 **One source's rewrites are bounded at `MAX_LINKS_PER_NOTE`, and over the cap
 is a refusal.** The read side has always been bounded — extraction stops at
 10,000 links — and the write side was not, so a 10 MiB note of `[[Old]] `

--- a/docs/architecture/vault-tools.md
+++ b/docs/architecture/vault-tools.md
@@ -446,6 +446,12 @@ grammar closes.
   link under such an opener may be inside a list item's code block.
   `rewrite_links=False` is unaffected and is the way to move such a note.
 
+`move_note(rewrite_links=True)` also refuses, before the rename and naming the
+source, when one source plans two rewrites over **overlapping spans** — a
+wikilink to the moved note sitting inside a markdown link's anchor that also
+names it. That note has no correct rewritten form; see the splice section
+below.
+
 `move_note(rewrite_links=True)` carries a **third**, unrelated refusal from the
 same change: it aborts while any note in the caller's owner scope still carries
 a stale `extraction_version`, because its rewrite-source inventory is
@@ -613,16 +619,30 @@ after the scan finished. `_splice_rewrites` walks the spans once with a cursor
 and joins once: 0.04 s for the 131,072 rewrites of a 1 MiB body, against ~25 s
 for the retired shape.
 
-The cursor walk is equivalent to the reverse splice **only while the spans do
-not overlap**, and they cannot: a markdown link's text class excludes `[` and
-`]`, so no `[text](` can begin inside a wikilink span and run past its `]]`,
-and each scanner is already non-overlapping within itself. That is a property
-of two grammars in another module, so `_splice_rewrites` *checks* it and falls
-back to the retired splice rather than silently writing different bytes — a
-rewrite that is fast but writes different bytes is a destructive write, not a
-speed-up. The fallback is unreachable through the scanners and is tested by
-calling the splice directly; the equality itself is tested against the retired
-implementation as an oracle over a randomized corpus.
+The cursor walk is equivalent to any per-span splice **only while the spans do
+not overlap**, and each scanner is already non-overlapping within itself. They
+were believed unable to overlap *each other* — a markdown link's text class
+excludes `[` and `]`, so no `[text](` can begin inside a wikilink span and run
+past its `]]` — and that is wrong, because the markdown **anchor** class is
+`[^)]`: `[x](Old.md#anchor[[Old]])` is one markdown link whose anchor contains
+a whole wikilink, and a move of `Old.md` plans both. `_splice_rewrites`
+therefore still *checks*, and an overlap is now a **refusal**
+(`MoveRewriteOverlap`), handled by `_move_note_locked` exactly as
+`MoveRewriteCapExceeded` is: the whole move aborts before the rename, naming
+the source note.
+
+It used to fall back to the retired reverse splice instead, on the theory that
+the retired implementation defined the answer. It does not define a *correct*
+one, which is the whole lesson of this hunk (#211): applying the inner
+replacement first changes the string's length, so the outer one then splices
+at a stale `end`. `[x](Old.md#anchor[[Old]])TAIL` came back as
+`[x](N.md#anchor[[Old]])IL` — two characters eaten past the end of the link,
+reported as two successful rewrites. A fallback that produces *some* bytes is
+worse than a refusal whenever nobody can say those bytes are right. The
+equality of the cursor walk with the retired splice is still tested as an
+oracle over a randomized corpus of non-overlapping spans; the overlap path is
+tested both through the splice directly and through `move_note` end to end,
+where the assertion is that nothing was renamed and nothing was written.
 
 **The recognizers read the masked copy; every byte written back is sliced from
 the unmasked note (#211).** The two scans run over `apply_fence_mask(content,
@@ -639,10 +659,26 @@ else: masking is a **same-length** substitution, so a span found in the masked
 copy indexes the identical region of `content`, and the rewriter re-slices
 `rest`, `text` and `anchor` out of `content` at that span
 (`MdLinkMatch.text_start` / `anchor_start` exist for exactly this). What the
-recognizers *see* is unchanged, so which links are rewritten is unchanged; only
-where the written bytes come from changed. Anything later added to the
-replacement — a new alias form, a title, a display component — takes its bytes
-from `content` too, never from `masked`.
+recognizers *see* is unchanged. Anything later added to the replacement — a
+new alias form, a title, a display component — takes its bytes from `content`
+too, never from `masked`.
+
+**And a candidate whose deciding span carries masked bytes is skipped.** The
+same bug has a second half, on the read side of the same loop: *which* links
+get rewritten was still decided from the masked wikilink target and markdown
+href, where the filler is spaces. ``[[`x`Old]]`` reached `resolve_target` as
+`"   Old"`, stripped to `Old`, and a move of `Old.md` published `[[New]]` over
+a link that named a different note — the destructive write again, this time on
+a link the author never pointed at the moved note. So each candidate's target
+or href span is compared between `masked` and `content` first
+(`MdLinkMatch.href_start` is there for the markdown half), and a difference
+skips it. Not "unmask it and resolve that": the mask exists because this server
+does not know what the hidden bytes mean, and on a destructive path the safe
+answer is to leave the link exactly as written. **Extraction is deliberately
+NOT changed to match** — it records a slightly wrong target for such a link,
+which is a graph inaccuracy the reindex can correct, not bytes lost from a
+note; changing it would need a `CURRENT_EXTRACTION_VERSION` bump and a full
+re-derivation of every note's links.
 
 **One source's rewrites are bounded at `MAX_LINKS_PER_NOTE`, and over the cap
 is a refusal.** The read side has always been bounded — extraction stops at

--- a/openspec/specs/vault-write/spec.md
+++ b/openspec/specs/vault-write/spec.md
@@ -733,7 +733,12 @@ the source note, inside the rewritten link and outside it, SHALL be preserved
 exactly as written. An implementation that recognises links in a
 code-masked copy of the note SHALL take the bytes it writes back from the
 unmasked note, so masked code inside a link's text, alias or anchor is never
-published as the mask's filler.
+published as the mask's filler, and SHALL NOT rewrite a link whose target or
+href differs between the masked copy and the note, because the mask, not the
+author, chose the note that link appears to name. When one source's links
+cannot all be rewritten without one replacement destroying another's span,
+the whole move SHALL be refused before any rename or write, naming that
+source, rather than published as a set of successful rewrites.
 
 #### Scenario: Default leaves source-note bodies untouched
 
@@ -769,6 +774,23 @@ published as the mask's filler.
   alias and anchor unchanged, backticks and all
 - **AND** no character of the source note outside the rewritten link spans
   SHALL differ from what was there before the move
+
+#### Scenario: A link whose target is hidden by code masking is left alone
+
+- **WHEN** a source note contains ``[[`x`Old]]`` or ``[t](`x`Old.md)`` and
+  `move_note(from_path="Old.md", …, rewrite_links=True)` runs
+- **THEN** neither link SHALL be rewritten, because the note each names is
+  not known once its inline code is masked
+- **AND** both SHALL be left byte-identical
+
+#### Scenario: A link nested inside another link to the moved note is refused
+
+- **WHEN** a source note contains `[x](Old.md#anchor[[Old]])`, in which both
+  the markdown link and the wikilink inside its anchor name the moved note,
+  and `rewrite_links=True`
+- **THEN** the whole move SHALL be aborted before the rename, with an error
+  naming that source note
+- **AND** nothing SHALL be moved, rewritten or reindexed
 
 #### Scenario: Path-style wikilinks updated when used
 

--- a/openspec/specs/vault-write/spec.md
+++ b/openspec/specs/vault-write/spec.md
@@ -728,7 +728,12 @@ incoming `[[wikilinks]]` and `![[embeds]]` in source notes to point at
 the new title/path. The set of source notes SHALL be the same set
 returned by `get_backlinks(from_path)` prior to the move. When
 `rewrite_links=False` (default), source-note bodies SHALL NOT be
-modified.
+modified. A rewrite SHALL change only the link target: every other byte of
+the source note, inside the rewritten link and outside it, SHALL be preserved
+exactly as written. An implementation that recognises links in a
+code-masked copy of the note SHALL take the bytes it writes back from the
+unmasked note, so masked code inside a link's text, alias or anchor is never
+published as the mask's filler.
 
 #### Scenario: Default leaves source-note bodies untouched
 
@@ -754,6 +759,16 @@ modified.
 - **WHEN** a source note contains `[[Foo|Display Text]]` and
   `rewrite_links=True`
 - **THEN** the link SHALL be rewritten to `[[Bar|Display Text]]`
+
+#### Scenario: Inline code inside a rewritten link is preserved byte-for-byte
+
+- **WHEN** a source note contains ``[the `foo` option](Old.md)``,
+  ``[[Old|the `foo` option]]`` or ``[[Old#the `foo` section]]`` and
+  `rewrite_links=True`
+- **THEN** each link SHALL be rewritten to name the new path with its text,
+  alias and anchor unchanged, backticks and all
+- **AND** no character of the source note outside the rewritten link spans
+  SHALL differ from what was there before the move
 
 #### Scenario: Path-style wikilinks updated when used
 

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -2581,6 +2581,21 @@ def _rewrite_links_in_text(
     masked = apply_fence_mask(content, fence_scan)
     rewrites: list[tuple[int, int, str]] = []
 
+    def _kept(start: int, masked_slice: str) -> str:
+        """The bytes at a match's span, taken from `content`, not `masked`.
+
+        The recognizers below run over `masked` — links inside code must not
+        be rewritten, and that is the whole reason the mask exists. But every
+        byte this function *writes back* has to come from the unmasked
+        `content`: masking is a same-length substitution, so a span found in
+        `masked` indexes the identical region of `content`, and splicing the
+        masked slice instead replaced any inline code inside a link's alias,
+        anchor or text with spaces — a silent destructive write on every
+        `move_note(rewrite_links=True)` over a source like
+        ``See [the `foo` option](Old.md)`` (#211).
+        """
+        return content[start:start + len(masked_slice)]
+
     for m in _WIKILINK_REWRITE_RE.finditer(masked):
         target_raw = m.group("target")
         target = target_raw.strip()
@@ -2595,7 +2610,7 @@ def _rewrite_links_in_text(
         else:
             new_target = to_stem
         embed_prefix = "!" if m.group("embed") else ""
-        rest = m.group("rest") or ""
+        rest = _kept(m.start("rest"), m.group("rest") or "")
         rewrites.append((m.start(), m.end(), f"{embed_prefix}[[{new_target}{rest}]]"))
 
     for link in scan_md_links(masked, **MDLINK_REWRITE_FLAGS):
@@ -2605,7 +2620,8 @@ def _rewrite_links_in_text(
         target_for_resolve = href[:-3] if href.endswith(".md") else href
         if resolve_target(target_for_resolve, source_path, pre_move_index) != from_id:
             continue
-        anchor = link.anchor
+        anchor = _kept(link.anchor_start, link.anchor)
+        text = _kept(link.text_start, link.text)
         # Resolve against the original source location, but generate the new
         # href relative to where that source lives after the move. These differ
         # for a moved note rewriting its own Markdown self-link.
@@ -2615,7 +2631,7 @@ def _rewrite_links_in_text(
         rewrites.append((
             link.start,
             link.end,
-            f"[{link.text}]({relative_target}{anchor})",
+            f"[{text}]({relative_target}{anchor})",
         ))
 
     if not rewrites:

--- a/src/mcp_server/tools.py
+++ b/src/mcp_server/tools.py
@@ -2484,10 +2484,50 @@ class MoveRewriteCapExceeded(Exception):
         )
 
 
-def _splice_rewrites(content: str, rewrites: list[tuple[int, int, str]]) -> str:
+class MoveRewriteOverlap(Exception):
+    """Two of one source's rewrites claim overlapping spans of the note.
+
+    Sibling of `MoveRewriteCapExceeded`, with the same disposition: raised out
+    of the pure rewrite function, turned into a whole-move refusal by
+    `_move_note_locked` **before any mutation**.
+
+    The spans come from two scans that are each non-overlapping, and they were
+    believed unable to overlap *each other*. They can: a markdown link's
+    ANCHOR class is `[^)]`, so `[x](Old.md#anchor[[Old]])` is one markdown
+    link whose anchor contains a whole wikilink, and when both halves resolve
+    to the moved note both are planned. There is no correct way to apply two
+    replacements to one region — the retired reverse splice applied the inner
+    one first and then used the outer one's now-stale `end`, deleting bytes
+    *outside* the link (`…[[Old]])TAIL` came back as `…[[Old]])IL`) and
+    reporting two successful rewrites — so this is refused rather than
+    resolved. The agent renames the anchor, or moves without `rewrite_links`.
+    """
+
+    def __init__(
+        self,
+        source_path: str | None,
+        first: tuple[int, int],
+        second: tuple[int, int],
+    ):
+        self.source_path = source_path
+        self.first = first
+        self.second = second
+        where = source_path or "the rewrite input"
+        super().__init__(
+            f"{where} holds two overlapping link rewrites: "
+            f"{first[0]}–{first[1]} and {second[0]}–{second[1]}"
+        )
+
+
+def _splice_rewrites(
+    content: str,
+    rewrites: list[tuple[int, int, str]],
+    source_path: str | None = None,
+) -> str:
     """Apply `(start, end, replacement)` spans to `content` in one pass.
 
-    **Linear, and byte-for-byte what the retired reverse-splice produced.**
+    **Linear, and byte-for-byte what the retired reverse-splice produced**
+    for every plan it now accepts (overlapping ones are refused, below).
     The old shape was `out = out[:start] + repl + out[end:]` per rewrite over
     a descending sort — a fresh copy of the whole note per link, so a note of
     `[[Old]] ` cost 0.07 / 0.18 / 0.72 / 5.3 s at 64 / 128 / 256 / 512 KiB
@@ -2498,43 +2538,37 @@ def _splice_rewrites(content: str, rewrites: list[tuple[int, int, str]]) -> str:
 
     The spans come from two non-overlapping scans (`_WIKILINK_REWRITE_RE`
     leftmost-non-overlapping, `scan_md_links` resuming at each match's end),
-    and they cannot overlap **each other** either: a markdown link's text
-    class excludes `[` and `]`, so no `[text](` can begin inside a wikilink
-    span and run past its `]]`. That is what makes the cursor walk equivalent
-    — but it is a property of two grammars in another module, so it is
-    *checked* rather than assumed, and a violation falls back to the old
-    splice rather than silently producing different bytes. The fallback is
-    unreachable through the scanners; it is reachable, and tested, through
-    this function directly.
+    and the cursor walk is equivalent to any per-span splice only while they
+    do not overlap **each other**. They can: a markdown link's anchor class is
+    `[^)]`, so a wikilink can sit inside a markdown link's anchor and both
+    halves can resolve to the moved note.
+
+    That is a **refusal**, not a fallback. This function used to hand such a
+    plan to a reverse splice, on the theory that the retired implementation
+    defined the answer. It does not define a correct one: applying the inner
+    replacement first changes the string's length, so the outer one then
+    splices at a stale `end` and deletes bytes *outside* the link, while the
+    tool reports both rewrites as successes — a silent destructive write, the
+    exact class this whole area exists to prevent. There is no right way to
+    apply two replacements to one region, so an overlap raises
+    `MoveRewriteOverlap` and `_move_note_locked` aborts the move before
+    anything is renamed or written.
     """
     if not rewrites:
         return content
     ordered = sorted(rewrites, key=lambda r: r[0])
     cursor = 0
+    previous = (0, 0)
     parts: list[str] = []
     for start, end, replacement in ordered:
         if start < cursor:
-            return _splice_rewrites_overlapping(content, rewrites)
+            raise MoveRewriteOverlap(source_path, previous, (start, end))
         parts.append(content[cursor:start])
         parts.append(replacement)
         cursor = end
+        previous = (start, end)
     parts.append(content[cursor:])
     return "".join(parts)
-
-
-def _splice_rewrites_overlapping(
-    content: str, rewrites: list[tuple[int, int, str]]
-) -> str:
-    """The retired reverse splice, kept verbatim for overlapping spans.
-
-    Quadratic, and deliberately so: it is the *definition* of what overlapping
-    spans mean here, and nothing the scanners can produce reaches it.
-    """
-    ordered = sorted(rewrites, key=lambda r: r[0], reverse=True)
-    out = content
-    for start, end, replacement in ordered:
-        out = out[:start] + replacement + out[end:]
-    return out
 
 
 def _rewrite_links_in_text(
@@ -2596,8 +2630,27 @@ def _rewrite_links_in_text(
         """
         return content[start:start + len(masked_slice)]
 
+    def _unmasked_target(start: int, masked_slice: str) -> bool:
+        """Is the part that DECIDES the rewrite free of masked bytes?
+
+        The other half of #211. Slicing the written-back bytes out of
+        `content` fixes what a rewrite publishes; it does not fix *which*
+        links are rewritten, and that is decided from the masked target or
+        href. The mask's filler is spaces, so ``[[`x`Old]]`` reaches
+        `resolve_target` as `"   Old"`, strips to `Old`, and a move of
+        `Old.md` rewrote a link that names a *different* note — publishing
+        `[[New]]` over a link the author never pointed at the moved note.
+        A candidate whose deciding span differs between `masked` and
+        `content` is therefore skipped outright: this server cannot know what
+        note the masked bytes were naming, and the safe answer on a
+        destructive path is to leave the link exactly as written.
+        """
+        return content[start:start + len(masked_slice)] == masked_slice
+
     for m in _WIKILINK_REWRITE_RE.finditer(masked):
         target_raw = m.group("target")
+        if not _unmasked_target(m.start("target"), target_raw):
+            continue
         target = target_raw.strip()
         if not target:
             continue
@@ -2614,6 +2667,8 @@ def _rewrite_links_in_text(
         rewrites.append((m.start(), m.end(), f"{embed_prefix}[[{new_target}{rest}]]"))
 
     for link in scan_md_links(masked, **MDLINK_REWRITE_FLAGS):
+        if not _unmasked_target(link.href_start, link.href):
+            continue
         href = link.href.strip()
         if not href:
             continue
@@ -2641,7 +2696,7 @@ def _rewrite_links_in_text(
     # at a path the move is about to vacate, reported as a success.
     if len(rewrites) > MAX_LINKS_PER_NOTE:
         raise MoveRewriteCapExceeded(source_path, len(rewrites), MAX_LINKS_PER_NOTE)
-    return _splice_rewrites(content, rewrites), len(rewrites)
+    return _splice_rewrites(content, rewrites, source_path), len(rewrites)
 
 
 def _rewrite_failure_warning(
@@ -3088,6 +3143,24 @@ async def _move_note_locked(
                         f"(MAX_LINKS_PER_NOTE={e.cap}). Nothing was moved, "
                         "rewritten or reindexed. Move without rewrite_links and "
                         "update that note's links in batches instead."
+                    )
+                except MoveRewriteOverlap as e:
+                    # Same disposition, and for a stronger reason: this source
+                    # has no correct rewritten form at all. One link nests
+                    # inside another — a wikilink inside a markdown link's
+                    # anchor — and both name the note being moved, so applying
+                    # either replacement destroys the other's span. Refused
+                    # here, before phase 2, rather than published as two
+                    # "successful" rewrites over mangled bytes (#211).
+                    logger.warning("Overlapping link rewrites: %s", e)
+                    drop(read_target)
+                    return (
+                        f"Move aborted: {original_src_path} holds a link to "
+                        f"{from_rel} nested inside another link to it, and "
+                        "rewriting either would corrupt the other. Nothing was "
+                        "moved, rewritten or reindexed. Move without "
+                        "rewrite_links, or rewrite that note's nested link by "
+                        "hand first."
                     )
                 except Exception as e:
                     logger.warning(

--- a/src/services/links.py
+++ b/src/services/links.py
@@ -181,14 +181,18 @@ class MdLinkMatch(NamedTuple):
     `m.group(0)` was), `href` carries the trailing `.md` and NOT the angle
     brackets, and `anchor` is `"#..."` or `""`.
 
-    `text_start` and `anchor_start` are where those two slices were taken
-    from, so a caller that scanned a *masked* copy can re-slice the same
-    bytes out of the unmasked original: `text` is
-    `content[text_start:text_start + len(text)]` and `anchor` is
-    `content[anchor_start:anchor_start + len(anchor)]`, both contiguous.
-    Masking is a same-length substitution, so the offsets are valid against
-    either string — `move_note`'s rewriter depends on exactly that (#211).
-    An empty `anchor` still carries the position it would have occupied.
+    `text_start`, `anchor_start` and `href_start` are where those three
+    slices were taken from, so a caller that scanned a *masked* copy can
+    re-slice the same bytes out of the unmasked original: `text` is
+    `content[text_start:text_start + len(text)]`, and `anchor` and `href`
+    likewise, each contiguous. Masking is a same-length substitution, so the
+    offsets are valid against either string — `move_note`'s rewriter depends
+    on exactly that (#211), both to write back the note's own bytes and to
+    refuse to rewrite a link whose href span differs between the two, which
+    means the mask decided a target the author never wrote. An empty `anchor`
+    still carries the position it would have occupied. `href_start` points
+    INSIDE the angle brackets for the angle form, matching `href`, which
+    excludes them.
     """
 
     start: int
@@ -199,6 +203,7 @@ class MdLinkMatch(NamedTuple):
     angle: bool
     text_start: int
     anchor_start: int
+    href_start: int
 
 
 def scan_md_links(
@@ -297,7 +302,7 @@ def scan_md_links(
                 found = MdLinkMatch(
                     m.start(), gt_at + 2, m.group("text"),
                     content[p + 1:ja + 3], content[ja + 3:gt_at], True,
-                    m.start() + 1, ja + 3,
+                    m.start() + 1, ja + 3, p + 1,
                 )
             elif (
                 gt_at < nl_at
@@ -311,7 +316,7 @@ def scan_md_links(
                 found = MdLinkMatch(
                     m.start(), gt_at + 2, m.group("text"),
                     content[p + 1:gt_at], "", True,
-                    m.start() + 1, gt_at,
+                    m.start() + 1, gt_at, p + 1,
                 )
 
         if found is None:
@@ -326,13 +331,13 @@ def scan_md_links(
                         found = MdLinkMatch(
                             m.start(), close_at + 1, m.group("text"),
                             content[p:j + 3], content[j + 3:close_at], False,
-                            m.start() + 1, j + 3,
+                            m.start() + 1, j + 3, p,
                         )
                 elif closes:
                     found = MdLinkMatch(
                         m.start(), q + 1, m.group("text"),
                         content[p:j + 3], content[j + 3:q], False,
-                        m.start() + 1, j + 3,
+                        m.start() + 1, j + 3, p,
                     )
             if (
                 found is None
@@ -344,7 +349,7 @@ def scan_md_links(
                 # `[t](href.md)`
                 found = MdLinkMatch(
                     m.start(), q + 1, m.group("text"), content[p:q], "", False,
-                    m.start() + 1, q,
+                    m.start() + 1, q, p,
                 )
 
         if found is not None:

--- a/src/services/links.py
+++ b/src/services/links.py
@@ -180,6 +180,15 @@ class MdLinkMatch(NamedTuple):
     `start`/`end` are the full match span (so `content[start:end]` is what
     `m.group(0)` was), `href` carries the trailing `.md` and NOT the angle
     brackets, and `anchor` is `"#..."` or `""`.
+
+    `text_start` and `anchor_start` are where those two slices were taken
+    from, so a caller that scanned a *masked* copy can re-slice the same
+    bytes out of the unmasked original: `text` is
+    `content[text_start:text_start + len(text)]` and `anchor` is
+    `content[anchor_start:anchor_start + len(anchor)]`, both contiguous.
+    Masking is a same-length substitution, so the offsets are valid against
+    either string — `move_note`'s rewriter depends on exactly that (#211).
+    An empty `anchor` still carries the position it would have occupied.
     """
 
     start: int
@@ -188,6 +197,8 @@ class MdLinkMatch(NamedTuple):
     href: str
     anchor: str
     angle: bool
+    text_start: int
+    anchor_start: int
 
 
 def scan_md_links(
@@ -286,6 +297,7 @@ def scan_md_links(
                 found = MdLinkMatch(
                     m.start(), gt_at + 2, m.group("text"),
                     content[p + 1:ja + 3], content[ja + 3:gt_at], True,
+                    m.start() + 1, ja + 3,
                 )
             elif (
                 gt_at < nl_at
@@ -299,6 +311,7 @@ def scan_md_links(
                 found = MdLinkMatch(
                     m.start(), gt_at + 2, m.group("text"),
                     content[p + 1:gt_at], "", True,
+                    m.start() + 1, gt_at,
                 )
 
         if found is None:
@@ -313,11 +326,13 @@ def scan_md_links(
                         found = MdLinkMatch(
                             m.start(), close_at + 1, m.group("text"),
                             content[p:j + 3], content[j + 3:close_at], False,
+                            m.start() + 1, j + 3,
                         )
                 elif closes:
                     found = MdLinkMatch(
                         m.start(), q + 1, m.group("text"),
                         content[p:j + 3], content[j + 3:q], False,
+                        m.start() + 1, j + 3,
                     )
             if (
                 found is None
@@ -329,6 +344,7 @@ def scan_md_links(
                 # `[t](href.md)`
                 found = MdLinkMatch(
                     m.start(), q + 1, m.group("text"), content[p:q], "", False,
+                    m.start() + 1, q,
                 )
 
         if found is not None:

--- a/tests/test_asvs_link_grammar.py
+++ b/tests/test_asvs_link_grammar.py
@@ -619,23 +619,31 @@ def test_the_linear_splice_is_byte_identical_to_the_retired_one():
         ), (content, spans)
 
 
-def test_overlapping_spans_fall_back_to_the_retired_splice():
-    """The cursor walk is only equivalent while spans do not overlap.
+def test_overlapping_spans_are_refused_not_spliced():
+    """The cursor walk is only equivalent while spans do not overlap — and
+    when they do, there is no correct answer to fall back to.
 
-    They cannot overlap coming out of the two scanners — a markdown link's
-    text class excludes `[` and `]`, so no `[text](` can begin inside a
-    wikilink span and run past its `]]` — but that is a property of two
-    grammars in another module, so the splice checks rather than assumes it.
-    Reached only by calling the splice directly, which is what this does.
+    This assertion used to say the opposite: overlapping spans fell back to
+    the retired reverse splice, on the theory that the retired implementation
+    *defined* the answer. It defined a wrong one. The reverse splice applies
+    the inner replacement first, which changes the string's length, so the
+    outer one then splices at a stale `end` and eats bytes outside the link
+    while the tool reports both rewrites as successes. Overlap is now a typed
+    refusal that aborts the whole move before any mutation (#211); the reach
+    from the scanners is `tests/test_issue_211_masked_splice.py`.
     """
     content = "0123456789"
     overlapping = [(0, 6, "AA"), (3, 10, "BBB")]
-    assert tools._splice_rewrites(content, overlapping) == _reverse_splice(
-        content, overlapping
-    )
-    # And it is the fallback's answer, not the cursor walk's: the cursor walk
-    # would emit "AA" then "BBB" with nothing dropped.
-    assert tools._splice_rewrites(content, overlapping) != "AABBB"
+
+    with pytest.raises(tools.MoveRewriteOverlap) as excinfo:
+        tools._splice_rewrites(content, overlapping)
+
+    assert excinfo.value.first == (0, 6)
+    assert excinfo.value.second == (3, 10)
+    # What the retired splice would have produced, for the record: it is not
+    # the cursor walk's "AABBB" either, and neither of them is `content` with
+    # two links renamed.
+    assert _reverse_splice(content, overlapping) == "AA"
 
 
 # ── the per-source rewrite cap ──────────────────────────────────────────────

--- a/tests/test_issue_211_masked_splice.py
+++ b/tests/test_issue_211_masked_splice.py
@@ -223,6 +223,136 @@ def test_backticks_on_two_different_lines_do_not_pair():
     )
 
 
+# ── eligibility is decided from the mask too (#211, round 2) ───────────────
+#
+# Slicing the written-back bytes out of `content` fixes what a rewrite
+# publishes. It does not fix *which* links are rewritten — that is decided
+# from the masked target or href, where the mask's filler is spaces. So a
+# link naming a note called `` `x`Old `` reached `resolve_target` as `"   Old"`
+# and a move of `Old.md` rewrote it, publishing `[[New]]` over a link the
+# author never pointed at the moved note. A candidate whose deciding span
+# differs between `masked` and `content` is skipped: the server cannot know
+# what the masked bytes named, and on a destructive path the safe answer is
+# to leave the link exactly as written.
+
+
+def test_a_wikilink_whose_target_holds_inline_code_is_not_rewritten():
+    content = "See [[`x`Old]] and ![[`x`Old|alias]] here.\n"
+
+    rewritten, count = _rewrite(content)
+
+    assert count == 0
+    assert rewritten == content
+
+
+def test_a_markdown_href_that_holds_inline_code_is_not_rewritten():
+    content = "See [t](`x`Old.md) and [u](`x`Old.md#sec) here.\n"
+
+    rewritten, count = _rewrite(content)
+
+    assert count == 0
+    assert rewritten == content
+
+
+def test_the_same_shapes_without_the_code_span_are_still_rewritten():
+    """The positive control: the skip above is about *masked* bytes in the
+    deciding span, not about the characters that happen to surround it."""
+    content = "See [[xOld]] and [t](xOld.md) and [[Old]] and [u](Old.md).\n"
+
+    rewritten, count = _rewrite(content)
+
+    # `xOld` is a different note and was never rewritten by anything; the two
+    # bare `Old` links are.
+    _assert_only_these_links_changed(
+        content, rewritten, count,
+        [("[[Old]]", "[[New]]"), ("[u](Old.md)", "[u](New.md)")],
+    )
+
+
+def test_a_masked_target_does_not_hide_a_neighbouring_real_link():
+    """The skip is per candidate, not per note."""
+    content = "[[`x`Old]] then [[Old]].\n"
+
+    rewritten, count = _rewrite(content)
+
+    _assert_only_these_links_changed(
+        content, rewritten, count, [("then [[Old]]", "then [[New]]")]
+    )
+
+
+# ── nested links have no correct rewrite, so the move is refused ────────────
+#
+# The two scans are each non-overlapping and were believed unable to overlap
+# *each other*. They can: a markdown link's anchor class is `[^)]`, so
+# `[x](Old.md#anchor[[Old]])` is one markdown link whose anchor contains a
+# whole wikilink, and when both halves resolve to the moved note both are
+# planned over overlapping spans. The retired reverse splice "resolved" that
+# by applying the inner replacement first and then splicing the outer one at
+# a now-stale `end`, eating bytes OUTSIDE the link while reporting two
+# successful rewrites. There is no correct answer to fall back to, so the
+# whole move is refused before anything is renamed or written.
+
+
+NESTED = "[x](Old.md#anchor[[Old]])TAIL\n"
+
+
+def test_a_wikilink_nested_in_a_markdown_anchor_raises_rather_than_splices():
+    with pytest.raises(tools.MoveRewriteOverlap) as excinfo:
+        tools._rewrite_links_in_text(
+            NESTED, "Old.md", "N.md", "src.md", _index()
+        )
+
+    assert excinfo.value.source_path == "src.md"
+    # The markdown link swallows the wikilink, which is what makes the two
+    # plans irreconcilable.
+    outer, inner = excinfo.value.first, excinfo.value.second
+    assert outer[0] <= inner[0] and inner[1] <= outer[1]
+
+
+def test_the_retired_fallback_would_have_eaten_bytes_outside_the_link():
+    """What the refusal replaces, recorded so nobody restores it.
+
+    The reverse splice applies the higher-start replacement first; the outer
+    span's `end` then points into a string that is no longer that length, so
+    `TAIL` comes back as `IL` — a destructive write two characters past a
+    link the tool said it rewrote successfully.
+    """
+    def _reverse_splice(content, rewrites):
+        out = content
+        for start, end, replacement in sorted(
+            rewrites, key=lambda r: r[0], reverse=True
+        ):
+            out = out[:start] + replacement + out[end:]
+        return out
+
+    # Exactly what the rewriter plans for `NESTED`: the markdown link is
+    # 0–25 and the wikilink inside its anchor is 17–24.
+    spans = [(0, 25, "[x](N.md#anchor[[N]])"), (17, 24, "[[N]]")]
+
+    assert _reverse_splice(NESTED, spans) == "[x](N.md#anchor[[N]])IL\n"
+    with pytest.raises(tools.MoveRewriteOverlap):
+        tools._splice_rewrites(NESTED, spans, "src.md")
+
+
+def test_a_non_overlapping_plan_still_splices():
+    """The refusal is about overlap, not about nesting-shaped input: a
+    markdown link whose anchor holds a wikilink to some OTHER note plans one
+    rewrite and goes through."""
+    content = "[x](Old.md#anchor[[Other]])TAIL\n"
+
+    rewritten, count = _rewrite(content)
+
+    _assert_only_these_links_changed(
+        content, rewritten, count,
+        [
+            (
+                "[x](Old.md#anchor[[Other]])",
+                "[x](New.md#anchor[[Other]])",
+            )
+        ],
+    )
+
+
 # ── end to end, through `move_note` ─────────────────────────────────────────
 #
 # The unit assertions above pin the function; this pins the tool, because the
@@ -305,15 +435,95 @@ async def test_move_note_does_not_blank_inline_code_in_a_backlink_source(
     )
 
 
+async def test_move_note_refuses_the_whole_move_on_a_nested_link(
+    rewrite_vault, monkeypatch
+):
+    """The refusal reaches the tool as a preflight abort: nothing renamed,
+    nothing written, and the message names the note the agent has to fix."""
+    source = NESTED
+    (rewrite_vault / "Old.md").write_text("moved\n", encoding="utf-8")
+    (rewrite_vault / "src.md").write_text(source, encoding="utf-8")
+    monkeypatch.setattr(
+        tools,
+        "async_session",
+        _fake_session(
+            [_Row(file_path="Old.md", id=1), _Row(file_path="src.md", id=2)],
+            [_Row(file_path="src.md")],
+        ),
+    )
+
+    result = await tools.move_note_impl("Old.md", "N.md", rewrite_links=True)
+
+    assert "Move aborted" in result, result
+    assert "src.md" in result, result
+    assert "Nothing was moved, rewritten or reindexed" in result, result
+    # Nothing was renamed …
+    assert (rewrite_vault / "Old.md").is_file()
+    assert not (rewrite_vault / "N.md").exists()
+    # … and the source note is byte-identical, `TAIL` and all.
+    assert (rewrite_vault / "src.md").read_text(encoding="utf-8") == source
+
+
 # ── the property the fix rests on ───────────────────────────────────────────
 
 
-def test_the_scanner_reports_where_it_took_text_and_anchor_from():
-    """`MdLinkMatch.text_start` / `anchor_start` are what let the rewriter
-    re-slice from the unmasked note, so they have to name the exact region the
-    scanner's own `text` and `anchor` came from — in every branch, extraction's
-    and the rewriter's alike, including the angle form the rewriter never
-    reaches and the empty anchor that still carries a position."""
+# Each row is one branch of the scanner, with the offsets written out rather
+# than derived. A slice-equality check cannot see a wrong `anchor_start` on an
+# anchorless link — every zero-length slice equals the empty anchor — so the
+# empty-anchor rows pin the exact `>` and `)` positions the scanner reports.
+# All five use the same 4-character prefix so a zero offset cannot pass.
+#
+#   (flags, text, start, end, text_start, href_start, anchor_start, href, anchor)
+SCANNER_BRANCHES = [
+    ("extract", "pre [t](a.md)", 4, 13, 5, 8, 12, "a.md", ""),
+    ("rewrite", "pre [t](a.md)", 4, 13, 5, 8, 12, "a.md", ""),
+    ("extract", "pre [t](a.md#sec)", 4, 17, 5, 8, 12, "a.md", "#sec"),
+    ("rewrite", "pre [t](a.md#sec)", 4, 17, 5, 8, 12, "a.md", "#sec"),
+    # The rewriter's anchor crosses newlines; extraction's does not, so this
+    # shape is a match for one grammar and not the other.
+    ("rewrite", "pre [t](a.md#sec\nmore)", 4, 22, 5, 8, 12, "a.md", "#sec\nmore"),
+    # The angle form exists only in extraction (`angle=False` for the
+    # rewriter), and `href_start` points INSIDE the bracket.
+    ("extract", "pre [t](<a.md>)", 4, 15, 5, 9, 13, "a.md", ""),
+    ("extract", "pre [t](<a.md#sec>)", 4, 19, 5, 9, 13, "a.md", "#sec"),
+]
+
+
+@pytest.mark.parametrize(
+    "flags,text,start,end,text_start,href_start,anchor_start,href,anchor",
+    SCANNER_BRANCHES,
+)
+def test_the_scanner_reports_where_it_took_each_slice_from(
+    flags, text, start, end, text_start, href_start, anchor_start, href, anchor
+):
+    """`text_start` / `href_start` / `anchor_start` are what let the rewriter
+    re-slice from the unmasked note and refuse a masked href, so each branch
+    reports them as integers here, not as "whatever the slice happens to
+    equal"."""
+    from src.services.links import scan_md_links
+
+    kwargs = {} if flags == "extract" else tools.MDLINK_REWRITE_FLAGS
+    (link,) = scan_md_links(text, **kwargs)
+
+    assert (link.start, link.end) == (start, end)
+    assert (link.text_start, link.href_start, link.anchor_start) == (
+        text_start,
+        href_start,
+        anchor_start,
+    )
+    assert (link.text, link.href, link.anchor) == ("t", href, anchor)
+    # Redundant with the integers above by construction, and kept anyway: it
+    # is the property the rewriter actually relies on.
+    assert text[link.text_start:link.text_start + len(link.text)] == link.text
+    assert text[link.href_start:link.href_start + len(link.href)] == link.href
+    assert (
+        text[link.anchor_start:link.anchor_start + len(link.anchor)] == link.anchor
+    )
+
+
+def test_every_scanner_branch_agrees_with_its_own_slices_over_a_corpus():
+    """The same property swept over a mixed corpus, so a branch nobody wrote a
+    row for is still covered."""
     from src.services.links import scan_md_links
 
     corpus = (
@@ -330,14 +540,16 @@ def test_the_scanner_reports_where_it_took_text_and_anchor_from():
                 == link.text
             ), (flags, link)
             assert (
+                corpus[link.href_start:link.href_start + len(link.href)]
+                == link.href
+            ), (flags, link)
+            assert (
                 corpus[link.anchor_start:link.anchor_start + len(link.anchor)]
                 == link.anchor
             ), (flags, link)
             # The reported spans sit inside the match they belong to.
-            assert link.start < link.text_start
+            assert link.start < link.text_start < link.href_start
             assert link.anchor_start + len(link.anchor) <= link.end
-
-
 
 
 def test_the_mask_is_the_same_length_as_what_it_replaces():

--- a/tests/test_issue_211_masked_splice.py
+++ b/tests/test_issue_211_masked_splice.py
@@ -1,0 +1,369 @@
+"""`move_note`'s rewrite splices bytes from the note, not from the mask (#211).
+
+`_rewrite_links_in_text` runs both recognizers over the fence/inline-code
+**masked** copy of the source — links inside code must not be rewritten, and
+that is the whole point of the mask. It then splices a replacement over the
+match's span in the **unmasked** content. Before this fix it built that
+replacement out of pieces it had read off the masked string: the wikilink
+`rest` (`#anchor|alias`) and the markdown link's text and anchor. Inline code
+inside any of those is a run of spaces in the mask, so::
+
+    IN : See [the `foo` option](Old.md) and [[Old]] here.
+    OUT: See [the       option](New.md) and [[New]] here.
+
+A silent destructive write on every `move_note(rewrite_links=True)` whose
+backlink sources hold inline code inside a link — the expensive failure class
+for this product, because an agent never sees the bytes it just lost.
+
+The fix is one property: masking is a **same-length** substitution, so a span
+discovered in `masked` indexes the identical region of `content`, and every
+byte written back is sliced from `content` at that span. What the recognizers
+*see* is unchanged, so which links get rewritten is unchanged too — the
+fenced-code and inline-code exclusions below are the same assertions they were
+before, kept here so a future "just splice from the mask, it is simpler"
+cannot pass.
+"""
+import pytest
+
+import src.mcp_server.tools as tools
+from src.auth.session import current_user_id
+from src.mcp_server.auth import current_permission
+from src.services import vault as vault_service
+from src.services.links import build_vault_index
+
+
+def _index():
+    return build_vault_index([("Old.md", 1), ("New.md", 2)])
+
+
+def _rewrite(content: str, source_path: str = "src.md"):
+    return tools._rewrite_links_in_text(
+        content, "Old.md", "New.md", source_path, _index()
+    )
+
+
+def _assert_only_these_links_changed(content, rewritten, count, edits):
+    """Byte identity everywhere outside the rewritten link spans.
+
+    `edits` is `[(old_link, new_link), …]`, each unique in `content`. Applying
+    exactly those substitutions to the input must reproduce the output
+    character for character — frontmatter, fences, inline code, whitespace,
+    non-ASCII and all — which is a stronger statement than "the new link is in
+    there somewhere".
+    """
+    expected = content
+    for old, new in edits:
+        assert expected.count(old) == 1, old
+        expected = expected.replace(old, new)
+    assert rewritten == expected
+    assert count == len(edits)
+
+
+# ── the bug: inline code inside a rewritten link ────────────────────────────
+
+
+def test_inline_code_in_markdown_link_text_survives_the_rewrite():
+    content = "See [the `foo` option](Old.md) for the flag.\n"
+
+    rewritten, count = _rewrite(content)
+
+    assert rewritten == "See [the `foo` option](New.md) for the flag.\n"
+    _assert_only_these_links_changed(
+        content, rewritten, count,
+        [("[the `foo` option](Old.md)", "[the `foo` option](New.md)")],
+    )
+
+
+def test_inline_code_in_a_wikilink_alias_survives_the_rewrite():
+    content = "See [[Old|the `foo` option]] for the flag.\n"
+
+    rewritten, count = _rewrite(content)
+
+    assert rewritten == "See [[New|the `foo` option]] for the flag.\n"
+    _assert_only_these_links_changed(
+        content, rewritten, count,
+        [("[[Old|the `foo` option]]", "[[New|the `foo` option]]")],
+    )
+
+
+def test_inline_code_in_a_wikilink_anchor_survives_the_rewrite():
+    content = "See [[Old#the `foo` section]] and ![[Old#`bar`|`baz` alias]].\n"
+
+    rewritten, count = _rewrite(content)
+
+    _assert_only_these_links_changed(
+        content, rewritten, count,
+        [
+            ("[[Old#the `foo` section]]", "[[New#the `foo` section]]"),
+            ("![[Old#`bar`|`baz` alias]]", "![[New#`bar`|`baz` alias]]"),
+        ],
+    )
+
+
+def test_inline_code_in_a_markdown_anchor_survives_the_rewrite():
+    """The anchor was spliced from the mask too, for the same reason."""
+    content = "See [t](Old.md#the `foo` section) for the flag.\n"
+
+    rewritten, count = _rewrite(content)
+
+    _assert_only_these_links_changed(
+        content, rewritten, count,
+        [
+            (
+                "[t](Old.md#the `foo` section)",
+                "[t](New.md#the `foo` section)",
+            )
+        ],
+    )
+
+
+def test_a_note_full_of_code_keeps_every_byte_outside_its_links():
+    """One document carrying every shape at once, asserted byte-for-byte.
+
+    Frontmatter, a fenced block, an inline span outside a link, non-ASCII, a
+    CRLF line and four rewritable links with code inside them. The masker is a
+    same-length substitution over all of it, so nothing outside the four link
+    spans may move by a single character.
+    """
+    content = (
+        "---\ntitle: Notes — `raw`\n---\n\n"
+        "Prose with `inline code` and an ünicöde — dash.\r\n"
+        "A markdown link: [the `foo` option](Old.md#sec `x`).\n"
+        "A wikilink: [[Old|`bar` baz]].\n"
+        "An embed: ![[Old#`h`]].\n"
+        "```python\n"
+        "x = [not_a_link](Old.md)  # inside a fence\n"
+        "```\n"
+        "A plain one: [[Old]].\n"
+    )
+
+    rewritten, count = _rewrite(content)
+
+    _assert_only_these_links_changed(
+        content, rewritten, count,
+        [
+            (
+                "[the `foo` option](Old.md#sec `x`)",
+                "[the `foo` option](New.md#sec `x`)",
+            ),
+            ("[[Old|`bar` baz]]", "[[New|`bar` baz]]"),
+            ("![[Old#`h`]]", "![[New#`h`]]"),
+            ("[[Old]]", "[[New]]"),
+        ],
+    )
+    # And the fenced link is still there, still naming the old path.
+    assert "x = [not_a_link](Old.md)  # inside a fence" in rewritten
+
+
+# ── the exclusions the mask exists for, unchanged ───────────────────────────
+
+
+def test_a_link_entirely_inside_inline_code_is_still_not_rewritten():
+    """The pre-existing behaviour, and the reason the recognizers keep running
+    over `masked`: a link written as an example inside backticks is text about
+    a link, not a link."""
+    content = "Write it as `[x](Old.md)` or `[[Old]]`, not otherwise.\n"
+
+    rewritten, count = _rewrite(content)
+
+    assert count == 0
+    assert rewritten == content
+
+
+def test_a_link_inside_a_fenced_block_is_still_not_rewritten():
+    content = (
+        "```\n[x](Old.md)\n[[Old]]\n```\n"
+        "~~~md\n![[Old]]\n~~~\n"
+        "and [[Old]] outside\n"
+    )
+
+    rewritten, count = _rewrite(content)
+
+    _assert_only_these_links_changed(
+        content, rewritten, count, [("[[Old]] outside", "[[New]] outside")]
+    )
+
+
+def test_a_lone_backtick_masks_nothing_and_is_kept():
+    """`_INLINE_CODE_RE` pairs backticks; a single one on the line is not a
+    code span, so the link is masked nowhere, is rewritten, and keeps its
+    backtick — the slice-from-content path with nothing to restore."""
+    content = "See [a ` b](Old.md) here.\n"
+
+    rewritten, count = _rewrite(content)
+
+    _assert_only_these_links_changed(
+        content, rewritten, count, [("[a ` b](Old.md)", "[a ` b](New.md)")]
+    )
+
+
+def test_two_backticks_around_a_link_still_hide_it_from_the_rewrite():
+    """The other side of the same rule, and PRE-EXISTING: two lone backticks on
+    one line pair with each other, so everything between them — including a
+    whole link — is a code span and is not rewritten. Unchanged by #211: the
+    fix moved where the written-back bytes come from, not what the recognizers
+    see."""
+    content = "See [a ` b](Old.md) and [[Old|c ` d]] here.\n"
+
+    rewritten, count = _rewrite(content)
+
+    assert count == 0
+    assert rewritten == content
+
+
+def test_backticks_on_two_different_lines_do_not_pair():
+    """`_INLINE_CODE_RE` never crosses a terminator, so these two backticks are
+    two lone backticks and the link between them is a link."""
+    content = "one ` line\n[[Old]] between\ntwo ` line\n"
+
+    rewritten, count = _rewrite(content)
+
+    _assert_only_these_links_changed(
+        content, rewritten, count, [("[[Old]]", "[[New]]")]
+    )
+
+
+# ── end to end, through `move_note` ─────────────────────────────────────────
+#
+# The unit assertions above pin the function; this pins the tool, because the
+# corruption reached disk. Same fixture shape as
+# `tests/test_asvs_link_grammar.py`'s dispatch test.
+
+
+class _Row:
+    def __init__(self, **fields):
+        self.__dict__.update(fields)
+
+
+def _fake_session(*result_rows):
+    calls = {"n": 0}
+
+    class Result:
+        def __init__(self, rows):
+            self._rows = rows
+
+        def all(self):
+            return self._rows
+
+    class FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def execute(self, statement):
+            i = calls["n"]
+            calls["n"] += 1
+            return Result(result_rows[i] if i < len(result_rows) else [])
+
+        async def commit(self):
+            return None
+
+    return FakeSession
+
+
+@pytest.fixture
+def rewrite_vault(monkeypatch, tmp_path):
+    monkeypatch.setattr(vault_service.settings, "vault_path", str(tmp_path))
+
+    async def noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(tools, "_log_usage", noop)
+    perm = current_permission.set("readwrite")
+    uid = current_user_id.set(None)
+    yield tmp_path
+    current_user_id.reset(uid)
+    current_permission.reset(perm)
+
+
+async def test_move_note_does_not_blank_inline_code_in_a_backlink_source(
+    rewrite_vault, monkeypatch
+):
+    source = (
+        "See [the `foo` option](Old.md) and [[Old|`bar` baz]].\n"
+        "`[x](Old.md)` is only an example.\n"
+    )
+    (rewrite_vault / "Old.md").write_text("moved\n", encoding="utf-8")
+    (rewrite_vault / "src.md").write_text(source, encoding="utf-8")
+    monkeypatch.setattr(
+        tools,
+        "async_session",
+        _fake_session(
+            [_Row(file_path="Old.md", id=1), _Row(file_path="src.md", id=2)],
+            [_Row(file_path="src.md")],
+        ),
+    )
+
+    result = await tools.move_note_impl("Old.md", "New.md", rewrite_links=True)
+
+    assert "Moved Old.md → New.md" in result, result
+    assert (rewrite_vault / "src.md").read_text(encoding="utf-8") == (
+        "See [the `foo` option](New.md) and [[New|`bar` baz]].\n"
+        "`[x](Old.md)` is only an example.\n"
+    )
+
+
+# ── the property the fix rests on ───────────────────────────────────────────
+
+
+def test_the_scanner_reports_where_it_took_text_and_anchor_from():
+    """`MdLinkMatch.text_start` / `anchor_start` are what let the rewriter
+    re-slice from the unmasked note, so they have to name the exact region the
+    scanner's own `text` and `anchor` came from — in every branch, extraction's
+    and the rewriter's alike, including the angle form the rewriter never
+    reaches and the empty anchor that still carries a position."""
+    from src.services.links import scan_md_links
+
+    corpus = (
+        "[plain](a.md) [anchored](b.md#sec) [angle](<c.md>) "
+        "[angle anchored](<d.md#sec>) [with `code`](e.md#an `chor`)\n"
+        "[crossing](f.md#sec\nmore)\n"
+    )
+    for flags in ({}, tools.MDLINK_REWRITE_FLAGS):
+        links = list(scan_md_links(corpus, **flags))
+        assert links, flags
+        for link in links:
+            assert (
+                corpus[link.text_start:link.text_start + len(link.text)]
+                == link.text
+            ), (flags, link)
+            assert (
+                corpus[link.anchor_start:link.anchor_start + len(link.anchor)]
+                == link.anchor
+            ), (flags, link)
+            # The reported spans sit inside the match they belong to.
+            assert link.start < link.text_start
+            assert link.anchor_start + len(link.anchor) <= link.end
+
+
+
+
+def test_the_mask_is_the_same_length_as_what_it_replaces():
+    """Stated here as well as in `src/services/links.py` because the rewrite's
+    correctness now depends on it directly: if masking ever stopped preserving
+    offsets, every slice taken from `content` at a masked match's span would
+    silently read the wrong bytes."""
+    from src.services.links import FULL_NOTE, apply_fence_mask, scan_fences
+
+    content = (
+        "---\nt: `y`\n---\n"
+        "a `b` c\n```\nfenced `code`\n```\n~~~\nmore\n~~~\nünicöde `x`\r\n"
+    )
+    masked = apply_fence_mask(content, scan_fences(content, context=FULL_NOTE))
+
+    assert len(masked) == len(content)
+    # It really did mask, so the length assertion is not vacuous — and every
+    # masked character is a space, never a shorter or longer stand-in.
+    assert "`" not in masked
+    assert all(
+        m == c or m == " " for m, c in zip(masked, content, strict=True)
+    )
+    # An inline span, unlike a fenced one, leaves its line terminators alone —
+    # only a fence masks across lines.
+    inline_only = "a `b` c\nd `e` f\r\n"
+    inline_masked = apply_fence_mask(
+        inline_only, scan_fences(inline_only, context=FULL_NOTE)
+    )
+    assert inline_masked == "a     c\nd     f\r\n"

--- a/tests/test_issue_211_masked_splice.py
+++ b/tests/test_issue_211_masked_splice.py
@@ -18,7 +18,11 @@ for this product, because an agent never sees the bytes it just lost.
 The fix is one property: masking is a **same-length** substitution, so a span
 discovered in `masked` indexes the identical region of `content`, and every
 byte written back is sliced from `content` at that span. What the recognizers
-*see* is unchanged, so which links get rewritten is unchanged too — the
+*see* is unchanged (they still run over the mask), but a post-recognition
+eligibility filter is new: a candidate whose *deciding* span — the wikilink
+target or the markdown href — contains masked bytes is skipped rather than
+rewritten, and overlapping rewrite spans refuse the whole move instead of
+falling back to a splice that corrupted bytes outside the link. The
 fenced-code and inline-code exclusions below are the same assertions they were
 before, kept here so a future "just splice from the mask, it is simpler"
 cannot pass.


### PR DESCRIPTION
## The bug

`_rewrite_links_in_text` (`src/mcp_server/tools.py`) runs both link
recognizers over the fence/inline-code **masked** copy of a backlink source —
correct, and the whole reason the mask exists: a link inside a fence or inside
backticks is text *about* a link and must not be rewritten. But it assembled
the replacement it splices back into the **unmasked** note out of pieces read
off that masked string: the wikilink `rest` (`#anchor|alias`), and the markdown
link's `text` and `anchor`. Inline code inside any of those is a run of spaces
in the mask, so:

```
IN : See [the `foo` option](Old.md) and [[Old]] here.
OUT: See [the       option](New.md) and [[New]] here.
```

That went to disk on every `move_note(rewrite_links=True)` whose backlink
sources hold inline code inside a link — a silent destructive write on the one
path whose entire job is to change the target and leave everything else alone.
Pre-existing on `main`; found by the adversarial review of #210 and filed
separately as out of that change's scope.

## The fix

Masking is a **same-length** substitution, so a span discovered in the masked
copy indexes the identical region of `content`. Every byte written back is now
sliced from `content` at the match's span:

- wikilink `rest` → `content[m.start("rest"):…]`, via a small local `_kept()`
  helper that carries the reason;
- markdown `text` / `anchor` → new `MdLinkMatch.text_start` and `anchor_start`
  fields on the scanner's result, recording where the scanner took those two
  slices from. The scanner's matching semantics are untouched — the five
  construction sites each gained the offsets they already had in hand.

## Round 2 — the Codex review's two BLOCKERs

**Overlapping rewrites are refused, not reverse-spliced.** The two scans were
believed unable to overlap each other because a markdown link's *text* class
excludes brackets. Its *anchor* class is `[^)]`, so
`[x](Old.md#anchor[[Old]])` is one markdown link whose anchor holds a whole
wikilink, and a move of `Old.md` plans both over overlapping spans.
`_splice_rewrites` handed that to the retired reverse splice, which applies the
inner replacement first — changing the string's length — and then splices the
outer one at a stale `end`:

```
[x](Old.md#anchor[[Old]])TAIL  ->  [x](N.md#anchor[[Old]])IL
```

Two characters eaten past the end of the link, reported as two successful
rewrites. `_splice_rewrites` now raises `MoveRewriteOverlap` (sibling of
`MoveRewriteCapExceeded`); `_move_note_locked` turns it into a whole-move
refusal before the rename, naming the source. `_splice_rewrites_overlapping` is
deleted — a fallback that produces *some* bytes is worse than a refusal
whenever nobody can say those bytes are right.

**A candidate whose deciding span carries masked bytes is skipped.** Slicing
the written-back bytes from `content` fixed what a rewrite publishes, not which
links it rewrites — that was still decided from the masked target or href,
where the filler is spaces. ``[[`x`Old]]`` reached `resolve_target` as
`"   Old"`, so a move of `Old.md` published `[[New]]` over a link naming a
different note. Each candidate's target/href span is now compared between
`masked` and `content`; a difference skips it. `MdLinkMatch` gains
`href_start`, appended like the previous two.

Neither round changes the grammar, the ordering, or the caps; what the
recognizers *see* is unchanged.

## Tests

`tests/test_issue_211_masked_splice.py` (28 cases):

- inline code inside markdown link text, a wikilink alias, a wikilink anchor,
  and a markdown link's anchor;
- one note mixing frontmatter, a fenced block, CRLF, non-ASCII and four
  rewritable links, asserted **byte-for-byte**: applying only the four target
  substitutions to the input must reproduce the output exactly;
- the exclusions the mask exists for, unchanged — a link wholly inside inline
  code and a link inside a fence are still not rewritten;
- backticks that form no code span (a lone backtick is not a span and is kept;
  two lone backticks on a line still pair and hide the link between them, as
  before);
- both masked-target inputs left byte-identical, with a positive control and a
  neighbouring-real-link case;
- the nested-link refusal at the unit level and end to end through
  `move_note` (nothing renamed, source byte-identical, refusal names it), plus
  the retired fallback's exact corruption pinned as the thing being replaced;
- the scanner's span fields parameterized over the five branches with explicit
  `text_start` / `href_start` / `anchor_start` integers — a zero-length slice
  can no longer hide a wrong `anchor_start` on an anchorless link — and swept
  over a mixed corpus.

Six of the round-1 cases fail on the pre-fix code. The retired-fallback
assertion in `tests/test_asvs_link_grammar.py` now asserts the refusal.

Full unit suite: 3072 → **3100 passed**, 435 skipped, 0 failures (3507 → 3535
collected). `openspec validate --specs --strict` passes.

## Docs and spec

- `docs/architecture/vault-tools.md`: the splice section now records that
  overlap is a refusal rather than a fallback and why the fallback was wrong,
  that recognizers read the masked copy while every written byte is sliced
  from the unmasked note, and that a candidate whose deciding span carries
  masked bytes is skipped. The refusal list above it gains the nested-link
  case.
- `openspec/specs/vault-write/spec.md`: the `move_note` rewrite requirement now
  says a rewrite changes only the link target, must not rewrite a link whose
  target differs between the masked copy and the note, and must refuse the
  whole move when two rewrites cannot both be applied — plus three scenarios
  (byte-for-byte inline code, masked target left alone, nested link refused).

## Noticed, deliberately left alone

- **Extraction is deliberately not changed** to match the new masked-target
  skip. `extract_links` still records `Old` as the target of ``[[`x`Old]]``,
  so `note_links` can hold a row for a link whose real target is unknowable
  once masked. That is a graph inaccuracy a reindex corrects, not bytes lost
  from a note, and closing it would change what `note_links` holds — a
  `CURRENT_EXTRACTION_VERSION` bump and a full re-derivation of every note's
  links. Left for a follow-up issue.
- Two lone backticks on one line pair into a code span, so
  ``[a ` b](Old.md) and [[Old|c ` d]]`` is masked end to end and neither link
  is rewritten. Pre-existing masker behaviour, unrelated to this splice; pinned
  as a test rather than changed.

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWbxW7QFtncUwizXdNyNCZ
