### PR TITLE
fix: reject graph link targets invented by code masking

### DIFF
--- a/docs/architecture/indexing-and-embeddings.md
+++ b/docs/architecture/indexing-and-embeddings.md
@@ -1440,6 +1440,26 @@ user until the pass completes, per the existing requirement — which is the
 correct disposition for a grammar change, since the rewrite planner and the
 extractor must agree about what a link is.
 
+### Version 3 rejects targets invented by code masking (#218)
+
+Masking inline code can manufacture a target: `` [[`x`Old]] `` used to become a
+link to `Old` after its masked prefix was stripped. Extraction now compares
+each raw wikilink target capture or markdown href span against the same
+code-point offsets in the original body, before stripping, decoding or cap
+accounting. A changed deciding span is omitted. Code confined to a label,
+alias or anchor does not change the target and remains extractable; the
+existing `link_text` representation and scanner grammar are unchanged.
+
+Rejected candidates neither consume `MAX_LINKS_PER_NOTE` nor set truncation.
+Version 3 shares version 2's embedding cleaner, so the existing atomic stale
+version pass repairs unchanged notes' links and stamps version 3 while
+preserving their content hashes and embedding certification. No migration or
+embedding reset is needed. Deployment costs one re-derivation pass; the
+existing owner-scoped `move_note(rewrite_links=True)` refusal lasts until that
+scope's markers are current. The version-2 row repair and unchanged vectors
+are pinned against PostgreSQL in
+`tests/integration/test_issue_150_extraction_version_pg.py`.
+
 ### The frozen v0 cleaner is a line scanner with the regexes as its oracle
 
 `_v0_clean` must keep producing byte-identical output forever — the
@@ -1474,7 +1494,7 @@ The rollback procedure is:
 
 1. revert the grammar commits on a branch;
 2. **bump `CURRENT_EXTRACTION_VERSION`** in that build (to the next unused
-   number — 2 is taken by the link-grammar bump above) and
+   number — 2 and 3 are taken by the link-grammar bumps above) and
    keep the versioned mechanism and the frozen per-version registry — the
    registry is what lets the pass compare each row's stamped grammar against
    the restored one;

--- a/docs/issue-triage-2026-09-06.md
+++ b/docs/issue-triage-2026-09-06.md
@@ -61,6 +61,7 @@ runs were stopped and are not counted as validation.
 `make test-integration` passed **554 tests**, including the new version-2 graph
 repair regression, with one existing warning. It used a dedicated disposable
 container; production was untouched. The feature branch is
-`codex-fix-mask-decided-links`; publication is the final implementation step. No production
+`codex-fix-mask-decided-links`, published as
+[draft PR #270](https://github.com/maxkuminov/obsidian-mcp/pull/270). No production
 deployment or live MCP exercise has run for this change; the OpenSpec change
 remains active for release checks.

--- a/docs/issue-triage-2026-09-06.md
+++ b/docs/issue-triage-2026-09-06.md
@@ -1,0 +1,53 @@
+# Open-issue triage — 2026-09-06
+
+Reviewed all 23 open GitHub issues against main at `668abea`, the previous
+[rollout report](issue-sweep-2026-09-06.md), current implementation and issue
+bodies. No open pull requests existed at triage time. Priorities weigh agent
+answer correctness, data integrity, availability, reach and implementation
+readiness; severity alone is not a work order.
+
+## Already implemented
+
+| Issues | Current disposition |
+| --- | --- |
+| #183, #197, #198 | Consent disclosure, password change and session registry shipped in the prior rollout. |
+| #188, #194 | Rate controls and default quota shipped; concurrency remains #261. |
+| #190–#193 | Structured security events and exception/refusal attribution shipped within their recorded scope; body-result classification remains #263. |
+| #200–#202, #206 | Stale result disclosure, typed embed failures, fairness and settings fingerprints shipped. |
+
+These 13 issues need reconciliation against their individual outstanding gates
+before closure, not duplicate implementations. The prior rollout report records
+real-database and live-server evidence as well as remaining owner confirmations.
+No issue is closed by this triage.
+
+## Remaining work in priority order
+
+| Priority | Issues | Decision and reason |
+| --- | --- | --- |
+| First implementation | #218 | Confirmed false graph edges: code masking turns an authored target into another note name. Fix extraction, preserve valid links, and re-derive existing rows with a version bump. Bounded application change, no migration. |
+| Next application change | #263 | A common typed outcome contract makes body refusals visible to agents and operators. Requires a complete inventory across 25 tools and tests distinguishing refusal from successful empty/no-op results; not safe as prose matching or a partial relabeling. |
+| Availability project | #261 | Tool concurrency remains unbounded. Design authentication admission, pool arithmetic and tenant/principal/class slots together; ship shadow mode first as already required. |
+| Owner decision | #262 | Nested mount grafts can breach tenant isolation. Decide supported mount topologies and fund detection, or explicitly accept the deployment restriction. Existing root identity/containment checks do not solve this. |
+| Coordinated infrastructure | #189, #184, #185, #196 | Restrict proxy trust and secure database/internal HTTP hops; reject plaintext API requests at the proxy. Needs stable proxy identity, certificates and shared-service configuration. Application-only enforcement risks outages without completing the control. |
+| Lower priority | #195 | CSP remains an explicit architecture decision; no new injection primitive was established by the issue. |
+| Documentation follow-up | #178 | Update external registry positioning when those listings are next edited. |
+
+## Scope check for #263
+
+A read-only follow-up found 197 return sites across the 25 tracked
+implementations, before shared move, mint and publication helpers. A terminal typed refusal
+helper can record a closed marker through the existing request timing context
+and render the existing sentinel without changing string return types. The
+migration must inventory each terminal outcome: successful empty results and
+`check_upload` status reads remain successes; committed partial moves/imports
+must never claim `nothing_written`. Parsing response prose or sentinels is
+unsafe because ordinary note content can contain those strings. This is a
+separate reviewed implementation, not a small follow-up to the extractor fix.
+
+## Selected change: #218
+
+Tracked in `openspec/changes/reject-mask-decided-links/`. Rejected candidates
+must not consume the extraction cap, and code only in an alias, anchor or label
+must not remove a valid target. Version 3 must repair existing link rows while
+preserving embedding certification when the cleaned content is unchanged.
+Validation and publication results will be recorded after independent review.

--- a/docs/issue-triage-2026-09-06.md
+++ b/docs/issue-triage-2026-09-06.md
@@ -50,4 +50,17 @@ Tracked in `openspec/changes/reject-mask-decided-links/`. Rejected candidates
 must not consume the extraction cap, and code only in an alias, anchor or label
 must not remove a valid target. Version 3 must repair existing link rows while
 preserving embedding certification when the cleaned content is unchanged.
-Validation and publication results will be recorded after independent review.
+Independent proposal and defensive implementation/spec reviews both returned
+PASS with no blocking findings. Strict OpenSpec validation passed all 33 items;
+`make audit` found no known vulnerabilities. The complete offline suite passed
+with **4,685 passed, 557 skipped**, and two existing dependency warnings. The
+sandboxed offline run stalled in an existing async filesystem test; its isolated
+unsandboxed run passed, followed by the complete unsandboxed suite. The stalled
+runs were stopped and are not counted as validation.
+
+`make test-integration` passed **554 tests**, including the new version-2 graph
+repair regression, with one existing warning. It used a dedicated disposable
+container; production was untouched. The feature branch is
+`codex-fix-mask-decided-links`; publication is the final implementation step. No production
+deployment or live MCP exercise has run for this change; the OpenSpec change
+remains active for release checks.

--- a/openspec/changes/reject-mask-decided-links/design.md
+++ b/openspec/changes/reject-mask-decided-links/design.md
@@ -1,0 +1,14 @@
+## Decision
+
+Compare the original and masked deciding spans using existing parser offsets.
+For wikilinks use the target capture only; for markdown links use the href
+span only. Skip a changed span rather than resolving it or recording an
+invented dangling target. Masking outside these spans does not decide a target.
+Do this before cap accounting so rejected candidates cannot hide valid links
+or claim truncation. Keep the existing bounded scanner and its complexity.
+
+Extraction version 3 shares version 2's cleaner. Existing stale-version scan
+transactions replace links and stamp metadata atomically, without changing
+content hashes or invalidating embeddings solely for this link-only change.
+No new write-tool behavior is introduced. Deployment triggers one re-derivation
+pass and temporarily refuses rewrite_links for scopes with stale markers.

--- a/openspec/changes/reject-mask-decided-links/proposal.md
+++ b/openspec/changes/reject-mask-decided-links/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+Issue #218 still reproduces after the previous issue sweep: masking inline code
+inside a link target can invent a different target and persist a false graph
+edge. Agents consume backlinks and neighborhoods as facts. The rewrite path
+already rejects these targets; extraction must apply the same rule.
+
+## What Changes
+
+Skip candidates whose deciding target/href span differs between original and
+code-masked text, before counting them toward the extraction cap. Preserve
+valid links with code only in labels, aliases or anchors. Advance extraction
+version 2 to 3 so unchanged notes repair their stored graph; reuse the existing
+embedding cleaner so the bump alone causes no provider work.
+
+## Capabilities
+
+### Modified Capabilities
+- `wikilink-graph`: reject targets invented by masking and repair existing rows.
+
+## Impact
+
+`src/services/links.py`, the extraction version in `indexer.py`, the cleaner
+registry in `embeddings.py`, regression tests and indexing architecture notes.
+No migration or new setting. Existing owner-scoped rewrite refusal applies
+until re-derivation completes. Existing issue #218 tracks this work.

--- a/openspec/changes/reject-mask-decided-links/specs/wikilink-graph/spec.md
+++ b/openspec/changes/reject-mask-decided-links/specs/wikilink-graph/spec.md
@@ -1,0 +1,25 @@
+## ADDED Requirements
+
+### Requirement: Code masking must not invent link targets
+
+The extractor SHALL omit a candidate when code masking changes any character
+in its deciding wikilink target or markdown href span, before resolution and
+before counting it toward the per-note link cap.
+
+#### Scenario: Inline code inside a target
+- **WHEN** a note contains [[`x`Old]], ![[`x`Old]] or [t](`x`Old.md)
+- **THEN** extraction SHALL emit no link for that candidate
+- **AND** the candidate SHALL neither consume the cap nor set truncation
+
+#### Scenario: Code outside the deciding span
+- **WHEN** an otherwise valid link has inline code only in its label, alias or anchor
+- **THEN** its unchanged target SHALL still be extracted
+
+#### Scenario: Existing indexed notes are repaired
+- **WHEN** a version-2 note with unchanged bytes is scanned by this build
+- **THEN** its links SHALL be re-derived and its extraction version stamped 3 in the existing atomic pass
+- **AND** its embedding certification SHALL remain unchanged solely on account of this link-only version bump
+
+#### Scenario: Ordinary links retain their behavior
+- **WHEN** extraction processes unchanged targets with whitespace, Unicode, percent encoding or balanced parentheses supported by the existing grammar
+- **THEN** their resolution inputs and bounded document ordering SHALL remain unchanged

--- a/openspec/changes/reject-mask-decided-links/tasks.md
+++ b/openspec/changes/reject-mask-decided-links/tasks.md
@@ -3,5 +3,5 @@
 - [x] 3. Reject mask-decided targets before cap accounting; bump extraction version with equivalent cleaner.
 - [x] 4. Add regressions for rejection, valid labels/aliases/anchors, caps and unchanged-note re-derivation; update architecture notes.
 - [x] 5. Independent defensive implementation/spec review — PASS, no findings; offline 4,685 passed / 557 skipped; real-PG 554 passed; OpenSpec 33 passed; audit clean.
-- [ ] 6. Record triage and validation; publish reviewable branch/PR.
+- [x] 6. Record triage and validation; published branch and draft PR #270.
 - [ ] 7. Release follow-up: deploy, confirm version-3 re-derivation and exercise affected live MCP graph tools, then archive the change.

--- a/openspec/changes/reject-mask-decided-links/tasks.md
+++ b/openspec/changes/reject-mask-decided-links/tasks.md
@@ -1,6 +1,6 @@
 - [x] 1. Confirm #218 remains in current code and record scope.
-- [ ] 2. Independent proposal review before implementation.
-- [ ] 3. Reject mask-decided targets before cap accounting; bump extraction version with equivalent cleaner.
-- [ ] 4. Add regressions for rejection, valid labels/aliases/anchors, caps and unchanged-note re-derivation; update architecture notes.
+- [x] 2. Independent proposal review before implementation — PASS, no findings; cap-zero, Unicode/angle-href and real-PG coverage requested.
+- [x] 3. Reject mask-decided targets before cap accounting; bump extraction version with equivalent cleaner.
+- [x] 4. Add regressions for rejection, valid labels/aliases/anchors, caps and unchanged-note re-derivation; update architecture notes.
 - [ ] 5. Independent defensive implementation/spec review and relevant offline/integration validation.
 - [ ] 6. Record triage and validation; publish reviewable branch/PR.

--- a/openspec/changes/reject-mask-decided-links/tasks.md
+++ b/openspec/changes/reject-mask-decided-links/tasks.md
@@ -2,5 +2,6 @@
 - [x] 2. Independent proposal review before implementation — PASS, no findings; cap-zero, Unicode/angle-href and real-PG coverage requested.
 - [x] 3. Reject mask-decided targets before cap accounting; bump extraction version with equivalent cleaner.
 - [x] 4. Add regressions for rejection, valid labels/aliases/anchors, caps and unchanged-note re-derivation; update architecture notes.
-- [ ] 5. Independent defensive implementation/spec review and relevant offline/integration validation.
+- [x] 5. Independent defensive implementation/spec review — PASS, no findings; offline 4,685 passed / 557 skipped; real-PG 554 passed; OpenSpec 33 passed; audit clean.
 - [ ] 6. Record triage and validation; publish reviewable branch/PR.
+- [ ] 7. Release follow-up: deploy, confirm version-3 re-derivation and exercise affected live MCP graph tools, then archive the change.

--- a/openspec/changes/reject-mask-decided-links/tasks.md
+++ b/openspec/changes/reject-mask-decided-links/tasks.md
@@ -1,0 +1,6 @@
+- [x] 1. Confirm #218 remains in current code and record scope.
+- [ ] 2. Independent proposal review before implementation.
+- [ ] 3. Reject mask-decided targets before cap accounting; bump extraction version with equivalent cleaner.
+- [ ] 4. Add regressions for rejection, valid labels/aliases/anchors, caps and unchanged-note re-derivation; update architecture notes.
+- [ ] 5. Independent defensive implementation/spec review and relevant offline/integration validation.
+- [ ] 6. Record triage and validation; publish reviewable branch/PR.

--- a/src/services/embeddings.py
+++ b/src/services/embeddings.py
@@ -219,6 +219,9 @@ _EXTRACTION_CLEANERS = {
     # re-embedded. Binding the same function is what makes that true by
     # construction rather than by inspection.
     2: clean_for_embedding,
+    # Version 3 only rejects mask-decided link targets (#218). Re-deriving
+    # their graph rows must preserve version-2 embedding certification.
+    3: clean_for_embedding,
 }
 
 

--- a/src/services/indexer.py
+++ b/src/services/indexer.py
@@ -708,6 +708,9 @@ def _content_hash(content: str) -> str:
 # `_grammar_changed_the_embedding_text` therefore compares equal for every v1
 # row and **no note is re-embedded** on account of this bump. The pass
 # re-extracts links and tags for every note once and re-stamps the marker.
+# Version 3 rejects links whose deciding target/href was changed by code
+# masking (#218). It also shares the version-1/2 cleaner: unchanged bytes
+# need repaired link rows, but no embedding invalidation from this bump.
 #
 # Embedding invalidation is scoped, not blanket: the pass compares the text the
 # row's *stamped* version would have embedded against the text the current one
@@ -719,7 +722,7 @@ def _content_hash(content: str) -> str:
 # CLEARS, so it can never suppress an invalidation another rule mandates — a
 # content change, a `file_path` change, a provider change, exclusion
 # reconciliation.
-CURRENT_EXTRACTION_VERSION = 2
+CURRENT_EXTRACTION_VERSION = 3
 
 
 def _grammar_changed_the_embedding_text(stamped_version: int, body: str) -> bool:

--- a/src/services/links.py
+++ b/src/services/links.py
@@ -28,7 +28,7 @@ class ExtractedLink:
     target: str  # target string with alias and anchor stripped
     link_text: str  # full original text (e.g. "[[Foo|Bar]]")
     kind: str  # "link" | "embed" | "markdown"
-    position: int  # byte offset in the (un-stripped) source
+    position: int  # code-point offset in the (un-stripped) source
 
 
 # ────────────────────────────────────────────────────────────────────────────
@@ -716,6 +716,12 @@ def extract_links_bounded(
     overflowed = False
 
     for m in _WIKILINK_RE.finditer(masked):
+        # Compare the raw deciding span BEFORE strip/cap accounting (#218).
+        # Masking `x` in [[`x`Old]] must not invent a link to Old; changes
+        # confined to the alias or anchor do not decide the target.
+        start, end = m.span("target")
+        if content[start:end] != masked[start:end]:
+            continue
         target = m.group("target").strip()
         if not target:
             continue
@@ -731,6 +737,12 @@ def extract_links_bounded(
         ))
 
     for link in scan_md_links(masked):
+        # href_start excludes angle brackets and uses the same code-point
+        # offsets as the original string. Labels and anchors stay outside
+        # this comparison; rejected candidates cannot cause truncation.
+        end = link.href_start + len(link.href)
+        if content[link.href_start:end] != link.href:
+            continue
         href = link.href.strip()
         if not href:
             continue

--- a/tests/integration/test_asvs_links_truncated_pg.py
+++ b/tests/integration/test_asvs_links_truncated_pg.py
@@ -232,7 +232,7 @@ async def test_the_pass_stamps_the_current_extraction_version(sessionmaker, vaul
     await indexer.index_vault(user_id=None)
 
     row = await note_row(sessionmaker, "Stamped.md")
-    assert row.extraction_version == indexer.CURRENT_EXTRACTION_VERSION == 2
+    assert row.extraction_version == indexer.CURRENT_EXTRACTION_VERSION == 3
 
 
 # ── get_links is bounded, and says what it is bounding ────────────────────

--- a/tests/integration/test_issue_150_extraction_version_pg.py
+++ b/tests/integration/test_issue_150_extraction_version_pg.py
@@ -156,6 +156,55 @@ CORPUS = [
 ]
 
 
+async def test_version_two_mask_decided_rows_are_repaired_without_reembedding(
+    sessionmaker, vault, monkeypatch
+):
+    """Unchanged version-2 bytes repair their graph and keep certified vectors."""
+    body = "[[`x`Old]] ![[`x`Old]] [t](<`x`Old.md>) [[Keep|`alias`]] #real\n"
+    ids = await seed_pre_150(sessionmaker, vault, [("Source.md", body, ["real"])])
+    note_id = ids["Source.md"]
+    async with sessionmaker() as session:
+        await session.execute(text("UPDATE notes_metadata SET extraction_version = 2"))
+        # Version 2 emitted phantom Old rows after trimming the masked prefix.
+        for kind in ("link", "embed", "markdown"):
+            session.add(NoteLink(source_note_id=note_id, target_path="Old", kind=kind))
+        session.add(NoteLink(source_note_id=note_id, target_path="Keep", kind="link"))
+        await session.commit()
+        before_vector = (await session.execute(
+            select(NoteEmbedding.id, NoteEmbedding.chunk_text, NoteEmbedding.embedding)
+            .where(NoteEmbedding.note_id == note_id)
+        )).one()
+    before = (await rows(sessionmaker))["Source.md"]
+
+    async def unexpected_provider_call(chunks):
+        pytest.fail("A link-only version bump must not call the embedding provider")
+
+    monkeypatch.setattr(embeddings_service, "get_embeddings_batch", unexpected_provider_call)
+    await indexer.index_vault(user_id=None)
+    await indexer.embed_vault(user_id=None)
+
+    after = (await rows(sessionmaker))["Source.md"]
+    assert after.id == note_id
+    assert after.extraction_version == 3
+    assert after.content_hash == before.content_hash == content_hash(body)
+    assert after.embedded_content_hash == before.embedded_content_hash == after.content_hash
+    assert after.tags == ["real"]
+    assert await link_targets(sessionmaker, note_id) == ["Keep"]
+    async with sessionmaker() as session:
+        after_vector = (await session.execute(
+            select(NoteEmbedding.id, NoteEmbedding.chunk_text, NoteEmbedding.embedding)
+            .where(NoteEmbedding.note_id == note_id)
+        )).one()
+    assert after_vector.id == before_vector.id
+    assert after_vector.chunk_text == before_vector.chunk_text
+    assert list(after_vector.embedding) == list(before_vector.embedding)
+    assert (vault / "Source.md").read_text(encoding="utf-8") == body
+
+    await indexer.index_vault(user_id=None)
+    assert (await rows(sessionmaker))["Source.md"] == after
+    assert await link_targets(sessionmaker, note_id) == ["Keep"]
+
+
 async def test_a_stale_marker_re_derives_links_and_tags_for_every_note(
     sessionmaker, vault
 ):

--- a/tests/test_asvs_indexer_bounds.py
+++ b/tests/test_asvs_indexer_bounds.py
@@ -405,8 +405,8 @@ _CORPUS = [
 ]
 
 
-def test_the_extraction_version_is_two():
-    assert indexer.CURRENT_EXTRACTION_VERSION == 2
+def test_the_extraction_version_is_three():
+    assert indexer.CURRENT_EXTRACTION_VERSION == 3
 
 
 def test_version_two_cleans_identically_to_version_one():

--- a/tests/test_issue_218_mask_decided_links.py
+++ b/tests/test_issue_218_mask_decided_links.py
@@ -1,0 +1,69 @@
+"""Code masking may hide links, but must never manufacture their targets."""
+
+import pytest
+
+from src.services import indexer
+from src.services.embeddings import clean_at_version
+from src.services.links import extract_links, extract_links_bounded
+
+
+@pytest.mark.parametrize("candidate", [
+    "[[`x`Old]]", "![[`x`Old]]", "[[Old`x`]]", "[[Ol`x`d]]",
+    "[t](`x`Old.md)", "[t](Ol`x`d.md)", "[t](<`x`Old.md>)",
+    "[t](<Ol`x`d.md#section>)", "[[` `Old]]",
+])
+def test_masked_deciding_span_is_rejected(candidate):
+    assert extract_links(candidate) == []
+    assert extract_links_bounded(candidate, max_links=0) == ([], False)
+
+
+@pytest.mark.parametrize("candidate,target,kind", [
+    ("[[Old|`alias`]]", "Old", "link"),
+    ("![[Old#`anchor`|`alias`]]", "Old", "embed"),
+    ("[`label`](Old.md#`anchor`)", "Old", "markdown"),
+    ("[`label`](<Old.md#`anchor`>)", "Old", "markdown"),
+    ("[[  Café 🐈  ]]", "Café 🐈", "link"),
+    ("[t](  Café%20🐈.md)", "Café 🐈", "markdown"),
+    ("[t](<Note (draft).md>)", "Note (draft)", "markdown"),
+])
+def test_unchanged_deciding_spans_keep_target_and_position(candidate, target, kind):
+    prefix = "🌍 café\n"
+    links = extract_links(prefix + candidate)
+    assert [(link.target, link.kind, link.position) for link in links] == [
+        (target, kind, len(prefix))
+    ]
+
+
+@pytest.mark.parametrize("rejected", ["[[`x`Old]]", "![[Old`x`]]", "[t](<`x`Old.md>)"])
+@pytest.mark.parametrize("placement", ["before", "after", "both"])
+@pytest.mark.parametrize("extra", [False, True])
+def test_rejected_candidates_do_not_spend_cap_or_set_truncation(rejected, placement, extra):
+    valid = "[first](One.md) [[Two]]"
+    body = (rejected if placement in {"before", "both"} else "") + valid
+    body += rejected if placement in {"after", "both"} else ""
+    if extra:
+        body += " ![[Three]]"
+    links, truncated = extract_links_bounded(body, max_links=2)
+    assert [link.target for link in links] == ["One", "Two"]
+    assert truncated is extra
+
+
+def test_zero_cap_reports_only_valid_overflow():
+    assert extract_links_bounded("[[`x`Old]] [t](Old.md)", max_links=0) == ([], True)
+
+
+def test_unbounded_historical_kind_order_is_preserved():
+    links = extract_links("[t](One.md) [[`x`Bad]] [[Two]] [t](`x`Bad.md) ![[Three]]")
+    assert [link.target for link in links] == ["Two", "Three", "One"]
+
+
+@pytest.mark.parametrize("body", [
+    "[[`x`Old]] [t](<`x`Old.md>) #tag",
+    "```\nfenced code\n```\n[[Old|`alias`]]",
+    "~~~\nfenced code\n~~~\n[t](Old.md#`anchor`)",
+    "🌍 prose", "",
+])
+def test_version_three_preserves_version_two_embedding_input(body):
+    assert indexer.CURRENT_EXTRACTION_VERSION == 3
+    assert clean_at_version(3, body) == clean_at_version(2, body)
+    assert indexer._grammar_changed_the_embedding_text(2, body) is False


### PR DESCRIPTION
Code masking inside a link target could manufacture a different target: for example, `` [[`x`Old]] `` produced a graph edge to `Old`. Extraction now rejects candidates whose original target or href differs from the code-masked span, before cap accounting. Valid links with code only in labels, aliases or anchors remain extractable.

Extraction version 3 re-derives existing graph rows using the current scan transaction. It shares the version-2 embedding cleaner, so the repair alone does not invalidate embeddings. Deployment triggers one re-derivation pass and the existing owner-scoped refusal of rewrite-enabled moves until that scope is current.

The accompanying triage report covers all 23 open issues: 13 have prior implementation/rollout evidence; this addresses the highest-priority bounded remaining correctness fix. #263 and #261 remain separate application projects; shared-infrastructure and owner decisions are documented.

Validation: independent proposal and implementation/spec reviews passed; strict OpenSpec validation passed all 33 items; dependency audit found no known vulnerabilities. Full offline suite passed: **4,685 passed, 557 skipped**, with two existing dependency warnings. `make test-integration` passed **554 tests**, including actual version-2 row repair with preserved embeddings.

No production deployment or live MCP exercise has run for this change. The OpenSpec change remains active for release checks.

Closes #218
