### PR TITLE
feat(panel): vault-root-overlap-guard Slice 6 — operator surface and E4

### DIFF
--- a/openspec/changes/vault-root-overlap-guard/tasks.md
+++ b/openspec/changes/vault-root-overlap-guard/tasks.md
@@ -90,13 +90,13 @@ slice-1 fixture and some need their expectations re-read:
 
 ## 6. Operator surface and the `_reindex_background` entry point — `src/control_panel/routes.py`, `src/control_panel/templates/dashboard.html`, `src/control_panel/templates/health.html`, `tests/test_panel_overlap_surface.py`
 
-- [ ] 6.1 `_health_strip` reads the published snapshot (never recomputes it, never opens a directory) and resolves the usernames and roots it names; the strip and the health page render the condition for administrators only.
-- [ ] 6.2 The two reasons are worded separately: an overlap names the peer account and the relation; an unexaminable root names the root and the errno and states that no peer was observed.
-- [ ] 6.3 The condition clears on its own when a later snapshot no longer names the account; it is not a flash message and needs no dismissal. An empty snapshot renders nothing, and the never-published state renders its own "not yet checked" note rather than an all-clear.
-- [ ] 6.4 `vault_page` renders the existing `vault_error` empty state for a named user.
-- [ ] 6.5 Templates use theme tokens only — no color literals — so `colorscan` / the literal sweep stays clean.
-- [ ] 6.6 **E4:** `_reindex_background` calls `detect_and_publish()` at its top, before `index_pass_lock` is taken, so Reindex Now, re-embed and reset-embeddings cannot start a pass against an unchecked snapshot. This file is owned here, so the call site lands in this slice; the helper it calls comes from slice 1 and the stage skip from slice 3.
-- [ ] 6.7 Tests: the strip names every affected account, its reason and its root for an admin; **the pair is still named from the snapshot's recorded facts after the peer's assignment is corrected and after the peer row is deleted, before the next detection publishes**; a non-admin sees no other account's name or path; an empty snapshot renders nothing; the never-published state renders the not-yet-checked note; the handler opens no directory; `vault_page` empty state; `_reindex_background` publishes before taking the pass lock.
+- [x] 6.1 `_health_strip` reads the published snapshot (never recomputes it, never opens a directory) and resolves the usernames and roots it names; the strip and the health page render the condition for administrators only.
+- [x] 6.2 The two reasons are worded separately: an overlap names the peer account and the relation; an unexaminable root names the root and the errno and states that no peer was observed.
+- [x] 6.3 The condition clears on its own when a later snapshot no longer names the account; it is not a flash message and needs no dismissal. An empty snapshot renders nothing, and the never-published state renders its own "not yet checked" note rather than an all-clear.
+- [x] 6.4 `vault_page` renders the existing `vault_error` empty state for a named user.
+- [x] 6.5 Templates use theme tokens only — no color literals — so `colorscan` / the literal sweep stays clean.
+- [x] 6.6 **E4:** `_reindex_background` calls `detect_and_publish()` at its top, before `index_pass_lock` is taken, so Reindex Now, re-embed and reset-embeddings cannot start a pass against an unchecked snapshot. This file is owned here, so the call site lands in this slice; the helper it calls comes from slice 1 and the stage skip from slice 3.
+- [x] 6.7 Tests: the strip names every affected account, its reason and its root for an admin; **the pair is still named from the snapshot's recorded facts after the peer's assignment is corrected and after the peer row is deleted, before the next detection publishes**; a non-admin sees no other account's name or path; an empty snapshot renders nothing; the never-published state renders the not-yet-checked note; the handler opens no directory; `vault_page` empty state; `_reindex_background` publishes before taking the pass lock.
 
 ## 7. Documentation — `docs/architecture/*.md`, `README.md`, `CLAUDE.md`
 

--- a/src/control_panel/routes.py
+++ b/src/control_panel/routes.py
@@ -44,7 +44,7 @@ from src.oauth.scope import (
     has_vault_scope,
     token_has_write,
 )
-from src.services import security_events
+from src.services import security_events, vault_overlap
 from src.services.index_state import (
     KEY_EMBEDDING_FINGERPRINT,
     acquire_generation_lock,
@@ -1753,6 +1753,70 @@ async def _backup_view(session: AsyncSession) -> dict | None:
     return {**backup, "age_rel": _humanize_delta(backup["created_at"])}
 
 
+def _quarantine_view(is_admin: bool) -> dict | None:
+    """The published vault-root quarantine, as the operator surfaces render it.
+
+    **A read of the published snapshot and nothing else.** One attribute read
+    and a mapping walk: no session, no statement, and — the part that matters —
+    no `open`, no `stat` and no `realpath`. The panel must not touch a vault
+    root on a page render, and two independent computations of "do these roots
+    overlap" is how the panel and the enforcement come to disagree.
+
+    **It re-reads no `users` row either.** Every name, path and relation here is
+    a fact the detection recorded at the moment it looked, and the surfaces
+    label them "as at last check". An operator's first move on reading "vault
+    root overlaps <peer>" is to edit or delete one of the two accounts; a
+    render-time resolution would show a changed path — or a blank where the
+    deleted peer was — beside a condition that is still in force.
+
+    Administrators only, the same split the backup and error cells already
+    take: the condition names another account and another account's vault path,
+    which is exactly what the tool-facing refusal withholds because its reader
+    is a tenant's agent. `None` for everyone else, so the templates render
+    nothing rather than an empty operator section.
+
+    The tri-state comes through intact:
+
+    * never published → `checked: False`, and the surfaces say the roots have
+      not been checked yet rather than rendering an all-clear;
+    * published and empty → `accounts: []`, and nothing renders — an empty
+      snapshot is the healthy state, not an error state;
+    * published with reasons → one entry per named account.
+    """
+    if not is_admin:
+        return None
+    snapshot = vault_overlap.published_snapshot()
+    if snapshot is None:
+        return {"checked": False, "detected_at_iso": None, "accounts": []}
+    return {
+        "checked": True,
+        "detected_at_iso": snapshot.detected_at.isoformat(),
+        "accounts": [
+            {
+                "user_id": entry.user_id,
+                "username": entry.username,
+                "assignment": entry.assignment,
+                # Which of the two reasons this is. They are worded apart
+                # because they need different fixes and the wrong wording sends
+                # the operator to the wrong place: an overlap is corrected by
+                # changing an assignment or a mount, an unexaminable root by
+                # restoring one — and describing the latter as an overlap sends
+                # an administrator hunting for a second account that does not
+                # exist.
+                "overlap": isinstance(entry.reason, vault_overlap.Overlap),
+                # The one operator wording, shared with the log line and the
+                # `indexer_runs` row. Composing a second one here is how the
+                # panel and the run row come to describe the same condition
+                # differently.
+                "text": vault_overlap.operator_text(entry),
+            }
+            for entry in sorted(
+                snapshot.entries.values(), key=lambda e: (e.username, e.user_id)
+            )
+        ],
+    }
+
+
 @router.get("/health", response_class=HTMLResponse)
 async def health_page(
     request: Request,
@@ -1787,6 +1851,11 @@ async def health_page(
             "show_ops": is_admin,
             "backup": backup,
             "stale_after_days": STALE_AFTER_DAYS,
+            # The same condition the dashboard's strip carries, from the same
+            # published snapshot — read once here, not recomputed, and never
+            # resolved against `users`. The page is where an operator reads the
+            # detail after the strip has told them there is some.
+            "quarantine": _quarantine_view(is_admin),
             **(errors or {}),
         }),
     )
@@ -1821,6 +1890,15 @@ async def _health_strip(session: AsyncSession, user) -> dict:
         # The count and the window, not the hundred records — the strip links
         # to the page, which is where they are read.
         strip.update(_error_window())
+    # The vault-root quarantine, read from the published snapshot. It belongs
+    # above the fold for the reason the strip exists: the condition has
+    # silently disabled a tenant's tools, it persists until an operator acts,
+    # and every other record of it decays — the container log rotates and the
+    # error ring buffer is a hundred entries for the life of *this* process, so
+    # the line naming it is gone after a restart while the two roots are still
+    # overlapping. It is not a flash: nothing is dismissed, and it disappears
+    # on its own once a later snapshot stops naming the account.
+    strip["quarantine"] = _quarantine_view(is_admin)
     return strip
 
 
@@ -1867,6 +1945,11 @@ async def _health_strip_or_degraded(session: AsyncSession, user) -> dict:
             exc_info=True,
             error_type=type(exc).__name__,
         )
+        # No `quarantine` key here, and the dashboard template treats its
+        # absence as "nothing to show". A degraded strip is the one case where
+        # the condition is not on the dashboard; it is still on the health page
+        # this cell links to, which reads the snapshot on its own and shares
+        # none of the three queries that failed here.
         return {"unavailable": True, "show_ops": _is_admin(user)}
 
 
@@ -1993,7 +2076,11 @@ async def vault_page(
     folder = request.query_params.get("folder", "")
     selected_note = request.query_params.get("note")
 
-    from src.services.vault import _vault_root, vault_unassigned_error
+    from src.services.vault import (
+        _refuse_quarantined_root,
+        _vault_root,
+        vault_unassigned_error,
+    )
 
     # Resolve the per-user vault root. In single-user mode `user.id` is None
     # and `_vault_root(None)` returns `settings.vault_path` — the legacy
@@ -2017,6 +2104,25 @@ async def vault_page(
         vault = await warm_user_vault_cache(session, user.id)
         if vault is None:
             vault_error = vault_unassigned_error(user.id)
+        else:
+            # The vault browser is the panel's third consuming surface, beside
+            # every MCP tool and transfer redemption, and it has to refuse for
+            # the same reasons: listing a directory tree beneath a root that
+            # overlaps another tenant's shows this user another tenant's notes,
+            # which is the leak the quarantine exists to stop. The gate's own
+            # refusal is reused rather than re-derived — one implementation of
+            # "is this caller quarantined", and the wording that names no other
+            # account or path, which is right here too because this page is not
+            # admin-only.
+            #
+            # After the warm, not before: an account whose assignment was
+            # cleared while a stale snapshot still names it should be told it
+            # has no vault, which is the thing the operator just did to it.
+            try:
+                _refuse_quarantined_root(user.id)
+            except RuntimeError as e:
+                vault = None
+                vault_error = str(e)
 
     if vault_error is not None:
         return templates.TemplateResponse(request, "vault.html", _panel_context(request, user, {
@@ -2511,9 +2617,20 @@ async def _reindex_background():
     # from a five-minute tick — which is the first thing anyone asks when a
     # pass in the history took ten times as long as its neighbours.
     from src.services.indexer import (
-        index_vault, embed_vault, _active_user_ids, index_pass_lock,
-        record_indexer_run,
+        index_vault, embed_vault, _active_user_ids, detect_root_overlaps,
+        index_pass_lock, record_indexer_run,
     )
+    # E4 — **before `index_pass_lock` is taken.** Reindex Now, re-embed and
+    # reset embeddings all land in this function, and it is a separate entry
+    # point from the indexer loop: it mirrors `run_indexer_loop` and shares only
+    # the pass lock with it, so a detection installed there is not installed
+    # here. The call is ahead of the lock deliberately — the check that gates
+    # the pass must not queue behind the pass it gates — which is also why
+    # `detect_and_publish` serializes itself and publishes monotonically, so a
+    # tick and a panel reindex overlapping here is ordinary rather than a race.
+    # The per-user skip is in the shared pass helpers, so the loops below
+    # inherit it without knowing about it.
+    await detect_root_overlaps("panel on-demand")
     async with index_pass_lock:
         if settings.multi_user_mode:
             for uid in await _active_user_ids():

--- a/src/control_panel/templates/dashboard.html
+++ b/src/control_panel/templates/dashboard.html
@@ -97,6 +97,65 @@
             <a href="/admin/health" style="margin-left:auto;font-size:12px;color:var(--primary-text);text-decoration:none;">Health &rarr;</a>
             {% endif %}
         </div>
+
+        {#
+          Vault-root quarantine. Administrators only — `_quarantine_view`
+          returns None for everyone else, so this whole block is absent for a
+          regular user rather than rendered empty; it names another account and
+          another account's vault path, which is exactly what the tool-facing
+          refusal withholds because its reader is a tenant's agent.
+
+          It is a block of its own rather than a cell in the row above because
+          it is several lines of prose naming two accounts and two paths, not a
+          badge. A degraded strip carries no `quarantine` key at all and this
+          renders nothing; the condition is still on the health page, which
+          reads the snapshot itself and shares none of the strip's queries.
+
+          Not a flash. Nothing is dismissed and nothing has to be: it stands
+          while the condition stands and disappears on its own once a later
+          snapshot no longer names the account. An empty snapshot renders
+          nothing at all — the healthy state is silence, not an all-clear
+          badge — and the never-published state gets its own note rather than
+          being mistaken for one.
+        #}
+        {% if health.quarantine and (not health.quarantine.checked or health.quarantine.accounts) %}
+        <div class="card-body" style="border-top:1px solid var(--border);padding-top:14px;padding-bottom:14px;">
+            {% if not health.quarantine.checked %}
+            <div style="font-size:13px;color:var(--text-2);line-height:1.6;">
+                <span class="badge badge-yellow" style="margin-right:8px;">not yet checked</span>
+                The vault roots have not been checked in this process yet, so no
+                account has been cleared. Startup publishes the first check
+                before the server accepts a request, so this normally never
+                shows; while it does, every multi-user tool call is refused.
+                A detection that failed is logged — see
+                <a href="/admin/health" style="color:var(--primary-text);text-decoration:none;">Health</a>.
+            </div>
+            {% else %}
+            <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:10px;">
+                <span class="badge badge-red">vault-root quarantine</span>
+                <span style="font-size:12px;color:var(--text-3);">
+                    Facts as at the last check{% if health.quarantine.detected_at_iso %},
+                    <time datetime="{{ health.quarantine.detected_at_iso }}" data-localize>{{ health.quarantine.detected_at_iso }}</time>{% endif %}
+                    — recorded when the roots were observed, not re-read now.
+                </span>
+            </div>
+            <ul style="margin:0;padding-left:18px;">
+                {% for a in health.quarantine.accounts %}
+                <li style="font-size:13px;color:var(--text-2);line-height:1.6;margin-bottom:6px;word-break:break-word;">
+                    <span class="badge {% if a.overlap %}badge-red{% else %}badge-yellow{% endif %}" style="margin-right:6px;">{% if a.overlap %}overlap{% else %}root unexaminable{% endif %}</span>
+                    {{ a.text }}
+                </li>
+                {% endfor %}
+            </ul>
+            <p style="font-size:12px;color:var(--text-3);line-height:1.6;margin:10px 0 0;">
+                No tool call is served for these accounts and no pass indexes
+                them; nothing was deleted. Correct the assignment on
+                <a href="/admin/users/" style="color:var(--primary-text);text-decoration:none;">Users</a>,
+                or restore the mount, and the next check clears it.
+            </p>
+            {% endif %}
+        </div>
+        {% endif %}
     </div>
 
     <!-- Stat row -->

--- a/src/control_panel/templates/health.html
+++ b/src/control_panel/templates/health.html
@@ -27,6 +27,80 @@
 
 <div class="page-body">
 
+    {#
+      Vault-root quarantine, first: it is the one condition on this page that
+      means a tenant is being served nothing at all, and it persists until an
+      operator acts. `quarantine` is None for a non-administrator — the block is
+      absent rather than empty — because it names another account and another
+      account's vault path, the detail the tool-facing refusal deliberately
+      withholds from a tenant's agent.
+
+      Read from the published snapshot: this page opens no directory, stats no
+      root and re-reads no `users` row. The names, paths and relation below are
+      the facts the detection recorded when it looked, which is what keeps the
+      pair nameable after an operator edits or deletes one of them — and why
+      they are labelled as at the last check rather than presented as the state
+      of those accounts now.
+    #}
+    {% if quarantine and (not quarantine.checked or quarantine.accounts) %}
+    <div class="card anim-1" style="margin-bottom:20px;">
+        <div class="card-header">
+            <span class="card-title">Vault-root quarantine</span>
+            {% if quarantine.checked %}
+            <span class="badge badge-red">{{ quarantine.accounts | length }} account(s) not served</span>
+            {% else %}
+            <span class="badge badge-yellow">not yet checked</span>
+            {% endif %}
+        </div>
+        <div class="card-body">
+            {% if not quarantine.checked %}
+            <p style="color:var(--text-2);font-size:14px;line-height:1.6;margin:0;">
+                The vault roots have not been checked in this process yet, so no
+                account has been cleared and none has been quarantined — this is
+                not an all-clear.
+            </p>
+            <p style="color:var(--text-3);font-size:12px;line-height:1.6;margin:10px 0 0;">
+                Startup runs the check before the server accepts its first
+                request, so this state is normally never seen. While it stands,
+                every multi-user tool call is refused rather than served against
+                roots nothing has checked. A detection that failed is logged at
+                ERROR and appears in Recent errors below; the next index pass
+                retries it.
+            </p>
+            {% else %}
+            <p style="color:var(--text-3);font-size:12px;line-height:1.6;margin:0 0 14px;">
+                Facts as at the last check{% if quarantine.detected_at_iso %},
+                <time datetime="{{ quarantine.detected_at_iso }}" data-localize>{{ quarantine.detected_at_iso }}</time>{% endif %}
+                — recorded when the roots were observed, not re-read now, so an
+                account or a path named here may already have been changed.
+            </p>
+            {% for a in quarantine.accounts %}
+            <div class="kv" style="align-items:flex-start;">
+                <span class="kv-k" style="white-space:nowrap;">
+                    {% if a.overlap %}
+                    <span class="badge badge-red">overlap</span>
+                    {% else %}
+                    <span class="badge badge-yellow">root unexaminable</span>
+                    {% endif %}
+                </span>
+                <span class="kv-v" style="text-align:left;font-size:13px;line-height:1.6;">{{ a.text }}</span>
+            </div>
+            {% endfor %}
+            <p style="color:var(--text-3);font-size:12px;line-height:1.6;margin:14px 0 0;">
+                These accounts are served by nothing — every tool call is refused
+                before its body runs and no pass indexes them — and nothing was
+                deleted: a corrected assignment or a restored mount resumes both.
+                An overlap is fixed by changing an assignment on the users page
+                or the mount behind it; a root that could not be examined is
+                fixed by restoring that mount, and names no conflicting account
+                because none was observed. The condition clears itself at the
+                next check; there is nothing to dismiss.
+            </p>
+            {% endif %}
+        </div>
+    </div>
+    {% endif %}
+
     {% if show_ops %}
 
     <!-- Backups -->

--- a/tests/test_panel_overlap_surface.py
+++ b/tests/test_panel_overlap_surface.py
@@ -1,0 +1,742 @@
+"""The operator surface for a vault-root quarantine, and E4 (#199).
+
+Slice 6 of `vault-root-overlap-guard`. What is pinned here:
+
+* **The panel reads the published snapshot and computes nothing.** A page
+  render must not open, stat or resolve a vault root, and two independent
+  computations of "do these roots overlap" is how the panel and the enforcement
+  come to disagree. `_quarantine_view` takes no session and no path — it is
+  handed `is_admin` and reads one module attribute — and the tests below assert
+  that by making every relevant syscall raise.
+
+* **The recorded facts, not a render-time resolution.** The operator's first
+  move on reading "vault root overlaps <peer>" is to edit or delete one of the
+  two accounts. A surface that resolved names against `users` would show a
+  changed path — or a blank where the deleted peer was — beside a condition that
+  is still in force, so the snapshot carries the usernames, the canonical
+  assignments and the moment it looked, and the surfaces label them as at the
+  last check.
+
+* **The two reasons are worded apart.** An overlap names the peer and the
+  relation; an unexaminable root names the cause and says explicitly that no
+  peer was observed. Describing the latter as an overlap sends an administrator
+  hunting for a second account that does not exist.
+
+* **The tri-state survives to the page.** Empty renders nothing (silence is the
+  healthy state, not an all-clear badge); never-published renders its own note,
+  because "not checked" is a refusal and must not read as "checked, clean".
+
+* **Administrators only.** The condition names another account and another
+  account's vault path — exactly what the tool-facing refusal withholds, because
+  its reader is a tenant's agent.
+
+* **E4.** `_reindex_background` publishes a snapshot *before* it takes
+  `index_pass_lock`. Reindex Now, re-embed and reset embeddings all land there,
+  and it is a separate entry point from the indexer loop: a detection installed
+  in the loop is not installed here.
+
+Hermetic: no database, no container, no filesystem.
+"""
+import asyncio
+import contextlib
+import datetime
+import os
+import tempfile
+
+import pytest
+
+os.environ.setdefault("SECRET_KEY", "test")
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://test:test@localhost/test")
+os.environ.setdefault("VAULT_PATH", "/tmp/test-vault")
+os.chdir(tempfile.gettempdir())
+
+from src.control_panel import routes  # noqa: E402
+from src.services import vault_overlap  # noqa: E402
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TEMPLATES_DIR = os.path.join(HERE, "..", "src", "control_panel", "templates")
+
+DETECTED_AT = datetime.datetime(2026, 9, 5, 11, 30, tzinfo=datetime.timezone.utc)
+
+
+# --------------------------------------------------------------------------
+# Fixtures and builders
+# --------------------------------------------------------------------------
+
+
+def _overlap_pair():
+    """The shape production would produce: `/vaults/team/private` inside
+    `/vaults/team`, so both accounts are named and each names the other."""
+    alice = vault_overlap.QuarantineEntry(
+        user_id=1,
+        username="alice",
+        assignment="/vaults/team",
+        reason=vault_overlap.Overlap(
+            peer_user_id=2,
+            peer_username="bob",
+            peer_assignment="/vaults/team/private",
+            relation=vault_overlap.RELATION_CONTAINS,
+        ),
+        detected_at=DETECTED_AT,
+    )
+    bob = vault_overlap.QuarantineEntry(
+        user_id=2,
+        username="bob",
+        assignment="/vaults/team/private",
+        reason=vault_overlap.Overlap(
+            peer_user_id=1,
+            peer_username="alice",
+            peer_assignment="/vaults/team",
+            relation=vault_overlap.RELATION_CONTAINED_BY,
+        ),
+        detected_at=DETECTED_AT,
+    )
+    return alice, bob
+
+
+def _unexaminable(cause=None):
+    return vault_overlap.QuarantineEntry(
+        user_id=3,
+        username="carol",
+        assignment="/vaults/carol",
+        reason=vault_overlap.RootUnexaminable(
+            cause=2 if cause is None else cause  # ENOENT
+        ),
+        detected_at=DETECTED_AT,
+    )
+
+
+class _Request:
+    def __init__(self):
+        self.session = {}
+        self.scope = {}
+        self.query_params = {}
+
+
+class _User:
+    def __init__(self, is_admin=True, user_id=1, username="alice"):
+        self.id = user_id
+        self.username = username
+        self.is_admin = is_admin
+        self.is_active = True
+
+
+class _NoFilesystem:
+    """Make every way of touching a vault root raise.
+
+    The claim under test is structural — `_quarantine_view` is handed a bool and
+    reads one module attribute — and the cheapest way to hold it to that is to
+    remove the floor: if the panel ever grows an `open`, a directory read or a
+    `realpath` on a page render, this fails rather than getting slower.
+
+    `os.stat` is deliberately left alone. It is what `linecache` calls while
+    pytest is *formatting a failure*, so poisoning it turns any assertion in
+    these tests into an unreadable interpreter-level traceback — the three
+    below are the calls a root observation actually makes.
+    """
+
+    def __init__(self, monkeypatch):
+        def _boom(*_a, **_k):
+            raise AssertionError("the panel touched the filesystem on a render")
+
+        for target in ("open", "scandir", "listdir"):
+            monkeypatch.setattr(os, target, _boom)
+        monkeypatch.setattr(os.path, "realpath", _boom)
+        monkeypatch.setattr(vault_overlap, "observe_root_blocking", _boom)
+
+        async def _no_detection(*_a, **_k):
+            raise AssertionError("the panel ran a detection on a render")
+
+        monkeypatch.setattr(vault_overlap, "detect_and_publish", _no_detection)
+
+
+# --------------------------------------------------------------------------
+# 1. The view: what the surfaces are handed
+# --------------------------------------------------------------------------
+
+
+def test_the_view_names_every_affected_account_its_root_and_its_reason():
+    alice, bob = _overlap_pair()
+    vault_overlap.publish_synthetic_snapshot([alice, bob], detected_at=DETECTED_AT)
+
+    view = routes._quarantine_view(is_admin=True)
+
+    assert view["checked"] is True
+    assert view["detected_at_iso"] == DETECTED_AT.isoformat()
+    assert [a["username"] for a in view["accounts"]] == ["alice", "bob"]
+    assert [a["assignment"] for a in view["accounts"]] == [
+        "/vaults/team",
+        "/vaults/team/private",
+    ]
+    assert all(a["overlap"] is True for a in view["accounts"])
+    # Each line names the subject, its root, the relation, the peer and the
+    # peer's root — the one operator wording, shared with the log line and the
+    # `indexer_runs` row rather than composed a second time here.
+    alice_text = view["accounts"][0]["text"]
+    assert "alice" in alice_text and "/vaults/team" in alice_text
+    assert "bob" in alice_text and "/vaults/team/private" in alice_text
+    assert "contains" in alice_text
+    assert "/vaults/team/private" in view["accounts"][1]["text"]
+    assert "is inside" in view["accounts"][1]["text"]
+
+
+def test_an_unexaminable_root_names_no_peer_and_is_not_called_an_overlap():
+    """Two reasons, two fixes. Calling this one an overlap sends the operator
+    looking for a second account that does not exist."""
+    vault_overlap.publish_synthetic_snapshot([_unexaminable()], detected_at=DETECTED_AT)
+
+    account = routes._quarantine_view(is_admin=True)["accounts"][0]
+
+    assert account["overlap"] is False
+    assert account["username"] == "carol"
+    assert "/vaults/carol" in account["text"]
+    assert "ENOENT" in account["text"]
+    assert "No peer was observed" in account["text"]
+    assert "overlap" not in account["text"].replace(
+        "no overlap could be ruled out", ""
+    )
+
+
+def test_a_timed_out_observation_is_worded_as_a_hung_mount():
+    """`timeout` is its own cause, distinct from an errno: "the mount is not
+    answering" and "the directory is gone" are different problems."""
+    vault_overlap.publish_synthetic_snapshot(
+        [_unexaminable(cause=vault_overlap.CAUSE_TIMEOUT)], detected_at=DETECTED_AT
+    )
+    text = routes._quarantine_view(is_admin=True)["accounts"][0]["text"]
+    assert "not answering" in text
+    assert "No peer was observed" in text
+
+
+def test_a_non_admin_is_handed_nothing_at_all():
+    """Not an empty section — absent. The condition names another account and
+    another account's vault path, which is the detail the tool-facing refusal
+    deliberately withholds."""
+    alice, bob = _overlap_pair()
+    vault_overlap.publish_synthetic_snapshot([alice, bob], detected_at=DETECTED_AT)
+
+    assert routes._quarantine_view(is_admin=False) is None
+
+
+def test_an_empty_snapshot_is_checked_and_names_nobody():
+    vault_overlap.publish_synthetic_snapshot([])
+    view = routes._quarantine_view(is_admin=True)
+    assert view["checked"] is True
+    assert view["accounts"] == []
+
+
+def test_the_never_published_state_is_not_an_all_clear(
+    unpublished_vault_root_snapshot,
+):
+    view = routes._quarantine_view(is_admin=True)
+    assert view["checked"] is False
+    assert view["accounts"] == []
+
+
+def test_the_view_opens_nothing_and_runs_no_detection(monkeypatch):
+    alice, bob = _overlap_pair()
+    vault_overlap.publish_synthetic_snapshot([alice, bob], detected_at=DETECTED_AT)
+    _NoFilesystem(monkeypatch)
+
+    view = routes._quarantine_view(is_admin=True)
+
+    assert len(view["accounts"]) == 2
+
+
+def test_the_pair_is_still_named_after_the_peer_is_corrected_or_deleted():
+    """The facts are the snapshot's, taken when it looked.
+
+    There is no `users` row for either account here — no session is passed and
+    none could be — which is the structural form of the requirement: the pair
+    stays nameable after the operator edits the peer's assignment or deletes the
+    peer outright, and the surfaces present it as observed at the last check
+    rather than as the state of those accounts now.
+    """
+    alice, bob = _overlap_pair()
+    vault_overlap.publish_synthetic_snapshot([alice, bob], detected_at=DETECTED_AT)
+
+    # The operator's remedy happens here: bob's assignment is corrected and the
+    # row is deleted. Nothing republishes, because no detection has run yet.
+    view = routes._quarantine_view(is_admin=True)
+
+    assert view["accounts"][0]["text"].count("bob") >= 1
+    assert "/vaults/team/private" in view["accounts"][0]["text"]
+    assert view["detected_at_iso"] == DETECTED_AT.isoformat()
+
+
+# --------------------------------------------------------------------------
+# 2. The dashboard strip
+# --------------------------------------------------------------------------
+
+
+def _env():
+    from jinja2 import (
+        ChainableUndefined,
+        ChoiceLoader,
+        DictLoader,
+        Environment,
+        FileSystemLoader,
+    )
+
+    return Environment(
+        loader=ChoiceLoader([
+            DictLoader({
+                "base.html":
+                    "{% block title %}{% endblock %}{% block content %}{% endblock %}"
+            }),
+            FileSystemLoader(TEMPLATES_DIR),
+        ]),
+        undefined=ChainableUndefined,
+        autoescape=True,
+    )
+
+
+def _render_strip(**health):
+    ctx = dict(
+        is_admin=True, username="max", multi_user_mode=True, csrf_token="csrf",
+        stats={"notes_indexed": 1, "notes_with_embeddings": 1,
+               "embedding_pct": 100, "active_keys": 1, "requests_today": 0},
+        recent_usage=[], reindexed_24h=0, last_indexed_iso=None,
+        last_indexed_rel="never", last_run_iso=None, last_run_rel="never",
+        last_run_ok=True, index_interval=300, graph={},
+        graph_backfill_running=False,
+        health=dict({
+            "show_ops": True, "last_run": None, "backup": None,
+            "error_count": 0, "errors_capped": False,
+            "observing_since_iso": "2026-09-05T08:00:00+00:00",
+            "observing_since_rel": "2 hours ago",
+            "stale_after_days": 7,
+            "quarantine": None,
+        }, **health),
+    )
+    return _env().get_template("dashboard.html").render(**ctx)
+
+
+def _strip_for(entries, is_admin=True):
+    vault_overlap.publish_synthetic_snapshot(entries, detected_at=DETECTED_AT)
+    return _render_strip(quarantine=routes._quarantine_view(is_admin))
+
+
+def test_the_strip_names_both_accounts_both_roots_and_the_relation():
+    html = _strip_for(_overlap_pair())
+    assert "vault-root quarantine" in html
+    assert "alice" in html and "bob" in html
+    assert "/vaults/team" in html and "/vaults/team/private" in html
+    assert "contains" in html and "is inside" in html
+    # The staleness is stated, not implied: these are recorded facts.
+    assert "as at the last check" in html
+    assert DETECTED_AT.isoformat() in html
+
+
+def test_the_strip_does_not_describe_an_unexaminable_root_as_an_overlap():
+    html = _strip_for([_unexaminable()])
+    assert "root unexaminable" in html
+    assert "ENOENT" in html
+    assert "No peer was observed" in html
+    assert "carol" in html and "/vaults/carol" in html
+
+
+def test_the_strip_is_not_a_flash_and_offers_no_dismissal():
+    """It stands while the condition stands and clears itself when a later
+    snapshot stops naming the account. Nothing to acknowledge, nothing to
+    remember to un-hide."""
+    html = _strip_for(_overlap_pair())
+    assert "dismiss" not in html.lower()
+    assert "clears it" in html
+
+
+def test_an_empty_snapshot_renders_no_condition_and_no_all_clear_badge():
+    html = _strip_for([])
+    assert "vault-root quarantine" not in html
+    assert "not yet checked" not in html
+    # And the rest of the strip is untouched.
+    assert "Last pass" in html
+
+
+def test_the_never_published_state_renders_its_own_note(
+    unpublished_vault_root_snapshot,
+):
+    html = _render_strip(quarantine=routes._quarantine_view(True))
+    assert "not yet checked" in html
+    assert "have not been checked in this process yet" in html
+    assert "vault-root quarantine" not in html
+
+
+def test_a_non_admin_strip_names_no_account_and_no_path():
+    alice, bob = _overlap_pair()
+    vault_overlap.publish_synthetic_snapshot([alice, bob], detected_at=DETECTED_AT)
+    html = _render_strip(
+        show_ops=False, quarantine=routes._quarantine_view(is_admin=False)
+    )
+    assert "alice" not in html and "bob" not in html
+    assert "/vaults/" not in html
+    assert "vault-root quarantine" not in html
+
+
+def test_a_degraded_strip_still_renders_and_shows_no_condition():
+    """`_health_strip_or_degraded` returns no `quarantine` key when its own
+    queries fail; the template must treat the absence as nothing to show rather
+    than raising in the middle of the page it exists to save."""
+    html = _render_strip(unavailable=True)
+    assert "Health summary unavailable" in html
+    assert "vault-root quarantine" not in html
+
+
+# --------------------------------------------------------------------------
+# 3. The health page
+# --------------------------------------------------------------------------
+
+
+def _render_health(quarantine, **overrides):
+    ctx = dict(
+        active="health",
+        runs=[],
+        runs_limit=50,
+        show_ops=True,
+        backup=None,
+        stale_after_days=7,
+        errors=[],
+        error_count=0,
+        errors_capped=False,
+        error_buffer_size=100,
+        observing_since_iso="2026-09-05T08:00:00+00:00",
+        observing_since_rel="2 hours ago",
+        quarantine=quarantine,
+    )
+    ctx.update(overrides)
+    return _env().get_template("health.html").render(**ctx)
+
+
+def _health_for(entries, is_admin=True):
+    vault_overlap.publish_synthetic_snapshot(entries, detected_at=DETECTED_AT)
+    return _render_health(routes._quarantine_view(is_admin))
+
+
+def test_the_health_page_carries_the_same_condition_beside_the_other_sections():
+    html = _health_for(_overlap_pair())
+    assert "Vault-root quarantine" in html
+    assert "alice" in html and "bob" in html
+    assert "/vaults/team/private" in html
+    assert "contains" in html
+    assert "as at the last check" in html
+    # Beside, not instead of: the page still renders its three sections.
+    assert "Last backup" in html
+    assert "Recent errors" in html
+    assert "Index passes" in html
+
+
+def test_the_health_page_words_the_unexaminable_reason_apart():
+    html = _health_for([_unexaminable()])
+    assert "root unexaminable" in html
+    assert "ENOENT" in html
+    assert "No peer was observed" in html
+    assert "restoring that mount" in html
+
+
+def test_the_health_page_renders_nothing_for_an_empty_snapshot():
+    html = _health_for([])
+    assert "Vault-root quarantine" not in html
+    assert "Index passes" in html
+
+
+def test_the_health_page_says_the_roots_have_not_been_checked(
+    unpublished_vault_root_snapshot,
+):
+    html = _render_health(routes._quarantine_view(True))
+    assert "not yet checked" in html
+    assert "not an all-clear" in html
+
+
+def test_the_health_page_shows_a_non_admin_no_account_and_no_path():
+    alice, bob = _overlap_pair()
+    vault_overlap.publish_synthetic_snapshot([alice, bob], detected_at=DETECTED_AT)
+    html = _render_health(
+        routes._quarantine_view(is_admin=False), show_ops=False, backup=None, errors=[]
+    )
+    assert "alice" not in html and "bob" not in html
+    assert "/vaults/" not in html
+    assert "shown to administrators only" in html
+
+
+# --------------------------------------------------------------------------
+# 4. The handlers
+# --------------------------------------------------------------------------
+
+
+class _Result:
+    def __init__(self, rows=(), scalar=0):
+        self._rows = list(rows)
+        self._scalar = scalar
+
+    def scalar(self):
+        return self._scalar
+
+    def all(self):
+        return self._rows
+
+    def fetchall(self):
+        return self._rows
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def scalars(self):
+        return self
+
+    def mappings(self):
+        return self
+
+
+class _EmptySession:
+    """A fresh install: every aggregate zero, every list empty, no timestamps.
+
+    `max(...)` answers None rather than 0 — the handlers humanize those into
+    "never", and an int there is a `tzinfo` AttributeError rather than a
+    meaningful failure.
+    """
+
+    async def execute(self, stmt, *_a, **_k):
+        if "max(" in str(stmt).lower():
+            return _Result(scalar=None)
+        return _Result()
+
+    async def rollback(self):
+        return None
+
+    async def close(self):
+        return None
+
+
+def _capture_context(monkeypatch, handler, user):
+    captured = {}
+
+    def _fake_response(request, name, context):
+        captured["name"] = name
+        captured["context"] = context
+        return "rendered"
+
+    monkeypatch.setattr(routes.templates, "TemplateResponse", _fake_response)
+    monkeypatch.setattr(routes, "generate_csrf_token", lambda _r: "csrf")
+    asyncio.run(handler(request=_Request(), session=_EmptySession(), user=user))
+    return captured["context"]
+
+
+def test_the_health_handler_hands_the_condition_to_an_admin_only(monkeypatch):
+    alice, bob = _overlap_pair()
+    vault_overlap.publish_synthetic_snapshot([alice, bob], detected_at=DETECTED_AT)
+
+    admin_ctx = _capture_context(monkeypatch, routes.health_page, _User(True))
+    assert [a["username"] for a in admin_ctx["quarantine"]["accounts"]] == [
+        "alice",
+        "bob",
+    ]
+
+    user_ctx = _capture_context(
+        monkeypatch, routes.health_page, _User(False, user_id=9, username="dave")
+    )
+    assert user_ctx["quarantine"] is None
+
+
+def test_the_health_handler_opens_no_directory(monkeypatch):
+    """The page render must not touch a vault root — not to confirm the
+    condition, not to resolve a name."""
+    vault_overlap.publish_synthetic_snapshot(_overlap_pair(), detected_at=DETECTED_AT)
+    _NoFilesystem(monkeypatch)
+
+    ctx = _capture_context(monkeypatch, routes.health_page, _User(True))
+    assert len(ctx["quarantine"]["accounts"]) == 2
+
+
+def test_the_strip_carries_the_condition_onto_the_dashboard(monkeypatch):
+    vault_overlap.publish_synthetic_snapshot(_overlap_pair(), detected_at=DETECTED_AT)
+
+    async def _graph(*_a, **_k):
+        return {}
+
+    monkeypatch.setattr(routes, "_graph_stats", _graph)
+    ctx = _capture_context(monkeypatch, routes.dashboard, _User(True))
+
+    accounts = ctx["health"]["quarantine"]["accounts"]
+    assert [a["username"] for a in accounts] == ["alice", "bob"]
+
+
+def test_the_dashboard_strip_hands_a_non_admin_nothing(monkeypatch):
+    vault_overlap.publish_synthetic_snapshot(_overlap_pair(), detected_at=DETECTED_AT)
+
+    async def _graph(*_a, **_k):
+        return {}
+
+    monkeypatch.setattr(routes, "_graph_stats", _graph)
+    ctx = _capture_context(
+        monkeypatch, routes.dashboard, _User(False, user_id=9, username="dave")
+    )
+    assert ctx["health"]["quarantine"] is None
+
+
+# --------------------------------------------------------------------------
+# 5. The vault browser
+# --------------------------------------------------------------------------
+
+
+def _vault_context(monkeypatch, user, warmed="/tmp/test-vault"):
+    from pathlib import Path
+
+    async def _warm(_session, _uid):
+        return None if warmed is None else Path(warmed)
+
+    monkeypatch.setattr(routes, "warm_user_vault_cache", _warm)
+    return _capture_context(monkeypatch, routes.vault_page, user)
+
+
+def test_the_vault_browser_refuses_a_quarantined_user(monkeypatch):
+    """It is the panel's third consuming surface. Listing a tree beneath a root
+    that overlaps another tenant's shows this user another tenant's notes."""
+    alice, _bob = _overlap_pair()
+    vault_overlap.publish_synthetic_snapshot([alice], detected_at=DETECTED_AT)
+
+    ctx = _vault_context(monkeypatch, _User(True, user_id=1, username="alice"))
+
+    assert ctx["vault_error"], "the empty state, not a directory listing"
+    assert ctx["notes"] == [] and ctx["folders"] == []
+    # The wording is the gate's own, which names no other account and no other
+    # path: this page is not admin-only.
+    assert "bob" not in ctx["vault_error"]
+    assert "/vaults/team/private" not in ctx["vault_error"]
+
+
+def test_the_vault_browser_refuses_an_unexaminable_root(monkeypatch):
+    vault_overlap.publish_synthetic_snapshot([_unexaminable()], detected_at=DETECTED_AT)
+
+    ctx = _vault_context(monkeypatch, _User(False, user_id=3, username="carol"))
+
+    assert "could not be examined" in ctx["vault_error"]
+
+
+def test_the_vault_browser_refuses_before_the_first_snapshot(
+    monkeypatch, unpublished_vault_root_snapshot
+):
+    ctx = _vault_context(monkeypatch, _User(True, user_id=1, username="alice"))
+    assert "not available yet" in ctx["vault_error"]
+
+
+def test_an_unassigned_account_is_still_told_it_has_no_vault(monkeypatch):
+    """The unassigned wording wins over a stale quarantine: clearing the
+    assignment is the operator's remedy, and telling them the account is
+    quarantined for a root it no longer holds is the wrong sentence."""
+    alice, _bob = _overlap_pair()
+    vault_overlap.publish_synthetic_snapshot([alice], detected_at=DETECTED_AT)
+
+    ctx = _vault_context(
+        monkeypatch, _User(True, user_id=1, username="alice"), warmed=None
+    )
+    assert "is not assigned" in ctx["vault_error"]
+
+
+def test_an_unaffected_account_still_browses(monkeypatch, tmp_path):
+    alice, _bob = _overlap_pair()
+    vault_overlap.publish_synthetic_snapshot([alice], detected_at=DETECTED_AT)
+    (tmp_path / "Notes").mkdir()
+    (tmp_path / "top.md").write_text("# top\n")
+
+    ctx = _vault_context(
+        monkeypatch,
+        _User(False, user_id=42, username="dave"),
+        warmed=str(tmp_path),
+    )
+
+    assert ctx.get("vault_error") is None
+    assert [f["name"] for f in ctx["folders"]] == ["Notes"]
+    assert [n["name"] for n in ctx["notes"]] == ["top"]
+
+
+# --------------------------------------------------------------------------
+# 6. E4 — the on-demand reindex
+# --------------------------------------------------------------------------
+
+
+class _RecordingLock:
+    def __init__(self, events):
+        self._events = events
+
+    async def __aenter__(self):
+        self._events.append("lock")
+        return self
+
+    async def __aexit__(self, *_exc):
+        return False
+
+
+def test_the_on_demand_reindex_publishes_before_it_takes_the_pass_lock(monkeypatch):
+    """E4. Reindex Now, re-embed and reset embeddings all land in
+    `_reindex_background`, which mirrors `run_indexer_loop` and shares only the
+    pass lock with it — a detection installed in that loop is not installed
+    here. And the call is *ahead* of the lock: the check that gates the pass
+    must not queue behind the pass it gates.
+    """
+    from src.services import indexer
+
+    events = []
+
+    async def _detect(where):
+        events.append(("detect", where))
+
+    async def _users():
+        return []
+
+    async def _index(*_a, **_k):
+        events.append("index")
+        return {}
+
+    async def _embed(*_a, **_k):
+        events.append("embed")
+        return 0
+
+    class _Stats:
+        def record_index(self, _v):
+            pass
+
+        def record_embedded(self, _v):
+            pass
+
+    @contextlib.asynccontextmanager
+    async def _run(_trigger, _uid):
+        yield _Stats()
+
+    monkeypatch.setattr(indexer, "detect_root_overlaps", _detect)
+    monkeypatch.setattr(indexer, "index_pass_lock", _RecordingLock(events))
+    monkeypatch.setattr(indexer, "_active_user_ids", _users)
+    monkeypatch.setattr(indexer, "index_vault", _index)
+    monkeypatch.setattr(indexer, "embed_vault", _embed)
+    monkeypatch.setattr(indexer, "record_indexer_run", _run)
+    monkeypatch.setattr(routes.settings, "multi_user_mode", False)
+
+    asyncio.run(routes._reindex_background())
+
+    assert events[0] == ("detect", "panel on-demand"), events
+    assert events[1] == "lock", events
+    assert events[2:] == ["index", "embed"], events
+
+
+def test_the_on_demand_reindex_routes_through_the_shared_detection_helper():
+    """It calls the indexer's `detect_root_overlaps`, which calls the one
+    `detect_and_publish` — rather than reimplementing the failure handling that
+    keeps a detection error from aborting the pass."""
+    import inspect
+
+    source = inspect.getsource(routes._reindex_background)
+    assert "detect_root_overlaps" in source
+    assert source.index("detect_root_overlaps(") < source.index("index_pass_lock:")
+
+
+@pytest.mark.parametrize(
+    "handler_name",
+    ["trigger_reindex", "trigger_reembed", "reset_embeddings"],
+)
+def test_all_three_danger_zone_controls_reach_the_guarded_entry_point(handler_name):
+    """Three controls, one entry point. The guard is on `_reindex_background`
+    because that is where all three land — Reindex Now directly, re-embed and
+    reset embeddings at their tails."""
+    import inspect
+
+    source = inspect.getsource(getattr(routes, handler_name))
+    assert "_reindex_background" in source


### PR DESCRIPTION
Slice 6 of `vault-root-overlap-guard`: the operator surface for a vault-root quarantine, and the `_reindex_background` entry point (E4). Tasks 6.1–6.7 ticked.

## What landed

**`src/control_panel/routes.py`**

- `_quarantine_view(is_admin)` — the one read of the published snapshot for both operator surfaces. One attribute read plus a mapping walk: no session, no statement, no `open`, no `stat`, no `realpath`, and **no `users` re-read**. It renders the usernames, canonical assignments, relation and detection time the snapshot recorded, so the pair stays nameable after the operator corrects or deletes the peer, and the surfaces label them as at the last check. Returns `None` for a non-administrator, so the block is absent rather than empty.
- Tri-state preserved end to end: never published → `checked: False`; published-empty → `accounts: []` (nothing renders); published-with-reasons → one entry per named account.
- `_health_strip` carries it onto the dashboard; `health_page` passes it to the health page. A *degraded* strip carries no `quarantine` key and renders nothing there — the condition is still on the health page, which reads the snapshot itself and shares none of the strip's three queries. (This keeps `_health_strip_or_degraded`'s return dict byte-identical, which an existing test in `test_issue_163_ops_health.py` — a file this slice does not own — asserts exactly.)
- `vault_page` refuses a named user through the gate's own `_refuse_quarantined_root` and renders the existing `vault_error` empty state. Placed after the warm, so an account whose assignment was just cleared is told it has no vault rather than that it is quarantined for a root it no longer holds; the wording is the agent-facing one that names no other account or path, which is right because this page is not admin-only.
- **E4:** `_reindex_background` awaits `detect_root_overlaps("panel on-demand")` at its top, **before** `index_pass_lock`. Reindex Now, re-embed and reset embeddings all land there. It routes through the indexer's shared helper rather than calling `detect_and_publish` directly, so the "a detection failure must not abort the caller" handling is not re-implemented.

**`dashboard.html` / `health.html`**

- The strip gets a block below the cell row (prose naming two accounts and two paths, not a badge); the health page gets a card above the three existing sections.
- The two reasons are worded apart from `operator_text` — the same wording the log line and the `indexer_runs` row use, so the panel and the run row cannot describe the same condition differently. An overlap names the peer and the relation; an unexaminable root names the cause and states that **no peer was observed**.
- Not a flash: nothing to dismiss, and it clears itself when a later snapshot stops naming the account. Empty renders nothing; never-published renders its own "not yet checked" note explicitly marked as *not* an all-clear.
- Theme tokens only.

## What the strip renders, per state

| State | Strip / page |
| --- | --- |
| never published | `not yet checked` badge + "the vault roots have not been checked in this process yet … while it does, every multi-user tool call is refused" |
| published, empty | nothing at all (no badge, no all-clear) |
| overlap | `vault-root quarantine` + per-account `overlap` badge and the line naming the account, its root, the relation, the peer and the peer's root, with the detection timestamp |
| root unexaminable | `root unexaminable` badge + the account, its root, the cause (`ENOENT (No such file or directory)`, or "the mount is not answering" for a timeout) and "No peer was observed" |
| non-admin | nothing — `_quarantine_view` returns `None` |
| degraded strip | nothing on the dashboard; the condition is on `/admin/health` |

## Gates

- `OMCP_ALLOW_SKIP_TRANSFER_INTEGRATION=1 pytest tests -q` — **3592 passed, 478 skipped** (before: 3558 / 478; +34 new tests, no existing test changed).
- Light-mode literal sweep: **21 templates read, 378 in-scope colour declarations, 0 literals outside tokens** (exit 0).
- `token_coverage.py`: 108 dark / 108 light / 108 OS-light tokens, 3 theme-color metas, **0 failures**.
- `openspec validate --all --strict`: **32 passed, 0 failed**.
- Pre-existing red in that check suite, unchanged and not fixed here (as briefed): `render.py` fails `dashboard.html: UndefinedError: 'health' is undefined` (its fixture context predates the #163 health strip) and `replay.py` reports 3 AMBIGUOUS entries against `base.html` SVG stroke attributes. Neither touches a file this slice changed.

## Deviations

- E4 calls `indexer.detect_root_overlaps` (which calls `detect_and_publish`) rather than `detect_and_publish` directly, so the entry point inherits the shared failure handling instead of duplicating it. The call site is still at the top of the function, ahead of the pass lock, and a test asserts that ordering.
- `_health_strip_or_degraded`'s failure return is left unchanged (no `quarantine` key). Adding one would have broken an equality assertion in `tests/test_issue_163_ops_health.py`, which slice 6 does not own; the health page covers the case instead.

Refs #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWbxW7QFtncUwizXdNyNCZ
