### PR TITLE
fix(sessions): round-3 adversarial finding

### DIFF
--- a/openspec/changes/panel-sessions-and-consent/tasks.md
+++ b/openspec/changes/panel-sessions-and-consent/tasks.md
@@ -319,6 +319,33 @@ sessions, which several slices would otherwise all have to touch.
       `docs/architecture/schema-and-migrations.md` now says the check is
       complete rather than minimal, and why a subset check is the dangerous
       one.
+  - **Round 3 returned FAIL: 1 MAJOR, nothing else; rounds 1-2 accepted.
+    Applied, and the review is closed here.**
+    - *MAJOR — the failure record could itself fail.* `touch_session`'s
+      commit-failure path called `_touch_failed(request, row, ...)`, which read
+      `row.user_id` off the mapped instance. When the connection dies during
+      `commit()` and the `rollback()` after it also raises, SQLAlchemy expires
+      what it is holding **before** re-raising — so that read is a refresh
+      against a dead connection, not an attribute read, and it raises. The one
+      path whose entire contract is "this may never fail a request" had a way
+      to fail one, on the branch reached only when everything else already has.
+      `user_id` and `route` are now captured as primitives **before the first
+      statement runs**, and `_touch_failed` takes them as keyword arguments;
+      nothing after the capture dereferences a mapped instance. (`row.id` is
+      deliberately not captured — it is the stored digest of the cookie's
+      identifier, and this event carries no session identifier in any form.)
+    - Two cases in `tests/test_issue_198_session_registry.py`. The first drives
+      a panel `GET` through `get_active_session_user` and `require_user_panel`
+      against a session double whose `commit` raises, whose `rollback` raises,
+      and whose row **expires on the way out** — modelled, not mocked, since a
+      `MagicMock` would answer `user_id` cheerfully and prove the opposite. It
+      asserts the page still renders, that both records carry the captured id
+      and route, and — counting the row's own post-expiry reads — that nothing
+      dereferenced it. The second pins the capture *above* the first statement
+      against the source, because moving it below the savepoint would pass
+      every other assertion and restore the defect on the only path that
+      expires anything. Both fail on the pre-fix tree, with the row's
+      `RuntimeError` escaping the request.
 - [ ] 8.9 `make deploy`, then `make db-check` (`alembic check` must read "No new upgrade operations detected").
 - [ ] 8.10 Browser pass on the live panel: sign in; open a second browser and confirm both work; log out of the first and **replay its cookie** — expect a redirect to login; change the password from the second and confirm the first is signed out while the second is not; sign in with the new password; open an `/authorize` URL for a self-registered test client with a non-allow-listed redirect host and confirm the warning and the host; confirm an allow-listed client shows the badge **and still shows the self-registration notice**. There is no `user-representative` gate on this project — record which flows were actually exercised.
 - [ ] 8.11 Confirm the deploy's one-time logout happened as designed and both production users can sign in.

--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -454,15 +454,23 @@ async def touch_session(
     * **Throttled to `session_touch_interval_seconds`.** Nothing authorizes on
       `last_seen_at`; a write per request buys nothing and costs a commit.
 
-    Any failure is swallowed: a `panel_session_touch_failed` record is emitted
-    and the request is served. **The `UPDATE` runs inside a savepoint**, so the
-    ordinary failure — the write refused while the reads succeed — rolls back
-    that savepoint alone and leaves the enclosing transaction, and every object
-    loaded in it, **attached and writable**. That last word is the point: a
-    plain rollback here detached the authenticated user, and a write through a
-    detached instance commits nothing and says nothing. `protect` names the
-    instances whose loaded state must survive the rarer case where the *commit*
-    fails and a real rollback is unavoidable.
+    Any failure is swallowed and a `panel_session_touch_failed` record is
+    emitted: the request is served either way. **The `UPDATE` runs inside a
+    savepoint**, so the ordinary failure — the write refused while the reads
+    succeed — rolls back that savepoint alone and leaves the enclosing
+    transaction, and every object loaded in it, **attached and writable**. That
+    last word is the point: a plain rollback here detached the authenticated
+    user, and a write through a detached instance commits nothing and says
+    nothing. `protect` names the instances whose loaded state must survive the
+    rarer case where the *commit* fails and a real rollback is unavoidable.
+
+    **The record itself cannot fail either.** Everything it needs is captured
+    as a primitive before the first statement runs, because a `commit()` and a
+    `rollback()` that both raise leave SQLAlchemy's instances expired — and a
+    read of `row.user_id` after that is a refresh against a dead connection,
+    not an attribute read. Nothing below the capture dereferences a mapped
+    instance.
+
     The exception's **class name only** reaches the log — SQLAlchemy renders
     bound parameters into an error's text, and one of them here is the stored
     session hash (the engine also sets `hide_parameters=True`; this is the
@@ -509,6 +517,22 @@ async def touch_session(
     # `user_sessions`, a trigger rejecting the write, a check constraint added
     # by hand. A savepoint rollback restores the connection and leaves the
     # enclosing transaction, and everything loaded in it, exactly as it was.
+    # **Everything the failure record needs, read now, as primitives.**
+    # `row` is a mapped instance, and the recovery below can leave it expired:
+    # when a connection dies during `commit()` and the `rollback()` that
+    # follows also raises, SQLAlchemy expires what it is holding before
+    # re-raising. A read of `row.user_id` after that is not a read at all — it
+    # is a refresh, against the connection that just died — so it raises, and
+    # the *record of the failure* becomes a second failure on a path whose
+    # entire contract is that it cannot fail. Two ints and a string, captured
+    # here, close that: nothing below dereferences a mapped instance.
+    #
+    # (`row.id` is deliberately **not** among them. It is the stored SHA-256 of
+    # the cookie's identifier, and this event does not carry a session
+    # identifier in any form — see `_touch_failed`.)
+    row_user_id = getattr(row, "user_id", None)
+    route = getattr(getattr(request, "url", None), "path", None)
+
     try:
         async with session.begin_nested():
             await session.execute(
@@ -519,14 +543,14 @@ async def touch_session(
     except Exception as exc:  # noqa: BLE001 - telemetry may not fail a request
         # The savepoint is gone; the outer transaction is untouched and there
         # is deliberately nothing else to undo.
-        _touch_failed(request, row, "touch", exc)
+        _touch_failed(request, "touch", exc, user_id=row_user_id, route=route)
         return False
 
     try:
         await session.commit()
         return True
     except Exception as exc:  # noqa: BLE001 - nor may the commit
-        _touch_failed(request, row, "touch", exc)
+        _touch_failed(request, "touch", exc, user_id=row_user_id, route=route)
         # A failed commit leaves the session unusable, and its rollback will
         # evict what is loaded whether or not a savepoint was used. `protect`
         # names the instances whose already-loaded state the caller still
@@ -541,11 +565,22 @@ async def touch_session(
         try:
             await session.rollback()
         except Exception as rollback_exc:  # noqa: BLE001 - nor may the recovery
-            _touch_failed(request, row, "rollback", rollback_exc)
+            # `row` may well be expired by now, which is exactly why this line
+            # passes the ints captured before the commit rather than reading it.
+            _touch_failed(
+                request, "rollback", rollback_exc, user_id=row_user_id, route=route
+            )
         return False
 
 
-def _touch_failed(request, row, stage: str, exc: BaseException) -> None:
+def _touch_failed(
+    request,
+    stage: str,
+    exc: BaseException,
+    *,
+    user_id: int | None,
+    route: str | None,
+) -> None:
     """One `panel_session_touch_failed`, bounded and class-only.
 
     `stage` is `touch` (the `UPDATE`/commit) or `rollback` (the recovery that
@@ -554,19 +589,26 @@ def _touch_failed(request, row, stage: str, exc: BaseException) -> None:
     rollback is a database refusing one statement, while a failing rollback is
     a connection that is gone — the same request, two different pages.
 
+    **`user_id` and `route` arrive as values, never as a mapped instance to
+    read them off.** The second call site runs after a `commit()` and a
+    `rollback()` have both raised, and SQLAlchemy expires what it holds before
+    re-raising — so `row.user_id` there is a refresh against a dead connection,
+    not an attribute read. Taking the primitives closes the one way this
+    best-effort record could itself raise and turn a served page into a 500.
+
     Never the exception's text and never a traceback: this failure is a
     statement binding `user_sessions.session_hash`, and rendering it is how the
-    registry's own key would reach a shared sink.
+    registry's own key would reach a shared sink. No session identifier in any
+    form either — not the cookie's, and not the stored digest that is the
+    table's primary key.
     """
     security_events.emit(
         "panel_session_touch_failed",
-        subject=security_events.subject_for(
-            user_id=getattr(row, "user_id", None), request=request
-        ),
+        subject=security_events.subject_for(user_id=user_id, request=request),
         reason=stage,
-        user_id=getattr(row, "user_id", None),
+        user_id=user_id,
         error_type=type(exc).__name__,
-        route=getattr(getattr(request, "url", None), "path", None),
+        route=route,
     )
 
 

--- a/tests/session_helpers.py
+++ b/tests/session_helpers.py
@@ -213,6 +213,12 @@ class FakeRegistry:
         #: apart and a test can tell which happened.
         self.savepoints = 0
         self.savepoint_rollbacks = 0
+        #: Called at the top of `rollback`, before `fail_rollback` fires. Models
+        #: the one thing a real session does that matters to the touch's
+        #: recovery: it **expires what it is holding before re-raising**, so a
+        #: mapped instance read afterwards is a refresh against a dead
+        #: connection rather than an attribute read.
+        self.on_rollback = None
         #: Instances detached with `expunge`, in order.
         self.expunged: list = []
         # The state a rollback before the first commit returns to.
@@ -267,6 +273,8 @@ class FakeRegistry:
     async def rollback(self):
         self.rolled_back += 1
         self.events.append(("rollback",))
+        if self.on_rollback is not None:
+            self.on_rollback()
         if self.restore_on_rollback:
             for user in self.users:
                 snapshot = self._user_snapshot.get(id(user))

--- a/tests/test_issue_198_session_registry.py
+++ b/tests/test_issue_198_session_registry.py
@@ -833,6 +833,131 @@ async def test_a_touch_whose_commit_fails_detaches_the_user_before_rolling_back(
     assert stages == ["touch", "rollback"]
 
 
+class _ExpiresWhenTheConnectionDies:
+    """A `user_sessions` row that behaves like an **expired** ORM instance.
+
+    What SQLAlchemy does when a `commit()` fails and the `rollback()` after it
+    also raises: it expires the instances it is holding *before* re-raising. An
+    expired instance has no values — every mapped column read goes back to the
+    database — and the database here is reachable only through the connection
+    that just died. So the read raises.
+
+    That is the whole shape of the round-3 finding: the failure *record*
+    dereferenced this object, on the one path whose contract is that it cannot
+    fail. Modelled rather than mocked, because a `MagicMock` answers `user_id`
+    cheerfully and would prove the opposite of what this asserts.
+    """
+
+    #: The columns the lifecycle reads off a row.
+    COLUMNS = ("id", "user_id", "created_at", "last_seen_at", "expires_at", "revoked_at")
+
+    def __init__(self, **values):
+        self.__dict__["_values"] = dict(values)
+        self.__dict__["_expired"] = False
+        self.__dict__["reads_after_expiry"] = 0
+
+    def expire(self):
+        self.__dict__["_expired"] = True
+
+    def __getattr__(self, name):
+        if name in self.COLUMNS:
+            if self.__dict__["_expired"]:
+                self.__dict__["reads_after_expiry"] += 1
+                raise RuntimeError(
+                    f"cannot refresh {name}: the connection this instance would "
+                    "reload from is gone"
+                )
+            return self.__dict__["_values"].get(name)
+        raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        if name in self.COLUMNS:
+            self.__dict__["_values"][name] = value
+        else:
+            self.__dict__[name] = value
+
+
+async def test_a_dead_connection_during_the_touch_still_serves_the_page(records):
+    """Round 3. Both halves of the recovery fail, and the page is still served.
+
+    `commit()` raises because the connection is gone; the `rollback()` that
+    follows raises for the same reason, and — as a real session does — expires
+    the row on its way out. Everything the two failure records need was read
+    **before** the commit was attempted, so neither of them touches the expired
+    instance and neither turns a served page into a 500.
+
+    The row counts its own post-expiry reads, so this cannot pass by the
+    expiry quietly never happening.
+    """
+    user = sh.fake_user(7, username="alice")
+    sid, request, registry = await sh.sign_in(user)
+
+    row = _ExpiresWhenTheConnectionDies(
+        id=hash_session_id(sid),
+        user_id=user.id,
+        created_at=sh.utcnow() - datetime.timedelta(hours=2),
+        last_seen_at=sh.utcnow() - datetime.timedelta(hours=1),
+        expires_at=sh.utcnow() + datetime.timedelta(days=7),
+        revoked_at=None,
+    )
+    registry.sessions = [row]
+    registry.fail_commit = RuntimeError("the connection is gone")
+    registry.fail_rollback = RuntimeError("and so is the recovery")
+    registry.on_rollback = row.expire
+
+    replay = sh.browser_request(
+        method="GET", path="/admin/", session=dict(request.session)
+    )
+
+    # The panel GET, through the dependency chain a route actually sits on.
+    # It must return the user, not raise.
+    from src.control_panel.routes import require_user_panel
+
+    resolved = await get_active_session_user(replay, registry)
+    assert resolved is user
+    assert replay.session["user_id"] == 7, "the cookie is intact; nothing was cleared"
+    gated = await require_user_panel(request=replay, user=resolved, session=registry)
+    assert gated is user, "the page still renders"
+
+    # Both stages recorded, both carrying the id captured before the failure.
+    failures = _touch_failures(records)
+    assert [r.reason for r in failures] == ["touch", "rollback"]
+    assert [r.user_id for r in failures] == [7, 7]
+    assert [r.route for r in failures] == ["/admin/", "/admin/"]
+    assert [r.error_type for r in failures] == ["RuntimeError", "RuntimeError"]
+
+    # Non-vacuity, both directions: the instance really was expired, and
+    # nothing read it afterwards.
+    assert registry.rolled_back == 1
+    assert row.reads_after_expiry == 0, (
+        "the failure record dereferenced an expired instance — the one read "
+        "that can turn this best-effort path into a 500"
+    )
+    with pytest.raises(RuntimeError):
+        row.user_id  # noqa: B018 - proving the expiry is real
+
+
+async def test_the_captured_ids_are_read_before_the_first_statement():
+    """The narrower guarantee, stated where it cannot drift.
+
+    A future edit that moves the capture below the `begin_nested` would pass
+    every assertion above — the savepoint path does not expire anything — and
+    reintroduce the defect on the path that does. So the order is asserted
+    against the source.
+    """
+    import inspect
+
+    source = inspect.getsource(auth_session.touch_session)
+    capture = source.index("row_user_id = getattr(row, \"user_id\", None)")
+    first_statement = source.index("session.begin_nested()")
+    assert capture < first_statement, (
+        "the primitives must be captured before anything that can fail"
+    )
+    # And no `_touch_failed` call reads off the row.
+    assert "_touch_failed(request, row," not in source
+    assert source.count("user_id=row_user_id") == 3
+
+
 async def test_a_hammering_stale_browser_cannot_flood_the_sink():
     """The reason this had to leave the bare logger.
 


### PR DESCRIPTION
Codex round 3 on the merged `panel-sessions-and-consent`: **FAIL, 1 MAJOR, nothing else**; rounds 1 and 2 accepted. This closes the review.

## MAJOR — the failure record could itself fail

`touch_session`'s commit-failure path called `_touch_failed(request, row, ...)`,
which read `row.user_id` off the mapped instance. When the connection dies
during `commit()` and the `rollback()` that follows also raises, SQLAlchemy
expires what it is holding **before** re-raising — so that read is not an
attribute read at all. It is a refresh, against the connection that just died,
and it raises. The one path in this module whose entire contract is *"this may
never fail a request"* had a way to fail one, on the branch reached only when
everything else already has.

```python
    # **Everything the failure record needs, read now, as primitives.**
    row_user_id = getattr(row, "user_id", None)
    route = getattr(getattr(request, "url", None), "path", None)
```

...and the three call sites take them by keyword:

```python
        _touch_failed(request, "touch", exc, user_id=row_user_id, route=route)
        ...
        try:
            await session.rollback()
        except Exception as rollback_exc:  # noqa: BLE001 - nor may the recovery
            # `row` may well be expired by now, which is exactly why this line
            # passes the ints captured before the commit rather than reading it.
            _touch_failed(
                request, "rollback", rollback_exc, user_id=row_user_id, route=route
            )
```

`_touch_failed`'s signature became
`(request, stage, exc, *, user_id, route)` — nothing after the capture
dereferences a mapped instance.

`row.id` is deliberately **not** captured. It is the stored SHA-256 of the
cookie's identifier, and this event carries no session identifier in any form;
adding one to make the record "more useful" is the thing the canary test
forbids.

## Tests

Two cases in `tests/test_issue_198_session_registry.py`, both of which **fail on
the pre-fix tree** with the row's `RuntimeError` escaping the request:

1. `test_a_dead_connection_during_the_touch_still_serves_the_page` — drives a
   panel `GET` through `get_active_session_user` **and** `require_user_panel`
   against a session double whose `commit` raises, whose `rollback` raises, and
   whose row **expires on the way out** (`FakeRegistry` gained an `on_rollback`
   hook for exactly the thing a real session does before re-raising). It
   asserts the page still renders, the cookie is intact, both records carry the
   captured `user_id` and `route`, and — by counting the row's own post-expiry
   reads — that nothing dereferenced it.

   The row is *modelled*, not mocked: a `MagicMock` answers `user_id`
   cheerfully and would prove the opposite of what this asserts.

2. `test_the_captured_ids_are_read_before_the_first_statement` — pins the
   capture *above* the first statement against the source. Moving it below the
   savepoint would pass every assertion in the first test (the savepoint path
   expires nothing) and quietly restore the defect on the only path that does.

```
FAILED tests/test_issue_198_session_registry.py::test_a_dead_connection_during_the_touch_still_serves_the_page
FAILED tests/test_issue_198_session_registry.py::test_the_captured_ids_are_read_before_the_first_statement
E           RuntimeError: the connection is gone
```

## Gates

- `OMCP_ALLOW_SKIP_TRANSFER_INTEGRATION=1 pytest tests -q -W error::RuntimeWarning`
  (foreground) — **4336 passed, 544 skipped**, zero RuntimeWarnings.
- `make test-schema` on a unique port/container (`55491` / `psc-r3-gate`) —
  **182 passed in 10m42s, "Schema gate passed"**.
- `npx -y @fission-ai/openspec@1.3.1 validate --all --strict` — **32 passed, 0 failed**.

Round 3 is recorded under task 8.8 in
`openspec/changes/panel-sessions-and-consent/tasks.md`, noting that the
adversarial review closed here.

Refs #198 #197 #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JWbxW7QFtncUwizXdNyNCZ
